### PR TITLE
Fix leader lap time access in fuel calculations

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -613,7 +613,7 @@ namespace LaunchPlugin
 
             if (lapCrossed)
             {
-                double leaderLastLapSec = ReadLeaderLapTimeSeconds(pluginManager, data);
+                double leaderLastLapSec = ReadLeaderLapTimeSeconds(PluginManager, data);
 
                 // This logic checks if the PitEngine is waiting for an out-lap and, if so,
                 // provides it with the necessary data to finalize the calculation.
@@ -621,7 +621,7 @@ namespace LaunchPlugin
                 {
                     var lastLapTsPit = data.NewData?.LastLapTime ?? TimeSpan.Zero;
                     double lastLapSecPit = lastLapTsPit.TotalSeconds;
-                    double leaderLastLapSec = ReadLeaderLapTimeSeconds(pluginManager, data);
+                    leaderLastLapSec = ReadLeaderLapTimeSeconds(PluginManager, data);
 
                     // Basic validity check for the lap itself
                     bool lastLapLooksClean = !inPitArea && lastLapSecPit > 20 && lastLapSecPit < 900;


### PR DESCRIPTION
## Summary
- use the plugin manager property when reading leader lap times during fuel updates
- reuse the existing leader lap time variable instead of redeclaring it inside the pit handling block

## Testing
- not run (environment missing dotnet runtime)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4dca0734832f86ace81171bdae27)