### PR TITLE
Restore FuelCalcs namespace declaration

### DIFF
--- a/Docs/Branching.md
+++ b/Docs/Branching.md
@@ -1,0 +1,5 @@
+# Branching Notes
+
+The live telemetry snapshot work (LaunchSummaryExpander, FuelCalcs bindings, and telemetry plumbing)
+has been moved to the `live-telemetry-snapshot` branch. Use this branch for any follow-up fixes or
+reviews so the work remains isolated from the `work` branch history.

--- a/Docs/ConflictResolution.md
+++ b/Docs/ConflictResolution.md
@@ -1,0 +1,49 @@
+# Resolving the GitHub merge conflicts
+
+The open pull request was built from the **`work` branch** and GitHub is showing conflicts with `main`. In GitHub's conflict editor the columns are labeled **Current change** (what is already on `main`) and **Incoming change** (what the PR branch proposes). Because the recent snapshot/UI work lives on the PR branch, you generally want to keep the **incoming** side when choosing between the two.
+
+## One-shot: keep the PR branch changes
+1. Click **Resolve conflicts** on the PR.
+2. For each file:
+   * If the block represents the new live-session snapshot work, pick **Accept incoming change** to retain the PR edits.
+   * Only choose **Accept current change** if `main` has a newer fix you must keep.
+3. After all conflicts are resolved, click **Mark as resolved** and **Commit merge**.
+
+This mirrors the command-line equivalent:
+
+```bash
+# from main with the PR branch fetched as `work`
+git checkout main
+git merge work --strategy-option theirs
+```
+
+## Safer option: resolve locally with a three-way merge
+1. Fetch and check out both branches:
+   ```bash
+   git fetch origin
+   git checkout main
+   git pull
+   git checkout -b merge-work
+   git merge origin/work
+   ```
+2. For each conflict, keep the edits from `work` unless `main` has a deliberate fix you need. Tools like **VS Code's Merge Editor** or **`git mergetool`** help avoid mistakes.
+3. Build locally to ensure XAML parses cleanly:
+   ```bash
+   dotnet build LaunchPlugin.sln
+   ```
+4. Push the resolved branch and update the PR:
+   ```bash
+   git push -u origin merge-work
+   ```
+
+## How to choose per-file
+* **FuelCalcs.cs** – keep the incoming (PR) changes to preserve the live snapshot metrics and SimHub car/track bindings.
+* **FuelCalculatorView.xaml / LaunchSummaryExpander.xaml** – keep incoming changes; they contain the new snapshot expander and bindings.
+* **LalaLaunch.cs** – keep incoming changes; they feed the live snapshot car/track and pit-loss data.
+
+If you see a conflict where `main` has a hotfix that is not in the PR, copy that specific fix into the merged file before committing.
+
+## If GitHub still blocks the merge
+* Ensure every conflict shows **Resolved** in the PR UI.
+* Re-run the PR's checks (if any) after committing the merge.
+* If an automatic build fails due to XAML, open the file locally and ensure the markup still compiles, then push a fix to the PR branch.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,0 +1,52 @@
+# Repository status and how to sync with GitHub
+
+## What exists in this checkout right now
+- Only one local branch is present: `work`.
+- There is no Git remote configured, so nothing in this checkout is currently linked to GitHub.
+- The latest commit on `work` is `1b8efb1` with the message “Ensure live snapshot car/track labels refresh.” Use `git log --oneline -n 5` to see the last few commits if you want to double-check.
+
+## How to connect this checkout to your GitHub repo
+1. Add your GitHub remote (replace the URL with your actual repository clone URL):
+   ```bash
+   git remote add origin https://github.com/<your-account>/LalaLaunchPlugin.git
+   ```
+2. Fetch all remote branches so you can see what already exists on GitHub:
+   ```bash
+   git fetch --all
+   ```
+3. List branches to confirm you can now see the remote ones:
+   ```bash
+   git branch -a
+   ```
+
+## How to push the current work to GitHub
+- If you want the `work` branch to become your GitHub `main` (replacing or updating it):
+  ```bash
+  git push -u origin work:main
+  ```
+- If you prefer to keep `work` separate and open a pull request later, push it as its own branch:
+  ```bash
+  git push -u origin work
+  ```
+
+## If GitHub already has different commits on `main`
+- First, fetch as above, then inspect remote history (example):
+  ```bash
+  git log --oneline origin/main | head
+  ```
+- To keep your current work safe, create a backup branch locally before attempting any merges or rebases:
+  ```bash
+  git branch backup/work-local
+  ```
+- To combine remote `main` with your local changes, check out `main` tracking the remote and merge/rebase `work` onto it:
+  ```bash
+  git checkout -b main origin/main
+  git merge work
+  ```
+  Resolve any conflicts that appear, commit the resolution, then push:
+  ```bash
+  git push -u origin main
+  ```
+
+## Where to ask SimHub for car/track live data
+- SimHub exposes the live car and track via data references such as `DataCorePlugin.GameData.CarModel` and `DataCorePlugin.GameData.TrackNameWithConfig`. The UI dropdowns use these live values, so once your GitHub branches are synced you can verify that both the pre-race and snapshot fields bind to the same live strings.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1,5 +1,4 @@
-﻿using LaunchPlugin;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -12,6 +11,8 @@ using System.Windows;
 using System.Windows.Input;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.Tab;
 
