### PR TITLE
central-track-resolution resolved

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -78,6 +78,19 @@ namespace LaunchPlugin
             return trackRecord;
         }
 
+        public TrackStats ResolveTrackByNameOrKey(string nameOrKey)
+        {
+            if (string.IsNullOrWhiteSpace(nameOrKey) || TrackStats == null) return null;
+
+            // 1) Try as key (direct)
+            var ts = FindTrack(nameOrKey);
+            if (ts != null) return ts;
+
+            // 2) Fallback: match by DisplayName (case-insensitive)
+            return TrackStats.Values
+                .FirstOrDefault(t => t.DisplayName?.Equals(nameOrKey, StringComparison.OrdinalIgnoreCase) == true);
+        }
+
         public TrackStats EnsureTrack(string trackKey, string trackDisplay)
         {
             if (string.IsNullOrWhiteSpace(trackKey)) return null;

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -259,26 +259,7 @@ public class FuelCalcs : INotifyPropertyChanged
     // Resolve the SelectedTrack string to the actual TrackStats object (try key first, then display name)
     private TrackStats ResolveSelectedTrackStats()
     {
-        var car = _selectedCarProfile;
-        var nameOrKey = _selectedTrack;
-
-        if (car == null || string.IsNullOrWhiteSpace(nameOrKey))
-            return null;
-
-        // 1) direct lookup (your FindTrack expects key)
-        var ts = car.FindTrack(nameOrKey);
-        if (ts != null) return ts;
-
-        // 2) try dictionary key
-        if (car.TrackStats != null && car.TrackStats.TryGetValue(nameOrKey, out ts))
-            return ts;
-
-        // 3) fallback by display name (case-insensitive)
-        if (car.TrackStats != null)
-            ts = car.TrackStats.Values.FirstOrDefault(t =>
-                t.DisplayName?.Equals(nameOrKey, StringComparison.OrdinalIgnoreCase) == true);
-
-        return ts;
+        return _selectedCarProfile?.ResolveTrackByNameOrKey(_selectedTrack);
     }
 
     public string SelectedTrack

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -190,18 +190,7 @@ namespace LaunchPlugin
         public TrackStats TryGetCarTrack(string carProfileName, string trackName)
         {
             var car = GetProfileForCar(carProfileName);
-            if (car == null) return null;
-
-            var ts = car.FindTrack(trackName);
-            if (ts == null && car.TrackStats != null)
-            {
-                if (!car.TrackStats.TryGetValue(trackName, out ts))
-                {
-                    ts = car.TrackStats.Values
-                        .FirstOrDefault(t => t.DisplayName?.Equals(trackName, StringComparison.OrdinalIgnoreCase) == true);
-                }
-            }
-            return ts;
+            return car?.ResolveTrackByNameOrKey(trackName);
         }
 
         public ObservableCollection<TrackStats> TracksForSelectedProfile { get; } = new ObservableCollection<TrackStats>();


### PR DESCRIPTION
We had 3 slightly different “try key, then name” snippets across the codebase. Now it’s one function, owned by the data model (CarProfile). Any future tweak to track identity rules happens in one place, and all UIs/load/save paths inherit it automatically.