### PR TITLE
Enhance live pace and confidence handling

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -59,6 +59,9 @@ public class FuelCalcs : INotifyPropertyChanged
     private bool _isLiveLapPaceAvailable;
     private string _liveLapPaceInfo = "-";
     private double _liveAvgLapSeconds = 0;   // internal cache of live estimate
+    private int _liveFuelConfidence;
+    private int _livePaceConfidence;
+    private int _liveOverallConfidence;
                                              
     // --- NEW: Local properties for "what-if" parameters ---
     private double _contingencyValue = 1.5;
@@ -107,6 +110,11 @@ public class FuelCalcs : INotifyPropertyChanged
         get => _liveLapPaceInfo;
         private set { if (_liveLapPaceInfo != value) { _liveLapPaceInfo = value; OnPropertyChanged(nameof(LiveLapPaceInfo)); } }
     }
+
+    public int LiveFuelConfidence { get; private set; }
+    public int LivePaceConfidence { get; private set; }
+    public int LiveOverallConfidence { get; private set; }
+    public string LiveConfidenceSummary { get; private set; } = "Live reliability: n/a";
 
     public string ProfileAvgLapTimeDisplay { get; private set; }
     public string ProfileAvgFuelDisplay { get; private set; }
@@ -1386,6 +1394,49 @@ public class FuelCalcs : INotifyPropertyChanged
             AvgDeltaToPbValue = "-";
         }
         OnPropertyChanged(nameof(AvgDeltaToPbValue));
+    }
+
+    public void SetLiveConfidenceLevels(int fuelConfidence, int paceConfidence, int overallConfidence)
+    {
+        var disp = System.Windows.Application.Current?.Dispatcher;
+        if (disp == null || disp.CheckAccess())
+        {
+            ApplyLiveConfidenceLevels(fuelConfidence, paceConfidence, overallConfidence);
+        }
+        else
+        {
+            disp.Invoke(() => ApplyLiveConfidenceLevels(fuelConfidence, paceConfidence, overallConfidence));
+        }
+    }
+
+    private void ApplyLiveConfidenceLevels(int fuelConfidence, int paceConfidence, int overallConfidence)
+    {
+        LiveFuelConfidence = ClampConfidence(fuelConfidence);
+        LivePaceConfidence = ClampConfidence(paceConfidence);
+        LiveOverallConfidence = ClampConfidence(overallConfidence);
+        LiveConfidenceSummary = BuildConfidenceSummary();
+
+        OnPropertyChanged(nameof(LiveFuelConfidence));
+        OnPropertyChanged(nameof(LivePaceConfidence));
+        OnPropertyChanged(nameof(LiveOverallConfidence));
+        OnPropertyChanged(nameof(LiveConfidenceSummary));
+    }
+
+    private static int ClampConfidence(int value)
+    {
+        if (value < 0) return 0;
+        if (value > 100) return 100;
+        return value;
+    }
+
+    private string BuildConfidenceSummary()
+    {
+        if (LiveFuelConfidence <= 0 && LivePaceConfidence <= 0 && LiveOverallConfidence <= 0)
+        {
+            return "Live reliability: n/a";
+        }
+
+        return $"Live reliability: Fuel {LiveFuelConfidence}% | Pace {LivePaceConfidence}% | Overall {LiveOverallConfidence}%";
     }
 
     // Helper does the actual updates (runs on UI thread)

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -138,6 +138,7 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <StackPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0">
                                 <TextBlock Text="Est Avg Lap Time:" VerticalAlignment="Center"/>
@@ -158,6 +159,8 @@
                             <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding HistoricalBestLapDisplay}" Foreground="Gray" FontStyle="Italic" Margin="0,2,0,0" HorizontalAlignment="Center" ToolTip="Personal Best lap time for this car/track."/>
                             <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding LiveLapPaceInfo}" Foreground="Gray" FontStyle="Italic" Margin="0,2,0,0" HorizontalAlignment="Center" ToolTip="Live rolling average lap time."/>
                             <TextBlock Grid.Row="1" Grid.Column="4" Text="{Binding ProfileAvgDryLapTimeDisplay}" Foreground="Gray" FontStyle="Italic" Margin="0,2,0,0" HorizontalAlignment="Center" ToolTip="Saved average dry lap time from profile."/>