+namespace LaunchPlugin
+{
 public class FuelCalcs : INotifyPropertyChanged
 {
     // --- Enums and Structs ---
@@ -62,6 +63,31 @@ public class FuelCalcs : INotifyPropertyChanged
     private int _liveFuelConfidence;
     private int _livePaceConfidence;
     private int _liveOverallConfidence;
+    private bool _isLiveSessionActive;
+    private string _liveCarName = "—";
+    private string _liveTrackName = "—";
+    private string _liveSurfaceModeDisplay = "Dry";
+    private string _liveFuelTankSizeDisplay = "-";
+    private string _dryLapTimeSummary = "-";
+    private string _wetLapTimeSummary = "-";
+    private string _dryPaceDeltaSummary = "-";
+    private string _wetPaceDeltaSummary = "-";
+    private string _dryFuelBurnSummary = "-";
+    private string _wetFuelBurnSummary = "-";
+    private string _lastPitDriveThroughDisplay = "-";
+    private string _lastRefuelRateDisplay = "-";
+    private string _liveBestLapDisplay = "-";
+    private string _liveLeaderPaceInfo = "-";
+    private string _racePaceVsLeaderSummary = "-";
+    private double _liveFuelTankLiters;
+    private double _liveDryFuelAvg;
+    private double _liveDryFuelMin;
+    private double _liveDryFuelMax;
+    private int _liveDrySamples;
+    private double _liveWetFuelAvg;
+    private double _liveWetFuelMin;
+    private double _liveWetFuelMax;
+    private int _liveWetSamples;
                                              
     // --- NEW: Local properties for "what-if" parameters ---
     private double _contingencyValue = 1.5;
@@ -115,6 +141,94 @@ public class FuelCalcs : INotifyPropertyChanged
     public int LivePaceConfidence { get; private set; }
     public int LiveOverallConfidence { get; private set; }
     public string LiveConfidenceSummary { get; private set; } = "Live reliability: n/a";
+    public bool IsLiveSessionActive
+    {
+        get => _isLiveSessionActive;
+        private set
+        {
+            if (_isLiveSessionActive != value)
+            {
+                _isLiveSessionActive = value;
+                OnPropertyChanged();
+                UpdateSurfaceModeLabel();
+            }
+        }
+    }
+    public string LiveCarName
+    {
+        get => _liveCarName;
+        private set { if (_liveCarName != value) { _liveCarName = value; OnPropertyChanged(); } }
+    }
+    public string LiveTrackName
+    {
+        get => _liveTrackName;
+        private set { if (_liveTrackName != value) { _liveTrackName = value; OnPropertyChanged(); } }
+    }
+    public string LiveSurfaceModeDisplay
+    {
+        get => _liveSurfaceModeDisplay;
+        private set { if (_liveSurfaceModeDisplay != value) { _liveSurfaceModeDisplay = value; OnPropertyChanged(); } }
+    }
+    public string LiveFuelTankSizeDisplay
+    {
+        get => _liveFuelTankSizeDisplay;
+        private set { if (_liveFuelTankSizeDisplay != value) { _liveFuelTankSizeDisplay = value; OnPropertyChanged(); } }
+    }
+    public string LiveBestLapDisplay
+    {
+        get => _liveBestLapDisplay;
+        private set { if (_liveBestLapDisplay != value) { _liveBestLapDisplay = value; OnPropertyChanged(); } }
+    }
+    public string LiveLeaderPaceInfo
+    {
+        get => _liveLeaderPaceInfo;
+        private set { if (_liveLeaderPaceInfo != value) { _liveLeaderPaceInfo = value; OnPropertyChanged(); } }
+    }
+    public string DryLapTimeSummary
+    {
+        get => _dryLapTimeSummary;
+        private set { if (_dryLapTimeSummary != value) { _dryLapTimeSummary = value; OnPropertyChanged(); } }
+    }
+    public string WetLapTimeSummary
+    {
+        get => _wetLapTimeSummary;
+        private set { if (_wetLapTimeSummary != value) { _wetLapTimeSummary = value; OnPropertyChanged(); } }
+    }
+    public string DryPaceDeltaSummary
+    {
+        get => _dryPaceDeltaSummary;
+        private set { if (_dryPaceDeltaSummary != value) { _dryPaceDeltaSummary = value; OnPropertyChanged(); } }
+    }
+    public string WetPaceDeltaSummary
+    {
+        get => _wetPaceDeltaSummary;
+        private set { if (_wetPaceDeltaSummary != value) { _wetPaceDeltaSummary = value; OnPropertyChanged(); } }
+    }
+    public string DryFuelBurnSummary
+    {
+        get => _dryFuelBurnSummary;
+        private set { if (_dryFuelBurnSummary != value) { _dryFuelBurnSummary = value; OnPropertyChanged(); } }
+    }
+    public string WetFuelBurnSummary
+    {
+        get => _wetFuelBurnSummary;
+        private set { if (_wetFuelBurnSummary != value) { _wetFuelBurnSummary = value; OnPropertyChanged(); } }
+    }
+    public string RacePaceVsLeaderSummary
+    {
+        get => _racePaceVsLeaderSummary;
+        private set { if (_racePaceVsLeaderSummary != value) { _racePaceVsLeaderSummary = value; OnPropertyChanged(); } }
+    }
+    public string LastPitDriveThroughDisplay
+    {
+        get => _lastPitDriveThroughDisplay;
+        private set { if (_lastPitDriveThroughDisplay != value) { _lastPitDriveThroughDisplay = value; OnPropertyChanged(); } }
+    }
+    public string LastRefuelRateDisplay
+    {
+        get => _lastRefuelRateDisplay;
+        private set { if (_lastRefuelRateDisplay != value) { _lastRefuelRateDisplay = value; OnPropertyChanged(); } }
+    }
 
     public string ProfileAvgLapTimeDisplay { get; private set; }
     public string ProfileAvgFuelDisplay { get; private set; }
@@ -576,10 +690,13 @@ public class FuelCalcs : INotifyPropertyChanged
         _loadedBestLapTimeSeconds = pbSeconds;
         IsPersonalBestAvailable = true;
 
-        // Update the label shown under the PB button
-        HistoricalBestLapDisplay = TimeSpan
+        var formatted = TimeSpan
             .FromSeconds(_loadedBestLapTimeSeconds)
             .ToString(@"m\:ss\.fff");
+
+        // Update the label shown under the PB button
+        HistoricalBestLapDisplay = formatted;
+        LiveBestLapDisplay = formatted;
 
         // If the user has ALREADY selected PB as the source, refresh the estimate and source label.
         if (LapTimeSourceInfo == "source: PB")
@@ -591,6 +708,7 @@ public class FuelCalcs : INotifyPropertyChanged
 
         OnPropertyChanged(nameof(IsPersonalBestAvailable));
         OnPropertyChanged(nameof(HistoricalBestLapDisplay));
+        UpdateLapTimeSummaries();
     }
 
     private void UseMaxFuelPerLap()
@@ -651,6 +769,72 @@ public class FuelCalcs : INotifyPropertyChanged
         OnPropertyChanged(nameof(IsMaxFuelAvailable));
     }
 
