### PR TITLE
Capture leader pace and preload pit drive-through display

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -308,8 +308,10 @@ public class FuelCalcs : INotifyPropertyChanged
     public bool ApplyLiveFuelSuggestion
     {
         get => _applyLiveFuelSuggestion;
-        private set { if (_applyLiveFuelSuggestion != value) { _applyLiveFuelSuggestion = value; OnPropertyChanged(); } }
+        set { if (_applyLiveFuelSuggestion != value) { _applyLiveFuelSuggestion = value; OnPropertyChanged(); } }
     }
+
+    public bool HasLiveMaxFuelSuggestion => _liveMaxFuel > 0;
 
     public void SetLiveFuelSuggestionFlags(bool applyFuelSuggestion, bool applyMaxFuelSuggestion)
     {
@@ -324,7 +326,7 @@ public class FuelCalcs : INotifyPropertyChanged
     public bool ApplyLiveMaxFuelSuggestion
     {
         get => _applyLiveMaxFuelSuggestion;
-        private set { if (_applyLiveMaxFuelSuggestion != value) { _applyLiveMaxFuelSuggestion = value; OnPropertyChanged(); } }
+        set { if (_applyLiveMaxFuelSuggestion != value) { _applyLiveMaxFuelSuggestion = value; OnPropertyChanged(); } }
     }
 
     // Update profile if the incoming rate differs (> tiny epsilon), then recalc.
@@ -1118,12 +1120,12 @@ public class FuelCalcs : INotifyPropertyChanged
     {
         if (fuelToAdd <= 0.0) return 0.0;
 
-        double baseSeconds = _conditionRefuelBaseSeconds ?? 0.0;
+        double baseSeconds = _conditionRefuelBaseSeconds;
 
         double pourSeconds;
-        if (_conditionRefuelSecondsPerLiter.HasValue)
+        if (_conditionRefuelSecondsPerLiter > 0.0)
         {
-            pourSeconds = _conditionRefuelSecondsPerLiter.Value * fuelToAdd;
+            pourSeconds = _conditionRefuelSecondsPerLiter * fuelToAdd;
         }
         else
         {
@@ -1132,9 +1134,9 @@ public class FuelCalcs : INotifyPropertyChanged
         }
 
         double curveSeconds = 0.0;
-        if (_conditionRefuelSecondsPerSquare.HasValue)
+        if (_conditionRefuelSecondsPerSquare > 0.0)
         {
-            curveSeconds = _conditionRefuelSecondsPerSquare.Value * fuelToAdd * fuelToAdd;
+            curveSeconds = _conditionRefuelSecondsPerSquare * fuelToAdd * fuelToAdd;
         }
 
         double total = baseSeconds + pourSeconds + curveSeconds;
@@ -2028,18 +2030,6 @@ public class FuelCalcs : INotifyPropertyChanged
     // Helper does the actual updates (runs on UI thread)
     private void ApplyLiveSession(string carName, string trackName)
     {
-        bool hasCar = !string.IsNullOrWhiteSpace(carName) && !carName.Equals("Unknown", StringComparison.OrdinalIgnoreCase);
-        bool hasTrack = !string.IsNullOrWhiteSpace(trackName) && !trackName.Equals("Unknown", StringComparison.OrdinalIgnoreCase);
-
-        LiveCarName = hasCar ? carName : _missingCarName;
-        LiveTrackName = hasTrack ? trackName : _missingTrackDisplayName;
-        SeenCarName = LiveCarName;
-        SeenTrackName = LiveTrackName;
-        IsLiveSessionActive = hasCar && hasTrack;
-        SeenSessionSummary = (hasCar || hasTrack)
-            ? $"Live: {FormatLabel(carName, _missingCarName)} @ {FormatLabel(trackName, _missingTrackDisplayName)}"
-            : "No Live Data";
-
         // 1) Make sure the car profile object is selected (this will also rebuild AvailableTracks once below)
         var carProfile = AvailableCarProfiles.FirstOrDefault(
             p => p.ProfileName.Equals(carName, StringComparison.OrdinalIgnoreCase));
@@ -2085,6 +2075,26 @@ public class FuelCalcs : INotifyPropertyChanged
 
             SetMissingTrackWarning(carName, trackName);
         }
+
+        // Prefer the same properties used by the Car/Track selectors so the snapshot mirrors the dropdowns
+        var displayCarName = !string.IsNullOrWhiteSpace(SelectedCarProfile?.ProfileName)
+            ? SelectedCarProfile.ProfileName
+            : carName;
+        var displayTrackName = !string.IsNullOrWhiteSpace(SelectedTrackStats?.DisplayName)
+            ? SelectedTrackStats.DisplayName
+            : trackName;
+
+        bool hasCar = !string.IsNullOrWhiteSpace(displayCarName) && !displayCarName.Equals("Unknown", StringComparison.OrdinalIgnoreCase);
+        bool hasTrack = !string.IsNullOrWhiteSpace(displayTrackName) && !displayTrackName.Equals("Unknown", StringComparison.OrdinalIgnoreCase);
+
+        LiveCarName = hasCar ? displayCarName : _missingCarName;
+        LiveTrackName = hasTrack ? displayTrackName : _missingTrackDisplayName;
+        SeenCarName = LiveCarName;
+        SeenTrackName = LiveTrackName;
+        IsLiveSessionActive = hasCar && hasTrack;
+        SeenSessionSummary = (hasCar || hasTrack)
+            ? $"Live: {FormatLabel(displayCarName, _missingCarName)} @ {FormatLabel(displayTrackName, _missingTrackDisplayName)}"
+            : "No Live Data";
 
         UpdateTrackDerivedSummaries();
     }
@@ -2204,6 +2214,7 @@ public class FuelCalcs : INotifyPropertyChanged
         if (ts?.PitLaneLossSeconds is double pll && pll > 0)
         {
             PitLaneTimeLoss = pll;
+            SetLastPitDriveThroughSeconds(PitLaneTimeLoss);
         }
 
         // --- CONSOLIDATED: Populate all display properties ---
@@ -2282,9 +2293,9 @@ public class FuelCalcs : INotifyPropertyChanged
                 }
             }
 
