### PR TITLE
UI polish

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -13,6 +13,20 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <local:InvertBooleanConverter x:Key="InvertBooleanConverter"/>
+        <!-- Unit label style: small, muted -->
+        <Style x:Key="UnitHint" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Opacity" Value="0.75"/>
+            <Setter Property="Margin" Value="6,2,0,0"/>
+        </Style>
+
+        <!-- Warning label style when a guard-rail condition is active -->
+        <Style x:Key="WarnText" TargetType="TextBlock" BasedOn="{StaticResource UnitHint}">
+            <Setter Property="Foreground" Value="#FFCC7A"/>
+            <!-- warm amber -->
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
+
     </UserControl.Resources>
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
@@ -146,7 +160,7 @@
                         </StackPanel>
 
                         <StackPanel Grid.Row="4" Margin="0,15,0,0">
-                            <ui:TitledSlider Title="Max Fuel Override (L):" Minimum="1" Maximum="150" Value="{Binding MaxFuelOverride, Mode=TwoWay}" ToolTip="Limit the car's tank size for races with restricted fuel.">
+                            <ui:TitledSlider Title="Max Fuel Override (litres):" Minimum="1" Maximum="150" Value="{Binding MaxFuelOverride, Mode=TwoWay}" ToolTip="Limit the car's tank size for races with restricted fuel.">
                                 <ui:TitledSlider.Resources>
                                     <Style TargetType="TextBlock">
                                         <Style.Triggers>
@@ -185,7 +199,7 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <StackPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0">
-                                <TextBlock Text="Fuel per Lap (L):" VerticalAlignment="Center"/>
+                                <TextBlock Text="Fuel per Lap (litres per lap):" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding FuelPerLapSourceInfo}" Foreground="Gray" FontStyle="Italic" Margin="2,2,0,0" ToolTip="Source of the current Fuel per Lap value."/>
                             </StackPanel>
                             <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Width="70" HorizontalAlignment="Left" Text="{Binding FuelPerLapText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -210,7 +224,7 @@
                         <ui:TitledSlider Title="Race Laps:" Minimum="1" Maximum="500" Value="{Binding RaceLaps, Mode=TwoWay}" Visibility="{Binding IsLapLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
                         <ui:TitledSlider Title="Race Minutes:" Minimum="10" Maximum="1440" Value="{Binding RaceMinutes, Mode=TwoWay}" Visibility="{Binding IsTimeLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
 
-                        <ui:TitledSlider Title="Formation Lap Fuel (Liters):" Minimum="0" Maximum="10" Value="{Binding FormationLapFuelLiters, Mode=TwoWay}" Margin="0,10,0,0"/>
+                        <ui:TitledSlider Title="Formation Lap Fuel (liters):" Minimum="0" Maximum="10" Value="{Binding FormationLapFuelLiters, Mode=TwoWay}" Margin="0,10,0,0"/>
 
                         <StackPanel Margin="0,10,0,0">
                             <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
@@ -283,7 +297,7 @@
                         <StackPanel Grid.Column="0">
                             <TextBlock Text="Total Fuel Needed" FontWeight="Bold"/>
                             <TextBlock FontSize="21" Margin="0,0,0,5">
-                                <Run Text="{Binding TotalFuelNeeded, StringFormat='{}{0:F1} L', Mode=OneWay}" FontWeight="Bold"/>
+                                <Run Text="{Binding TotalFuelNeeded, StringFormat='{}{0:F1} litres', Mode=OneWay}" FontWeight="Bold"/>
                             </TextBlock>
                         </StackPanel>
 
@@ -291,7 +305,7 @@
                             <TextBlock Text="First Stint Fuel" FontWeight="Bold"/>
                             <Border BorderBrush="Gray" BorderThickness="1" Padding="4,2" CornerRadius="3" Background="#222" HorizontalAlignment="Left">
                                 <TextBlock FontSize="21">
-                                    <Run Text="{Binding FirstStintFuel, StringFormat='{}{0:F1} L', Mode=OneWay}" FontWeight="Bold"/>
+                                    <Run Text="{Binding FirstStintFuel, StringFormat='{}{0:F1} litres', Mode=OneWay}" FontWeight="Bold"/>
                                 </TextBlock>
                             </Border>
                         </StackPanel>


### PR DESCRIPTION
- Fuel per Lap label -> “(litres per lap)”
- Max Fuel Override, Formation Lap Fuel -> “(litres)”
- Tooltips: clarify litres/lap wording
- Optional: header cards “L” -> “litres” (No layout or binding changes)