+    public void SetLiveFuelWindowStats(double avgDry, double minDry, double maxDry, int drySamples,
+        double avgWet, double minWet, double maxWet, int wetSamples)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.CheckAccess())
+        {
+            ApplyLiveFuelWindowStats(avgDry, minDry, maxDry, drySamples, avgWet, minWet, maxWet, wetSamples);
+        }
+        else
+        {
+            disp.Invoke(() => ApplyLiveFuelWindowStats(avgDry, minDry, maxDry, drySamples, avgWet, minWet, maxWet, wetSamples));
+        }
+    }
+
+    private void ApplyLiveFuelWindowStats(double avgDry, double minDry, double maxDry, int drySamples,
+        double avgWet, double minWet, double maxWet, int wetSamples)
+    {
+        _liveDryFuelAvg = avgDry;
+        _liveDryFuelMin = minDry > 0 ? minDry : 0.0;
+        _liveDryFuelMax = maxDry > 0 ? maxDry : 0.0;
+        _liveDrySamples = Math.Max(0, drySamples);
+
+        _liveWetFuelAvg = avgWet;
+        _liveWetFuelMin = minWet > 0 ? minWet : 0.0;
+        _liveWetFuelMax = maxWet > 0 ? maxWet : 0.0;
+        _liveWetSamples = Math.Max(0, wetSamples);
+
+        UpdateFuelBurnSummaries();
+    }
+
+    public void SetLastPitDriveThroughSeconds(double seconds)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.CheckAccess())
+        {
+            ApplyLastPitDriveThroughSeconds(seconds);
+        }
+        else
+        {
+            disp.Invoke(() => ApplyLastPitDriveThroughSeconds(seconds));
+        }
+    }
+
+    private void ApplyLastPitDriveThroughSeconds(double seconds)
+    {
+        LastPitDriveThroughDisplay = seconds > 0 ? $"{seconds:F1}s" : "-";
+    }
+
+    public void SetLastRefuelRate(double litersPerSecond)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.CheckAccess())
+        {
+            ApplyLastRefuelRate(litersPerSecond);
+        }
+        else
+        {
+            disp.Invoke(() => ApplyLastRefuelRate(litersPerSecond));
+        }
+    }
+
+    private void ApplyLastRefuelRate(double litersPerSecond)
+    {
+        LastRefuelRateDisplay = litersPerSecond > 0 ? $"{litersPerSecond:F2} L/s" : "-";
+    }
+
     public TrackCondition SelectedTrackCondition
     {
         get => _selectedTrackCondition;
@@ -662,6 +846,8 @@ public class FuelCalcs : INotifyPropertyChanged
                 OnPropertyChanged(nameof(SelectedTrackCondition));
                 OnPropertyChanged(nameof(IsDry));
                 OnPropertyChanged(nameof(IsWet));
+                OnPropertyChanged(nameof(ShowDrySnapshotRows));
+                OnPropertyChanged(nameof(ShowWetSnapshotRows));
 
                 // Apply fuel factor
                 if (IsWet) { ApplyWetFactor(); }
@@ -679,6 +865,8 @@ public class FuelCalcs : INotifyPropertyChanged
                         LapTimeSourceInfo = $"source: {(IsWet ? "wet avg" : "dry avg")}";
                     }
                 }
+                UpdateTrackDerivedSummaries();
+                UpdateSurfaceModeLabel();
             }
             OnPropertyChanged(nameof(ProfileAvgLapTimeDisplay));
             OnPropertyChanged(nameof(ProfileAvgFuelDisplay));
@@ -696,6 +884,8 @@ public class FuelCalcs : INotifyPropertyChanged
         get => SelectedTrackCondition == TrackCondition.Wet;
         set { if (value) SelectedTrackCondition = TrackCondition.Wet; }
     }
+    public bool ShowDrySnapshotRows => IsDry;
+    public bool ShowWetSnapshotRows => IsWet;
 
     public double MaxFuelOverride
     {
@@ -1370,8 +1560,17 @@ public class FuelCalcs : INotifyPropertyChanged
             LivePaceDeltaInfo = ""; // Clear delta info when not available
         }
 
-        // Update Delta to Leader Value
+        // Update Delta to Leader Value + store their rolling average pace
         double leaderAvgPace = _plugin.LiveLeaderAvgPaceSeconds;
+        if (leaderAvgPace > 0)
+        {
+            LiveLeaderPaceInfo = TimeSpan.FromSeconds(leaderAvgPace).ToString(@"m\:ss\.fff");
+        }
+        else
+        {
+            LiveLeaderPaceInfo = "-";
+        }
+
         if (avgSeconds > 0 && leaderAvgPace > 0)
         {
             double delta = avgSeconds - leaderAvgPace;
@@ -1394,6 +1593,7 @@ public class FuelCalcs : INotifyPropertyChanged
             AvgDeltaToPbValue = "-";
         }
         OnPropertyChanged(nameof(AvgDeltaToPbValue));
+        UpdateTrackDerivedSummaries();
     }
 
     public void SetLiveConfidenceLevels(int fuelConfidence, int paceConfidence, int overallConfidence)
@@ -1439,11 +1639,148 @@ public class FuelCalcs : INotifyPropertyChanged
         return $"Live reliability: Fuel {LiveFuelConfidence}% | Pace {LivePaceConfidence}% | Overall {LiveOverallConfidence}%";
     }
 