-            _conditionRefuelBaseSeconds = trackMultipliers?.RefuelSecondsBase ?? carMultipliers?.RefuelSecondsBase;
-            _conditionRefuelSecondsPerLiter = trackMultipliers?.RefuelSecondsPerLiter ?? carMultipliers?.RefuelSecondsPerLiter;
-            _conditionRefuelSecondsPerSquare = trackMultipliers?.RefuelSecondsPerSquare ?? carMultipliers?.RefuelSecondsPerSquare;
+            _conditionRefuelBaseSeconds = trackMultipliers?.RefuelSecondsBase ?? carMultipliers?.RefuelSecondsBase ?? 0.0;
+            _conditionRefuelSecondsPerLiter = trackMultipliers?.RefuelSecondsPerLiter ?? carMultipliers?.RefuelSecondsPerLiter ?? 0.0;
+            _conditionRefuelSecondsPerSquare = trackMultipliers?.RefuelSecondsPerSquare ?? carMultipliers?.RefuelSecondsPerSquare ?? 0.0;
         }
         finally
         {

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -176,6 +176,7 @@ namespace LaunchPlugin
         private const int LapTimeSampleCount = 6;   // keep last N clean laps
         private TimeSpan _lastSeenBestLap = TimeSpan.Zero;
         private readonly List<double> _recentLeaderLapTimes = new List<double>(); // seconds
+        private double _lastLeaderLapTimeSec = 0.0;
         public double LiveLeaderAvgPaceSeconds { get; private set; }
         private double _lastPitLossSaved = 0.0;
         private DateTime _lastPitLossSavedAtUtc = DateTime.MinValue;
@@ -471,6 +472,8 @@ namespace LaunchPlugin
             // Clear pace tracking alongside fuel model resets so session transitions don't carry stale data
             _recentLapTimes.Clear();
             _recentLeaderLapTimes.Clear();
+            _lastLeaderLapTimeSec = 0.0;
+            LiveLeaderAvgPaceSeconds = 0.0;
             Pace_StintAvgLapTimeSec = 0.0;
             Pace_Last5LapAvgSec = 0.0;
             PaceConfidence = 0;
@@ -743,6 +746,24 @@ namespace LaunchPlugin
                     // --- Lap-time / pace tracking (clean laps only) ---
                     var lastLapTs = data.NewData?.LastLapTime ?? TimeSpan.Zero;
                     double lastLapSec = lastLapTs.TotalSeconds;
+
+                    // Refresh the leader rolling average whenever we see a new lap time
+                    if (leaderLastLapSec > 20.0 && leaderLastLapSec < 900.0 &&
+                        Math.Abs(leaderLastLapSec - _lastLeaderLapTimeSec) > 1e-6)
+                    {
+                        _recentLeaderLapTimes.Add(leaderLastLapSec);
+                        while (_recentLeaderLapTimes.Count > LapTimeSampleCount)
+                        {
+                            _recentLeaderLapTimes.RemoveAt(0);
+                        }
+
+                        _lastLeaderLapTimeSec = leaderLastLapSec;
+                        LiveLeaderAvgPaceSeconds = _recentLeaderLapTimes.Average();
+                    }
+                    else if (_recentLeaderLapTimes.Count == 0)
+                    {
+                        LiveLeaderAvgPaceSeconds = 0.0;
+                    }
 
                     bool paceReject = false;
                     string paceReason = "";
@@ -1807,9 +1828,8 @@ namespace LaunchPlugin
                 Pit_OnValidPitStopTimeLossCalculated(loss, src);
                 source = src;
                 seconds = loss;
-                return true;
-
                 SimHub.Logging.Current.Info($"Pit Lite Data used for DTL.");
+                return true;
             }
 
             return false;
