### PR TITLE
Handle leader pace dropouts on fuel tab

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1770,6 +1770,7 @@ public class FuelCalcs : INotifyPropertyChanged
         else
         {
             AvgDeltaToLdrValue = "-";
+            LeaderDeltaSeconds = 0.0; // Clear stale leader delta when pace is unavailable
         }
         OnPropertyChanged(nameof(AvgDeltaToLdrValue));
 
@@ -1851,6 +1852,7 @@ public class FuelCalcs : INotifyPropertyChanged
         LiveLeaderPaceInfo = "-";
         LiveLapPaceInfo = "-";
         AvgDeltaToLdrValue = "-";
+        LeaderDeltaSeconds = 0.0;
         AvgDeltaToPbValue = "-";
         _liveMaxFuel = 0;
         _liveFuelTankLiters = 0;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -617,6 +617,14 @@ namespace LaunchPlugin
             {
                 leaderLastLapSec = ReadLeaderLapTimeSeconds(PluginManager, data);
 
+                if (leaderLastLapSec <= 0.0 && _recentLeaderLapTimes.Count > 0)
+                {
+                    // Feed dropped: clear leader pace so downstream calcs don't reuse stale values
+                    _recentLeaderLapTimes.Clear();
+                    _lastLeaderLapTimeSec = 0.0;
+                    LiveLeaderAvgPaceSeconds = 0.0;
+                }
+
                 // This logic checks if the PitEngine is waiting for an out-lap and, if so,
                 // provides it with the necessary data to finalize the calculation.
                 if (_pit != null && (_pit.CurrentPitPhase == PitPhase.None || _pit.CurrentPitPhase == PitPhase.ExitingPits)) // Ensure we are on track


### PR DESCRIPTION
## Summary
- Clear stored leader pace averages when leader lap timing data disappears to avoid stale strategy inputs
- Reset leader delta outputs when live pace is unavailable so the snapshot and planner stay in sync with available data

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcb47cd30832fa5e880f08a74f909)