+    private void UpdateSurfaceModeLabel()
+    {
+        string mode = IsWet ? "Wet" : "Dry";
+        LiveSurfaceModeDisplay = IsLiveSessionActive ? $"{mode} • Live" : mode;
+    }
+
+    private void ResetSnapshotDisplays()
+    {
+        IsLiveSessionActive = false;
+        LiveCarName = "—";
+        LiveTrackName = "—";
+        LiveFuelTankSizeDisplay = "-";
+        LiveBestLapDisplay = "-";
+        LiveLeaderPaceInfo = "-";
+        DryLapTimeSummary = "-";
+        WetLapTimeSummary = "-";
+        DryPaceDeltaSummary = "-";
+        WetPaceDeltaSummary = "-";
+        DryFuelBurnSummary = "-";
+        WetFuelBurnSummary = "-";
+        RacePaceVsLeaderSummary = "-";
+        LastPitDriveThroughDisplay = "-";
+        LastRefuelRateDisplay = "-";
+        SeenCarName = LiveCarName;
+        SeenTrackName = LiveTrackName;
+        SeenSessionSummary = "No Live Data";
+        UpdateSurfaceModeLabel();
+    }
+
+    private void UpdateTrackDerivedSummaries()
+    {
+        UpdateLapTimeSummaries();
+        UpdatePaceSummaries();
+        UpdateRacePaceVsLeaderSummary();
+    }
+
+    private void UpdateLapTimeSummaries()
+    {
+        DryLapTimeSummary = BuildLiveLapSummary(ShowDrySnapshotRows);
+        WetLapTimeSummary = BuildLiveLapSummary(ShowWetSnapshotRows);
+    }
+
+    private string BuildLiveLapSummary(bool isVisible)
+    {
+        if (!isVisible) return "-";
+
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(LiveBestLapDisplay) && LiveBestLapDisplay != "-")
+        {
+            parts.Add($"PB {LiveBestLapDisplay}");
+        }
+        if (!string.IsNullOrWhiteSpace(LiveLapPaceInfo) && LiveLapPaceInfo != "-")
+        {
+            parts.Add($"Avg {LiveLapPaceInfo}");
+        }
+        return parts.Count > 0 ? string.Join(" | ", parts) : "-";
+    }
+
+    private void UpdatePaceSummaries()
+    {
+        DryPaceDeltaSummary = BuildLivePaceDeltaSummary(ShowDrySnapshotRows);
+        WetPaceDeltaSummary = BuildLivePaceDeltaSummary(ShowWetSnapshotRows);
+    }
+
+    private void UpdateRacePaceVsLeaderSummary()
+    {
+        bool hasDriverAvg = !string.IsNullOrWhiteSpace(LiveLapPaceInfo) && LiveLapPaceInfo != "-";
+        bool hasLeaderAvg = !string.IsNullOrWhiteSpace(LiveLeaderPaceInfo) && LiveLeaderPaceInfo != "-";
+        if (!hasDriverAvg || !hasLeaderAvg)
+        {
+            RacePaceVsLeaderSummary = "-";
+            return;
+        }
+
+        var delta = NormalizeDelta(AvgDeltaToLdrValue);
+        RacePaceVsLeaderSummary = delta == null
+            ? $"Avg {LiveLapPaceInfo} vs Leader {LiveLeaderPaceInfo}"
+            : $"Avg {LiveLapPaceInfo} vs Leader {LiveLeaderPaceInfo} (Δ {delta})";
+    }
+
+    private string BuildLivePaceDeltaSummary(bool isVisible)
+    {
+        if (!isVisible) return "-";
+
+        var parts = new List<string>();
+        var pbDelta = NormalizeDelta(AvgDeltaToPbValue);
+        var leaderDelta = NormalizeDelta(AvgDeltaToLdrValue);
+
+        if (pbDelta != null)
+        {
+            parts.Add($"Δ PB: {pbDelta}");
+        }
+        if (leaderDelta != null)
+        {
+            parts.Add($"Δ Leader: {leaderDelta}");
+        }
+
+        return parts.Count > 0 ? string.Join(" | ", parts) : "-";
+    }
+
+    private static string NormalizeDelta(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) || value == "-" ? null : value;
+    }
+
+    private static string FormatLabel(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "Unknown" : value;
+    }
+
+    private void UpdateFuelBurnSummaries()
+    {
+        DryFuelBurnSummary = BuildFuelSummary(_liveDryFuelAvg, _liveDryFuelMin, _liveDryFuelMax, _liveDrySamples);
+        WetFuelBurnSummary = BuildFuelSummary(_liveWetFuelAvg, _liveWetFuelMin, _liveWetFuelMax, _liveWetSamples);
+    }
+
+    private static string BuildFuelSummary(double avg, double min, double max, int samples)
+    {
+        var parts = new List<string>();
+        if (avg > 0) parts.Add($"Avg {avg:F2} L");
+        if (min > 0 && max > 0) parts.Add($"Range {min:F2}–{max:F2} L");
+        else if (max > 0) parts.Add($"Max {max:F2} L");
+        else if (min > 0) parts.Add($"Min {min:F2} L");
+        if (samples > 0) parts.Add(samples == 1 ? "1 lap" : $"{samples} laps");
+        if (parts.Count == 0) return "-";
+        return string.Join(" | ", parts);
+    }
+
     // Helper does the actual updates (runs on UI thread)
     private void ApplyLiveSession(string carName, string trackName)
     {
-        // Keep the nice human-readable label
-        SeenSessionSummary = $"Live: {carName} @ {trackName}";
+        bool hasCar = !string.IsNullOrWhiteSpace(carName) && !carName.Equals("Unknown", StringComparison.OrdinalIgnoreCase);
+        bool hasTrack = !string.IsNullOrWhiteSpace(trackName) && !trackName.Equals("Unknown", StringComparison.OrdinalIgnoreCase);
+
+        LiveCarName = hasCar ? carName : "—";
+        LiveTrackName = hasTrack ? trackName : "—";
+        SeenCarName = LiveCarName;
+        SeenTrackName = LiveTrackName;
+        IsLiveSessionActive = hasCar && hasTrack;
+        SeenSessionSummary = (hasCar || hasTrack)
+            ? $"Live: {FormatLabel(carName)} @ {FormatLabel(trackName)}"
+            : "No Live Data";
 
         // 1) Make sure the car profile object is selected (this will also rebuild AvailableTracks once below)
         var carProfile = AvailableCarProfiles.FirstOrDefault(
@@ -1488,10 +1825,12 @@ public class FuelCalcs : INotifyPropertyChanged
                 this.SelectedTrackStats = AvailableTrackStats[0];
         }
 
+        UpdateTrackDerivedSummaries();
     }
 
     private void SetUIDefaults()
     {
+        ResetSnapshotDisplays();
         _raceLaps = 20.0;
         _raceMinutes = 40.0;
         _raceType = RaceType.TimeLimited;
@@ -1635,6 +1974,8 @@ public class FuelCalcs : INotifyPropertyChanged
 
         // Recompute with the newly loaded data
         CalculateStrategy();
+
+        UpdateTrackDerivedSummaries();
     }
 
     private void ApplyWetFactor()
