### PR TITLE
Fix refuel parameter null handling and logging warning

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -311,6 +311,8 @@ public class FuelCalcs : INotifyPropertyChanged
         private set { if (_applyLiveFuelSuggestion != value) { _applyLiveFuelSuggestion = value; OnPropertyChanged(); } }
     }
 
+    public bool HasLiveMaxFuelSuggestion => _liveMaxFuel > 0;
+
     public void SetLiveFuelSuggestionFlags(bool applyFuelSuggestion, bool applyMaxFuelSuggestion)
     {
         ApplyLiveFuelSuggestion = applyFuelSuggestion;
@@ -1118,12 +1120,12 @@ public class FuelCalcs : INotifyPropertyChanged
     {
         if (fuelToAdd <= 0.0) return 0.0;
 
-        double baseSeconds = _conditionRefuelBaseSeconds ?? 0.0;
+        double baseSeconds = _conditionRefuelBaseSeconds;
 
         double pourSeconds;
-        if (_conditionRefuelSecondsPerLiter.HasValue)
+        if (_conditionRefuelSecondsPerLiter > 0.0)
         {
-            pourSeconds = _conditionRefuelSecondsPerLiter.Value * fuelToAdd;
+            pourSeconds = _conditionRefuelSecondsPerLiter * fuelToAdd;
         }
         else
         {
@@ -1132,9 +1134,9 @@ public class FuelCalcs : INotifyPropertyChanged
         }
 
         double curveSeconds = 0.0;
-        if (_conditionRefuelSecondsPerSquare.HasValue)
+        if (_conditionRefuelSecondsPerSquare > 0.0)
         {
-            curveSeconds = _conditionRefuelSecondsPerSquare.Value * fuelToAdd * fuelToAdd;
+            curveSeconds = _conditionRefuelSecondsPerSquare * fuelToAdd * fuelToAdd;
         }
 
         double total = baseSeconds + pourSeconds + curveSeconds;
@@ -2282,9 +2284,9 @@ public class FuelCalcs : INotifyPropertyChanged
                 }
             }
 
-            _conditionRefuelBaseSeconds = trackMultipliers?.RefuelSecondsBase ?? carMultipliers?.RefuelSecondsBase;
-            _conditionRefuelSecondsPerLiter = trackMultipliers?.RefuelSecondsPerLiter ?? carMultipliers?.RefuelSecondsPerLiter;
-            _conditionRefuelSecondsPerSquare = trackMultipliers?.RefuelSecondsPerSquare ?? carMultipliers?.RefuelSecondsPerSquare;
+            _conditionRefuelBaseSeconds = trackMultipliers?.RefuelSecondsBase ?? carMultipliers?.RefuelSecondsBase ?? 0.0;
+            _conditionRefuelSecondsPerLiter = trackMultipliers?.RefuelSecondsPerLiter ?? carMultipliers?.RefuelSecondsPerLiter ?? 0.0;
+            _conditionRefuelSecondsPerSquare = trackMultipliers?.RefuelSecondsPerSquare ?? carMultipliers?.RefuelSecondsPerSquare ?? 0.0;
         }
         finally
         {

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1807,9 +1807,8 @@ namespace LaunchPlugin
                 Pit_OnValidPitStopTimeLossCalculated(loss, src);
                 source = src;
                 seconds = loss;
-                return true;
-
                 SimHub.Logging.Current.Info($"Pit Lite Data used for DTL.");
+                return true;
             }
 
             return false;


### PR DESCRIPTION
## Summary
- remove nullable usage on refuel calculation fields and default missing values to zero
- add explicit live max-fuel suggestion flag for UI updates
- relocate pit stop log to avoid unreachable code warning

## Testing
- not run (dotnet SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3d619c6c832f9ed4cd507c792583)