### PR TITLE
Simplify live session snapshot panel

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -89,6 +89,7 @@ namespace LaunchPlugin
     private int _livePaceConfidence;
     private int _liveOverallConfidence;
     private bool _isLiveSessionActive;
+    private bool _isLiveSessionSnapshotExpanded;
     private string _liveCarName = "—";
     private string _liveTrackName = "—";
     private string _liveSurfaceModeDisplay = "Dry";
@@ -208,6 +209,13 @@ namespace LaunchPlugin
             IsEstimatedLapTimeManual = false;
             IsFuelPerLapManual = false;
 
+            // When the user switches to Live snapshot planning, automatically expand
+            // the Live Session Snapshot panel so the live data becomes visible.
+            if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
+            {
+                IsLiveSessionSnapshotExpanded = true;
+            }
+
             ApplyPlanningSourceToAutoFields();
         }
     }
@@ -251,6 +259,16 @@ namespace LaunchPlugin
                 OnPropertyChanged();
                 UpdateSurfaceModeLabel();
             }
+        }
+    }
+    public bool IsLiveSessionSnapshotExpanded
+    {
+        get => _isLiveSessionSnapshotExpanded;
+        set
+        {
+            if (_isLiveSessionSnapshotExpanded == value) return;
+            _isLiveSessionSnapshotExpanded = value;
+            OnPropertyChanged();
         }
     }
     public string LiveCarName

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -48,7 +48,7 @@
         <StackPanel Margin="10">
             <local:LaunchSummaryExpander Header="LIVE SESSION SNAPSHOT"
                                          Margin="0,0,0,15"
-                                         IsExpanded="True"
+                                         IsExpanded="{Binding IsLiveSessionSnapshotExpanded}"
                                          IsHighlighted="{Binding IsLiveSessionActive}">
                 <local:LaunchSummaryExpander.BodyContent>
                     <Grid>
@@ -85,9 +85,6 @@
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Surface" Style="{StaticResource SnapshotLabelStyle}"/>
                         <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding LiveSurfaceModeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
 
-                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Race Pace vs Leader" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding RacePaceVsLeaderSummary}" Style="{StaticResource SnapshotValueStyle}"/>
-
                         <TextBlock Grid.Row="5" Grid.Column="0" Text="Dry Lap Times" Style="{StaticResource SnapshotLabelStyle}"
                                    Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding DryLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
@@ -117,12 +114,6 @@
                                    Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding WetFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
                                    Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-
-                        <TextBlock Grid.Row="11" Grid.Column="0" Text="Last Pit Drive-Through" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="11" Grid.Column="1" Text="{Binding LastPitDriveThroughDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
-
-                        <TextBlock Grid.Row="12" Grid.Column="0" Text="Last Refuel Rate" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="12" Grid.Column="1" Text="{Binding LastRefuelRateDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
 
                         <TextBlock Grid.Row="13" Grid.Column="0" Text="Live Reliability" Style="{StaticResource SnapshotLabelStyle}"/>
                         <TextBlock Grid.Row="13" Grid.Column="1" Text="{Binding LiveConfidenceSummary}" Style="{StaticResource SnapshotValueStyle}" TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary
- add view model control for live snapshot expander and auto-expand when switching to live snapshot mode
- hide redundant live session snapshot rows and bind expansion state to the view model
- clean up pre-race planner UI by removing duplicate live car/track summary line

## Testing
- dotnet build LaunchPlugin.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692463ee756c832f8504fb41da3f3cc9)