@@ -1653,8 +1994,10 @@ public class FuelCalcs : INotifyPropertyChanged
         }
 
         _liveMaxFuel = liveMaxFuel; // Store the latest value for the next check
+        _liveFuelTankLiters = liveMaxFuel;
         if (liveMaxFuel > 0) { DetectedMaxFuelDisplay = $"(Detected Max: {liveMaxFuel:F1} L)"; }
         else { DetectedMaxFuelDisplay = "(Detected Max: N/A)"; }
+        LiveFuelTankSizeDisplay = liveMaxFuel > 0 ? $"{liveMaxFuel:F1} L" : "-";
         OnPropertyChanged(nameof(DetectedMaxFuelDisplay));
         OnPropertyChanged(nameof(IsMaxFuelOverrideTooHigh)); // Notify UI to re-check the highlight
     }
@@ -2226,4 +2569,5 @@ public class FuelCalcs : INotifyPropertyChanged
             Delta = delta ?? string.Empty;
         }
     }
+}
 }

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -20,6 +20,20 @@
             <Setter Property="Margin" Value="6,2,0,0"/>
         </Style>
 
+        <Style x:Key="SnapshotLabelStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="#C9CFDC"/>
+            <Setter Property="Margin" Value="0,4,8,0"/>
+        </Style>
+
+        <Style x:Key="SnapshotValueStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Margin" Value="0,4,0,0"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+
         <!-- Warning label style when a guard-rail condition is active -->
         <Style x:Key="WarnText" TargetType="TextBlock" BasedOn="{StaticResource UnitHint}">
             <Setter Property="Foreground" Value="#FFCC7A"/>
@@ -31,6 +45,90 @@
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <StackPanel Margin="10">
+            <local:LaunchSummaryExpander Header="LIVE SESSION SNAPSHOT"
+                                         Margin="0,0,0,15"
+                                         IsExpanded="True"
+                                         IsHighlighted="{Binding IsLiveSessionActive}">
+                <local:LaunchSummaryExpander.BodyContent>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="190"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Car" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding LiveCarName}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Track" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding LiveTrackName}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Fuel Tank Size (max factored)" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding LiveFuelTankSizeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Surface" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding LiveSurfaceModeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Race Pace vs Leader" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding RacePaceVsLeaderSummary}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Dry Lap Times" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding DryLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Wet Lap Times" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding WetLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Dry Pace Delta" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding DryPaceDeltaSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="8" Grid.Column="0" Text="Wet Pace Delta" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding WetPaceDeltaSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="9" Grid.Column="0" Text="Dry Fuel Burn" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="9" Grid.Column="1" Text="{Binding DryFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="10" Grid.Column="0" Text="Wet Fuel Burn" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding WetFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="11" Grid.Column="0" Text="Last Pit Drive-Through" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="11" Grid.Column="1" Text="{Binding LastPitDriveThroughDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="12" Grid.Column="0" Text="Last Refuel Rate" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="12" Grid.Column="1" Text="{Binding LastRefuelRateDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
+
+                        <TextBlock Grid.Row="13" Grid.Column="0" Text="Live Reliability" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="13" Grid.Column="1" Text="{Binding LiveConfidenceSummary}" Style="{StaticResource SnapshotValueStyle}" TextWrapping="Wrap"/>
+                    </Grid>
+                </local:LaunchSummaryExpander.BodyContent>
+            </local:LaunchSummaryExpander>
+
             <styles:SHSection Title="PRE-RACE PLANNER" ShowSeparator="True" Margin="0,5,0,0">
                 <Grid Margin="5,0,5,5">
                     <Grid.RowDefinitions>
@@ -160,7 +258,6 @@
                             <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding LiveLapPaceInfo}" Foreground="Gray" FontStyle="Italic" Margin="0,2,0,0" HorizontalAlignment="Center" ToolTip="Live rolling average lap time."/>
                             <TextBlock Grid.Row="1" Grid.Column="4" Text="{Binding ProfileAvgDryLapTimeDisplay}" Foreground="Gray" FontStyle="Italic" Margin="0,2,0,0" HorizontalAlignment="Center" ToolTip="Saved average dry lap time from profile."/>
 
-                            <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="4" Text="{Binding LiveConfidenceSummary}" Foreground="Gray" FontStyle="Italic" Margin="0,4,0,0" TextWrapping="Wrap"/>
                         </Grid>
 
                         <StackPanel Grid.Row="4" Margin="0,10,0,10" Grid.IsSharedSizeScope="True">

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -125,6 +125,8 @@ namespace LaunchPlugin
         private double _avgWetFuelPerLap = 0.0;
         private double _maxDryFuelPerLap = 0.0;
         private double _maxWetFuelPerLap = 0.0;
+        private double _minDryFuelPerLap = 0.0;
+        private double _minWetFuelPerLap = 0.0;
         private int _validDryLaps = 0;
         private int _validWetLaps = 0;
 
@@ -455,6 +457,8 @@ namespace LaunchPlugin
             _avgWetFuelPerLap = 0.0;
             _maxDryFuelPerLap = 0.0;
             _maxWetFuelPerLap = 0.0;
+            _minDryFuelPerLap = 0.0;
+            _minWetFuelPerLap = 0.0;
             _lastFuelLevel = -1.0;
             _lapStartFuel = -1.0;
             _lastLapDistPct = -1.0;
