### PR TITLE
Reset pace tracking on session change

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -464,6 +464,13 @@ namespace LaunchPlugin
             _hadOffTrackThisLap = false;
             _latchedIncidentReason = null;
 
+            // Clear pace tracking alongside fuel model resets so session transitions don't carry stale data
+            _recentLapTimes.Clear();
+            _recentLeaderLapTimes.Clear();
+            Pace_StintAvgLapTimeSec = 0.0;
+            Pace_Last5LapAvgSec = 0.0;
+            PaceConfidence = 0;
+
             LiveFuelPerLap = 0.0;
             Confidence = 0;
             _maxFuelPerLapSession = 0.0;


### PR DESCRIPTION
## Summary
- clear the race pace rolling windows alongside the fuel burn model when a session transition occurs so stale averages are not reused

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8dad2bbc832fbf92cc8f8c403cbc)