+
+                            <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="4" Text="{Binding LiveConfidenceSummary}" Foreground="Gray" FontStyle="Italic" Margin="0,4,0,0" TextWrapping="Wrap"/>
                         </Grid>
 
                         <StackPanel Grid.Row="4" Margin="0,10,0,10" Grid.IsSharedSizeScope="True">

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -143,6 +143,7 @@ namespace LaunchPlugin
         private int _lapsSincePitExit = int.MaxValue; // big value so early race laps are not treated as pit warmup
         private bool _wasInPitThisLap = false;
         private bool _hadOffTrackThisLap = false; // placeholder; can be wired to incidents later
+        private RejoinReason? _latchedIncidentReason = null;
 
         // --- Cross-session fuel seeds (for Race start) ---
         private double _seedDryFuelPerLap = 0.0;
@@ -471,10 +472,13 @@ namespace LaunchPlugin
             _lapsSincePitExit = int.MaxValue;
             _wasInPitThisLap = false;
             _hadOffTrackThisLap = false;
+            _latchedIncidentReason = null;
 
             LiveFuelPerLap = 0.0;
             Confidence = 0;
             _maxFuelPerLapSession = 0.0;
+            FuelCalculator?.SetLiveConfidenceLevels(0, 0, 0);
+            FuelCalculator?.SetLiveLapPaceEstimate(0, 0);
 
             // Only seed when entering Race with matching car/track
             if (applySeeds &&
@@ -732,6 +736,20 @@ namespace LaunchPlugin
 
                     bool paceReject = false;
                     string paceReason = "";
+                    double paceBaselineForLog = 0.0;
+                    double paceDeltaForLog = 0.0;
+
+                    if (_recentLapTimes.Count > 0)
+                    {
+                        int baselineSamples = Math.Min(5, _recentLapTimes.Count);
+                        double sum = 0.0;
+                        for (int i = _recentLapTimes.Count - baselineSamples; i < _recentLapTimes.Count; i++)
+                        {
+                            sum += _recentLapTimes[i];
+                        }
+                        paceBaselineForLog = sum / baselineSamples;
+                        paceDeltaForLog = lastLapSec - paceBaselineForLog;
+                    }
 
                     // 1) Global race warm-up: ignore very early race laps (same as fuel)
                     if (completedLapsNow <= 2)
@@ -751,7 +769,9 @@ namespace LaunchPlugin
                     if (!paceReject && _hadOffTrackThisLap)
                     {
                         paceReject = true;
-                        paceReason = "incident";
+                        paceReason = _latchedIncidentReason.HasValue
+                            ? $"incident:{_latchedIncidentReason.Value}"
+                            : "incident";
                     }
 
                     // 4) Obvious junk lap times
@@ -765,25 +785,26 @@ namespace LaunchPlugin
                     }
 
                     // 5) Timing bracket: moderate + gross outliers