@@ -476,6 +480,7 @@ namespace LaunchPlugin
             _maxFuelPerLapSession = 0.0;
             FuelCalculator?.SetLiveConfidenceLevels(0, 0, 0);
             FuelCalculator?.SetLiveLapPaceEstimate(0, 0);
+            FuelCalculator?.SetLiveFuelWindowStats(0, 0, 0, 0, 0, 0, 0, 0);
 
             // Only seed when entering Race with matching car/track
             if (applySeeds &&
@@ -490,6 +495,8 @@ namespace LaunchPlugin
                     _recentDryFuelLaps.Add(_seedDryFuelPerLap);
                     _validDryLaps = 1;
                     _avgDryFuelPerLap = _seedDryFuelPerLap;
+                    _maxDryFuelPerLap = _seedDryFuelPerLap;
+                    _minDryFuelPerLap = _seedDryFuelPerLap;
                     seededAny = true;
                 }
 
@@ -498,6 +505,8 @@ namespace LaunchPlugin
                     _recentWetFuelLaps.Add(_seedWetFuelPerLap);
                     _validWetLaps = 1;
                     _avgWetFuelPerLap = _seedWetFuelPerLap;
+                    _maxWetFuelPerLap = _seedWetFuelPerLap;
+                    _minWetFuelPerLap = _seedWetFuelPerLap;
                     seededAny = true;
                 }
 
@@ -518,6 +527,8 @@ namespace LaunchPlugin
                     }
                     catch { /* logging must not throw */ }
                 }
+                FuelCalculator?.SetLiveFuelWindowStats(_avgDryFuelPerLap, _minDryFuelPerLap, _maxDryFuelPerLap, _validDryLaps,
+                    _avgWetFuelPerLap, _minWetFuelPerLap, _maxWetFuelPerLap, _validWetLaps);
             }
         }
 