@@ -1925,7 +1945,9 @@ namespace LaunchPlugin
 
             string trackLabel = !string.IsNullOrWhiteSpace(CurrentTrackName)
                 ? CurrentTrackName
-                : (!string.IsNullOrWhiteSpace(CurrentTrackKey) ? CurrentTrackKey : string.Empty);
+                : (!string.IsNullOrWhiteSpace(CurrentTrackKey) && !CurrentTrackKey.Equals("unknown", StringComparison.OrdinalIgnoreCase)
+                    ? CurrentTrackKey
+                    : string.Empty);
 
             if (FuelCalculator == null)
             {
@@ -2247,7 +2269,10 @@ namespace LaunchPlugin
 
                 // Check if the currently detected car/track is different from the one we last auto-selected.
                 // ---- THIS IS THE FINAL, CORRECTED LOGIC ----
-                string trackIdentity = !string.IsNullOrWhiteSpace(CurrentTrackKey) ? CurrentTrackKey : CurrentTrackName;
+                string trackIdentity =
+                    (!string.IsNullOrWhiteSpace(CurrentTrackKey) && !CurrentTrackKey.Equals("unknown", StringComparison.OrdinalIgnoreCase))
+                        ? CurrentTrackKey
+                        : CurrentTrackName;
                 bool hasCar = !string.IsNullOrEmpty(CurrentCarModel) && CurrentCarModel != "Unknown";
                 bool hasTrack = !string.IsNullOrWhiteSpace(trackIdentity);
 
@@ -2373,6 +2398,41 @@ namespace LaunchPlugin
         #endregion
 
         #region Private Helper Methods for DataUpdate
+
+        private static double ReadLeaderLapTimeSeconds(PluginManager pluginManager, GameData data)
+        {
+            double TryReadSeconds(object raw)
+            {
+                if (raw == null) return 0.0;
+
+                try
+                {
+                    if (raw is TimeSpan ts) return ts.TotalSeconds;
+                    if (raw is double d) return d;
+                    if (raw is float f) return (double)f;
+                    if (raw is IConvertible c) return Convert.ToDouble(c);
+                }
+                catch { /* ignore parse errors, fall through to 0 */ }
+
+                return 0.0;
+            }
+
+            // Try a small set of common property names (works across iRacing/ACC)
+            var candidates = new object[]
+            {
+                pluginManager.GetPropertyValue("IRacingExtraProperties.iRacing_LeaderLastLapTime"),
+                pluginManager.GetPropertyValue("DataCorePlugin.GameData.LeaderLastLapTime"),
+                pluginManager.GetPropertyValue("DataCorePlugin.GameData.LeaderAverageLapTime")
+            };
+
+            foreach (var candidate in candidates)
+            {
+                double seconds = TryReadSeconds(candidate);
+                if (seconds > 0.0) return seconds;
+            }
+
+            return 0.0;
+        }
 
         private static string GetString(object o) => Convert.ToString(o, CultureInfo.InvariantCulture) ?? "";
 


### PR DESCRIPTION
## Summary
- capture leader lap times from common telemetry properties to populate live pace deltas
- seed the live pit drive-through display from the selected car/track profile values so the snapshot shows data immediately

## Testing
- not run (dotnet SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3d619c6c832f9ed4cd507c792583)