-                    if (!paceReject && _recentLapTimes.Count >= 3)
+                    if (!paceReject && _recentLapTimes.Count >= 3 && paceBaselineForLog > 0)
                     {
-                        double recentAvg = _recentLapTimes.Average();
-                        double delta = lastLapSec - recentAvg; // +ve = slower than recent average
+                        double delta = paceDeltaForLog; // +ve = slower than recent average
 
                         // 5a) Gross outliers: >20s away from our current clean pace, either direction.
                         //     This catches things like huge course cuts or tow / timing glitches.
                         if (Math.Abs(delta) > 20.0)
                         {
                             // You can log this if you like:
-                            SimHub.Logging.Current.Info($"LalaLaunch.Pace: gross outlier lap {lastLapSec:F2}s (avg={recentAvg:F2}s, Δ={delta:F1}s)");
+                            SimHub.Logging.Current.Info($"LalaLaunch.Pace: gross outlier lap {lastLapSec:F2}s (avg={paceBaselineForLog:F2}s, Δ={delta:F1}s)");
                             paceReject = true;
+                            paceReason = "gross-outlier";
                         }
                         // 5b) Normal too-slow laps: more than ~6s slower than our recent clean pace.
                         //     Keeps spins / heavy traffic / yellows out of the model, but allows faster laps.
                         else if (delta > 6.0)
                         {
-                            SimHub.Logging.Current.Info($"LalaLaunch.Pace: rejected too-slow lap {lastLapSec:F2}s (avg={recentAvg:F2}s, Δ={delta:F1}s)");
+                            SimHub.Logging.Current.Info($"LalaLaunch.Pace: rejected too-slow lap {lastLapSec:F2}s (avg={paceBaselineForLog:F2}s, Δ={delta:F1}s)");
                             paceReject = true;
+                            paceReason = "slow-outlier";
                         }
                     }
 
@@ -820,6 +841,11 @@ namespace LaunchPlugin
                         // Update pace confidence
                         PaceConfidence = ComputePaceConfidence();
 
+                        if (Pace_StintAvgLapTimeSec > 0)
+                        {
+                            FuelCalculator?.SetLiveLapPaceEstimate(Pace_StintAvgLapTimeSec, _recentLapTimes.Count);
+                        }
+
                         if (string.IsNullOrEmpty(paceReason))
                         {
                             paceReason = "accepted";
@@ -835,16 +861,25 @@ namespace LaunchPlugin
                     }
 
                     // Log pace line every lap we cross S/F
+                    string paceBaselineLog = (paceBaselineForLog > 0)
+                        ? paceBaselineForLog.ToString("F3")
+                        : "-";
+                    string paceDeltaLog = (paceBaselineForLog > 0)
+                        ? paceDeltaForLog.ToString("+0.000;-0.000;0.000")
+                        : "-";
+
                     SimHub.Logging.Current.Info(
                         string.Format(
-                            "LalaLaunch.Pace: lap={0}, time={1:F3}s, accepted={2}, reason={3}, stintAvg={4:F3}s, last5={5:F3}s, paceConf={6}%",
+                            "LalaLaunch.Pace: lap={0}, time={1:F3}s, accepted={2}, reason={3}, stintAvg={4:F3}s, last5={5:F3}s, paceConf={6}%, baseline={7}, delta={8}",
                             completedLapsNow,
                             lastLapSec,
                             !paceReject,
                             paceReason,
                             Pace_StintAvgLapTimeSec,
                             Pace_Last5LapAvgSec,
-                            PaceConfidence));
+                            PaceConfidence,
+                            paceBaselineLog,
+                            paceDeltaLog));
 
                     // --- Fuel per lap calculation & rolling averages ---
                     SimHub.Logging.Current.Info($"LalaLaunch.LiveFuel: Lap crossed. CompletedLaps={completedLapsNow}");
@@ -884,7 +919,9 @@ namespace LaunchPlugin
                     if (!reject && _hadOffTrackThisLap)
                     {
                         reject = true;
-                        reason = "incident";
+                        reason = _latchedIncidentReason.HasValue
+                            ? $"incident:{_latchedIncidentReason.Value}"
+                            : "incident";
                     }
 
                     // 4) Obvious telemetry junk
@@ -969,6 +1006,7 @@ namespace LaunchPlugin
                         // Overall confidence is computed in its getter from Confidence + PaceConfidence
 
                         FuelCalculator?.SetLiveFuelPerLap(LiveFuelPerLap);
+                        FuelCalculator?.SetLiveConfidenceLevels(Confidence, PaceConfidence, OverallConfidence);
 
                         // Update session max for current mode if available
                         double maxForMode = isWetMode ? _maxWetFuelPerLap : _maxDryFuelPerLap;