@@ -967,6 +978,8 @@ namespace LaunchPlugin
                         {
                             _avgWetFuelPerLap = window.Average();
                             _validWetLaps = window.Count;
+                            if (window.Count > 0)
+                                _minWetFuelPerLap = window.Min();
 
                             // Max tracking with looser bounds [0.7, 1.8] × baseline
                             var (_, baselineWet) = GetProfileFuelBaselines();
@@ -982,6 +995,8 @@ namespace LaunchPlugin
                         {
                             _avgDryFuelPerLap = window.Average();
                             _validDryLaps = window.Count;
+                            if (window.Count > 0)
+                                _minDryFuelPerLap = window.Min();
 
                             var (baselineDry, _) = GetProfileFuelBaselines();
                             double baseline = baselineDry > 0 ? baselineDry : _avgDryFuelPerLap;
@@ -1012,6 +1027,10 @@ namespace LaunchPlugin
                             _maxFuelPerLapSession = maxForMode;
                             FuelCalculator?.SetMaxFuelPerLap(_maxFuelPerLapSession);
                         }
+
+                        FuelCalculator?.SetLiveFuelWindowStats(
+                            _avgDryFuelPerLap, _minDryFuelPerLap, _maxDryFuelPerLap, _validDryLaps,
+                            _avgWetFuelPerLap, _minWetFuelPerLap, _maxWetFuelPerLap, _validWetLaps);
 
                         // Keep profile’s dry fuel updated from stable dry data only
                         if (!isWetMode && _validDryLaps >= 3 && ActiveProfile != null)
@@ -1389,6 +1408,8 @@ namespace LaunchPlugin
 
         private string _lastSeenCar = "";
         private string _lastSeenTrack = "";
+        private string _lastSnapshotCar = string.Empty;
+        private string _lastSnapshotTrack = string.Empty;
         private double _lastLapTimeSec = 0.0;   // last completed lap time
         private int _lastSavedLap = -1;   // last completedLaps value we saved against
 
@@ -1758,7 +1779,8 @@ namespace LaunchPlugin
             trackRecord.PitLaneLossSource = src;                  // "dtl" or "direct"
             trackRecord.PitLaneLossUpdatedUtc = now;              // DateTime.UtcNow above
 
-            // Push to Fuel tab immediately
+            // Publish to the live snapshot + Fuel tab immediately
+            FuelCalculator?.SetLastPitDriveThroughSeconds(rounded);
             FuelCalculator?.ForceProfileDataReload();
 
             // Remember last save
@@ -1891,6 +1913,31 @@ namespace LaunchPlugin
 
         #region Core Update Method
 
+        private void PushLiveSnapshotIdentity()
+        {
+            string carName = (!string.IsNullOrWhiteSpace(CurrentCarModel) && !CurrentCarModel.Equals("Unknown", StringComparison.OrdinalIgnoreCase))
+                ? CurrentCarModel
+                : string.Empty;
+
+            string trackLabel = !string.IsNullOrWhiteSpace(CurrentTrackName)
+                ? CurrentTrackName
+                : (!string.IsNullOrWhiteSpace(CurrentTrackKey) ? CurrentTrackKey : string.Empty);
+
+            if (FuelCalculator == null)
+            {
+                return;
+            }
+
+            if (carName == _lastSnapshotCar && trackLabel == _lastSnapshotTrack)
+            {
+                return;
+            }
+
+            FuelCalculator.SetLiveSession(carName, trackLabel);
+            _lastSnapshotCar = carName;
+            _lastSnapshotTrack = trackLabel;
+        }
+
         public void DataUpdate(PluginManager pluginManager, ref GameData data)
         {
             // ==== New, Simplified Car & Track Detection ====
@@ -1899,22 +1946,33 @@ namespace LaunchPlugin
             try
             {
                 string trackKey = Convert.ToString(pluginManager.GetPropertyValue("DataCorePlugin.GameData.TrackCode"));
-                string trackDisplay = Convert.ToString(pluginManager.GetPropertyValue("IRacingExtraProperties.iRacing_TrackDisplayName"));
+                string trackDisplay = FirstNonEmpty(
+                    pluginManager.GetPropertyValue("IRacingExtraProperties.iRacing_TrackDisplayName"),
+                    pluginManager.GetPropertyValue("DataCorePlugin.GameData.TrackNameWithConfig"),
+                    pluginManager.GetPropertyValue("DataCorePlugin.GameData.TrackName")
+                );
 
-                string carModel = "Unknown";
-                var carModelProbe = FirstNonEmpty(
+                string carModel = FirstNonEmpty(
                     pluginManager.GetPropertyValue("DataCorePlugin.GameData.CarModel"),
                     pluginManager.GetPropertyValue("IRacingExtraProperties.iRacing_CarModel")
                 );
-                if (!string.IsNullOrWhiteSpace(carModelProbe)) { carModel = carModelProbe; }
+
+                if (!string.IsNullOrWhiteSpace(carModel))
+                {
+                    CurrentCarModel = carModel;
+                }
 
                 if (!string.IsNullOrWhiteSpace(trackKey))
                 {
-                    if (string.IsNullOrWhiteSpace(trackDisplay)) { trackDisplay = Convert.ToString(pluginManager.GetPropertyValue("DataCorePlugin.GameData.TrackName")); }
-                    CurrentCarModel = carModel;
                     CurrentTrackKey = trackKey;
+                }
+
+                if (!string.IsNullOrWhiteSpace(trackDisplay))
+                {
                     CurrentTrackName = trackDisplay;
                 }
+
+                PushLiveSnapshotIdentity();
             }
             catch (Exception ex) { SimHub.Logging.Current.Warn($"[LalaLaunch] Simplified Car/Track probe failed: {ex.Message}"); }
 
@@ -1942,6 +2000,10 @@ namespace LaunchPlugin
                 _pitLite?.ResetCycle();
                 _pit?.ResetPitPhaseState();
                 _currentCarModel = "Unknown";
+                _lastSeenCar = string.Empty;
+                _lastSeenTrack = string.Empty;
+                _lastSnapshotCar = string.Empty;
+                _lastSnapshotTrack = string.Empty;
                 _lastSessionId = currentSessionId;
                 FuelCalculator.ForceProfileDataReload();
 
@@ -2084,6 +2146,7 @@ namespace LaunchPlugin
                             var savedRate = _refuelRateEmaLps;
 
                             SaveRefuelRateToActiveProfile(savedRate);
+                            FuelCalculator?.SetLastRefuelRate(savedRate);
                             _refuelLearnCooldownEnd = sessionTime + LearnCooldownSec;
 
                             SimHub.Logging.Current.Info(
@@ -2180,15 +2243,18 @@ namespace LaunchPlugin
 
                 // Check if the currently detected car/track is different from the one we last auto-selected.
                 // ---- THIS IS THE FINAL, CORRECTED LOGIC ----
-                if (!string.IsNullOrEmpty(CurrentCarModel) && CurrentCarModel != "Unknown" && !string.IsNullOrEmpty(CurrentTrackKey) &&
-                    (CurrentCarModel != _lastSeenCar || CurrentTrackKey != _lastSeenTrack))
+                string trackIdentity = !string.IsNullOrWhiteSpace(CurrentTrackKey) ? CurrentTrackKey : CurrentTrackName;
+                bool hasCar = !string.IsNullOrEmpty(CurrentCarModel) && CurrentCarModel != "Unknown";
+                bool hasTrack = !string.IsNullOrWhiteSpace(trackIdentity);
+
+                if (hasCar && hasTrack && (CurrentCarModel != _lastSeenCar || trackIdentity != _lastSeenTrack))
                 {
                     // It's a new combo, so we'll perform the auto-selection.
-                    SimHub.Logging.Current.Info($"[LalaLaunch] New live combo detected. Auto-selecting profile for Car='{CurrentCarModel}', Track='{CurrentTrackName}'.");
+                    SimHub.Logging.Current.Info($"[LalaLaunch] New live combo detected. Auto-selecting profile for Car='{CurrentCarModel}', Track='{trackIdentity}'.");
 
                     // Store this combo's KEY so we don't trigger again for the same session.
                     _lastSeenCar = CurrentCarModel;
-                    _lastSeenTrack = CurrentTrackKey; // <-- This now correctly stores the key
+                    _lastSeenTrack = trackIdentity; // track key preferred, fall back to display name
 
                     // Dispatch UI updates to the main thread.
                     System.Windows.Application.Current.Dispatcher.Invoke(() =>
@@ -2204,10 +2270,14 @@ namespace LaunchPlugin
                         }
                         else
                         {
-                            SimHub.Logging.Current.Info("[LalaLaunch] Skipped EnsureCarTrack: live track key is empty/unknown.");
+                            SimHub.Logging.Current.Info($"[LalaLaunch] EnsureCarTrack fallback -> car='{CurrentCarModel}', trackName='{trackIdentity}'");
+                            ProfilesViewModel.EnsureCarTrack(CurrentCarModel, trackIdentity);
                         }
 
-                        FuelCalculator.SetLiveSession(CurrentCarModel, CurrentTrackName);
+                        string trackNameForSnapshot = !string.IsNullOrWhiteSpace(CurrentTrackName)
+                            ? CurrentTrackName
+                            : trackIdentity;
+                        FuelCalculator?.SetLiveSession(CurrentCarModel, trackNameForSnapshot);
                     });
 
                 }

--- a/LaunchPlugin.csproj
+++ b/LaunchPlugin.csproj
@@ -98,6 +98,9 @@
     <Compile Include="FuelCalculatorView.xaml.cs">
       <DependentUpon>FuelCalculatorView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="LaunchSummaryExpander.xaml.cs">
+      <DependentUpon>LaunchSummaryExpander.xaml</DependentUpon>
+    </Compile>
     <Compile Include="InvertBooleanConverter.cs" />
     <Compile Include="LapTimeValidationRule.cs" />
     <Compile Include="LaunchAnalysisControl.xaml.cs">
@@ -137,6 +140,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="FuelCalculatorView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="LaunchSummaryExpander.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/LaunchSummaryExpander.xaml
+++ b/LaunchSummaryExpander.xaml
@@ -1,0 +1,112 @@
+<UserControl x:Class="LaunchPlugin.LaunchSummaryExpander"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:LaunchPlugin"
+             mc:Ignorable="d"
+             d:DesignHeight="120"
+             d:DesignWidth="300"
+             x:Name="Root">
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="CardBackgroundBrush" Color="#16181D"/>
+        <SolidColorBrush x:Key="CardBorderBrush" Color="#2B2E33"/>
+        <SolidColorBrush x:Key="HeaderBrush" Color="#1F2128"/>
+        <SolidColorBrush x:Key="AccentBrush" Color="#FF4FC3F7"/>
+        <SolidColorBrush x:Key="MutedAccentBrush" Color="#FF353A45"/>
+
+        <Style x:Key="LaunchSummaryHeaderToggleStyle" TargetType="ToggleButton">
+            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border Background="{StaticResource HeaderBrush}"
+                                CornerRadius="10,10,0,0"
+                                Padding="0">
+                            <Grid Margin="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="6"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Border x:Name="HighlightBar"
+                                        Grid.Column="0"
+                                        Margin="0,6,10,6"
+                                        CornerRadius="3"
+                                        Background="{StaticResource MutedAccentBrush}">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="{StaticResource MutedAccentBrush}"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsHighlighted, RelativeSource={RelativeSource AncestorType=local:LaunchSummaryExpander}}" Value="True">
+                                                    <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                </Border>
+                                <TextBlock Grid.Column="1"
+                                           Text="{TemplateBinding Content}"
+                                           FontWeight="SemiBold"
+                                           Foreground="White"
+                                           VerticalAlignment="Center"
+                                           FontSize="14"
+                                           Margin="0,0,10,0"/>
+                                <Path Grid.Column="2"
+                                      Margin="0,0,16,0"
+                                      Width="10"
+                                      Height="10"
+                                      Stroke="White"
+                                      StrokeThickness="2"
+                                      Data="M 0 0 L 6 6 L 0 12"
+                                      Stretch="Uniform"
+                                      RenderTransformOrigin="0.5,0.5">
+                                    <Path.Style>
+                                        <Style TargetType="Path">
+                                            <Setter Property="RenderTransform">
+                                                <Setter.Value>
+                                                    <RotateTransform Angle="-90"/>
+                                                </Setter.Value>
+                                            </Setter>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource TemplatedParent}}"
+                                                             Value="True">
+                                                    <Setter Property="RenderTransform">
+                                                        <Setter.Value>
+                                                            <RotateTransform Angle="0"/>
+                                                        </Setter.Value>
+                                                    </Setter>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Path.Style>
+                                </Path>
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Border Background="{StaticResource CardBackgroundBrush}"
+            BorderBrush="{StaticResource CardBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="10">
+        <StackPanel>
+            <ToggleButton x:Name="HeaderButton"
+                          Margin="0"
+                          Padding="16,10"
+                          FontSize="14"
+                          FontWeight="SemiBold"
+                          Content="{Binding Header, ElementName=Root}"
+                          Style="{StaticResource LaunchSummaryHeaderToggleStyle}"/>
+            <ContentPresenter x:Name="BodyPresenter"
+                              Margin="16,4,16,16"
+                              Visibility="Collapsed"
+                              Content="{Binding BodyContent, ElementName=Root}"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/LaunchSummaryExpander.xaml.cs
+++ b/LaunchSummaryExpander.xaml.cs
@@ -1,0 +1,78 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LaunchPlugin
+{
+    public partial class LaunchSummaryExpander : UserControl
+    {
+        private bool _isSyncingToggle;
+
+        public LaunchSummaryExpander()
+        {
+            InitializeComponent();
+            Loaded += (s, e) => UpdateBodyVisibility();
+            HeaderButton.Checked += HeaderButton_Toggled;
+            HeaderButton.Unchecked += HeaderButton_Toggled;
+        }
+
+        private void HeaderButton_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isSyncingToggle) return;
+            IsExpanded = HeaderButton.IsChecked == true;
+        }
+
+        private void UpdateBodyVisibility()
+        {
+            if (BodyPresenter == null || HeaderButton == null) return;
+            _isSyncingToggle = true;
+            HeaderButton.IsChecked = IsExpanded;
+            BodyPresenter.Visibility = IsExpanded ? Visibility.Visible : Visibility.Collapsed;
+            _isSyncingToggle = false;
+        }
+
+        public static readonly DependencyProperty HeaderProperty = DependencyProperty.Register(
+            nameof(Header), typeof(string), typeof(LaunchSummaryExpander), new PropertyMetadata(string.Empty));
+
+        public string Header
+        {
+            get => (string)GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
+        }
+
+        public static readonly DependencyProperty BodyContentProperty = DependencyProperty.Register(
+            nameof(BodyContent), typeof(object), typeof(LaunchSummaryExpander), new PropertyMetadata(null));
+
+        public object BodyContent
+        {
+            get => GetValue(BodyContentProperty);
+            set => SetValue(BodyContentProperty, value);
+        }
+
+        public static readonly DependencyProperty IsExpandedProperty = DependencyProperty.Register(
+            nameof(IsExpanded), typeof(bool), typeof(LaunchSummaryExpander),
+            new PropertyMetadata(true, OnIsExpandedChanged));
+
+        public bool IsExpanded
+        {
+            get => (bool)GetValue(IsExpandedProperty);
+            set => SetValue(IsExpandedProperty, value);
+        }
+
+        private static void OnIsExpandedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is LaunchSummaryExpander expander)
+            {
+                expander.UpdateBodyVisibility();
+            }
+        }
+
+        public static readonly DependencyProperty IsHighlightedProperty = DependencyProperty.Register(
+            nameof(IsHighlighted), typeof(bool), typeof(LaunchSummaryExpander), new PropertyMetadata(false));
+
+        public bool IsHighlighted
+        {
+            get => (bool)GetValue(IsHighlightedProperty);
+            set => SetValue(IsHighlightedProperty, value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move FuelCalcs back under the LaunchPlugin namespace to align with the rest of the WPF types
- close out the namespace so XAML and code-behind can resolve the shared view model cleanly

## Testing
- ⚠️ `msbuild LaunchPlugin.sln /nologo /maxcpucount` *(not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd8aaaca8832fb1b8c7e6659e1039)