@@ -1021,6 +1059,7 @@ namespace LaunchPlugin
 
                     _wasInPitThisLap = false;
                     _hadOffTrackThisLap = false;
+                    _latchedIncidentReason = null;
                     _lastCompletedFuelLap = completedLapsNow;
                 }
 
@@ -1035,6 +1074,7 @@ namespace LaunchPlugin
                     PluginManager.GetPropertyValue("DataCorePlugin.Computed.Fuel_LitersPerLap") ?? 0.0
                 );
                 Confidence = 0;
+                FuelCalculator?.SetLiveConfidenceLevels(Confidence, PaceConfidence, OverallConfidence);
 
                 if (LiveFuelPerLap > 0)
                     FuelCalculator?.OnLiveFuelPerLapUpdated();
@@ -1065,6 +1105,8 @@ namespace LaunchPlugin
                 Pace_StintAvgLapTimeSec = 0.0;
                 Pace_Last5LapAvgSec = 0.0;
                 PaceConfidence = 0;
+                FuelCalculator?.SetLiveLapPaceEstimate(0, 0);
+                FuelCalculator?.SetLiveConfidenceLevels(Confidence, PaceConfidence, OverallConfidence);
             }
             else
             {
@@ -1934,6 +1976,23 @@ namespace LaunchPlugin
             }
 
             _pitLite?.Update(inLane, completedLaps, lastLapSec, avgUsed);
+
+            // --- Rejoin assist update & lap incident tracking ---
+            _rejoinEngine?.Update(data, pluginManager, IsLaunchActive);
+            if (_rejoinEngine != null && !_hadOffTrackThisLap)
+            {
+                var latchedReason = _rejoinEngine.CurrentLogicCode;
+                if (!RejoinAssistEngine.IsSeriousIncidentReason(latchedReason))
+                {
+                    latchedReason = _rejoinEngine.DetectedReason;
+                }
+
+                if (RejoinAssistEngine.IsSeriousIncidentReason(latchedReason))
+                {
+                    _hadOffTrackThisLap = true;
+                    _latchedIncidentReason = latchedReason;
+                }
+            }
 
             // === AUTO-LEARN REFUEL RATE FROM PIT BOX (hardened) ===
             double currentFuel = data.NewData?.Fuel ?? 0.0;

--- a/RejoinAssistEngine.cs
+++ b/RejoinAssistEngine.cs
@@ -97,6 +97,24 @@ namespace LaunchPlugin
         public double OverrideTimeSeconds => _msgCxTimer.Elapsed.TotalSeconds;
         public double DelayTimerSeconds => _delayTimer.Elapsed.TotalSeconds;
         public RejoinReason DetectedReason => _detectedReason;
+
+        public bool IsSeriousIncidentActive =>
+            IsSeriousIncidentReason(_currentLogicReason) ||
+            IsSeriousIncidentReason(_detectedReason);
+
+        public static bool IsSeriousIncidentReason(RejoinReason reason)
+        {
+            switch (reason)
+            {
+                case RejoinReason.Spin:
+                case RejoinReason.OffTrackHighSpeed:
+                case RejoinReason.StoppedOnTrack:
+                case RejoinReason.WrongWay:
+                    return true;
+                default:
+                    return false;
+            }
+        }
         //public bool IsEnteringPits => _isEnteringPits;
 
         public RejoinAssistEngine(Func<double> getSpeedThreshold, Func<double> getLingerTime, Func<double> getYawThreshold)


### PR DESCRIPTION
## Summary
- integrate the rejoin assist engine with the live lap filters so serious incident laps are rejected consistently and logged with the originating reason
- tighten the pace rejection and logging to include the ±20s/6s gates, surface detailed baseline/delta metrics, and push live lap estimates into the fuel planner
- surface combined fuel/pace confidence in the fuel calculator UI via new plumbing between the plugin and the view model

## Testing
- `dotnet build LaunchPlugin.sln` *(fails: dotnet CLI not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691baf4702c0832f8fd0d7720096a3b1)