### PR TITLE
Tidy Est Avg Lap Time helpers and lap source labels

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -74,7 +74,7 @@ namespace LaunchPlugin
         private bool _hasLiveLeaderDelta;
         private bool _isLeaderDeltaManual;
 
-    private string _lapTimeSourceInfo = "source: manual";
+    private string _lapTimeSourceInfo = "source: manual (user entry)";
     private bool _isLiveLapPaceAvailable;
 
     private bool _isEstimatedLapTimeManual;
@@ -777,7 +777,7 @@ namespace LaunchPlugin
                 if (!_isApplyingPlanningSourceUpdates)
                 {
                     IsEstimatedLapTimeManual = true;
-                    LapTimeSourceInfo = "source: manual";
+                    LapTimeSourceInfo = "source: manual (user entry)";
                 }
                 CalculateStrategy();
             }
@@ -1099,7 +1099,7 @@ namespace LaunchPlugin
                     if (lapTimeMs.HasValue && lapTimeMs > 0)
                     {
                         EstimatedLapTime = TimeSpan.FromMilliseconds(lapTimeMs.Value).ToString(@"m\:ss\.fff");
-                        LapTimeSourceInfo = $"source: {(IsWet ? "wet avg" : "dry avg")}";
+                        LapTimeSourceInfo = "source: profile avg (dry)";
                     }
                 }
                 UpdateTrackDerivedSummaries();
@@ -1285,7 +1285,7 @@ namespace LaunchPlugin
         if (lapMs.HasValue && lapMs.Value > 0)
         {
             EstimatedLapTime = TimeSpan.FromMilliseconds(lapMs.Value).ToString(@"m\:ss\.fff");
-            LapTimeSourceInfo = "source: profile";
+            LapTimeSourceInfo = "source: profile avg (dry)";
             OnPropertyChanged(nameof(EstimatedLapTime));
             OnPropertyChanged(nameof(LapTimeSourceInfo));
             CalculateStrategy();
@@ -1842,8 +1842,8 @@ namespace LaunchPlugin
                     EstimatedLapTime = lap.Value.ToString("m\\:ss\\.fff");
                     IsEstimatedLapTimeManual = false;
                     LapTimeSourceInfo = SelectedPlanningSourceMode == PlanningSourceMode.Profile
-                        ? "source: profile average"
-                        : "source: live average";
+                        ? "source: profile avg (dry)"
+                        : "source: live avg";
                 }
             }
 
@@ -1967,7 +1967,7 @@ namespace LaunchPlugin
             EstimatedLapTime = TimeSpan.FromSeconds(estSeconds).ToString(@"m\:ss\.fff");
 
             // This is explicitly “live average”, not manual
-            LapTimeSourceInfo = "source: live average";
+            LapTimeSourceInfo = "source: live avg";
             IsEstimatedLapTimeManual = false;
         }
         finally
@@ -2398,13 +2398,13 @@ namespace LaunchPlugin
         if (ts?.AvgLapTimeDry is int dryMs && dryMs > 0)
         {
             EstimatedLapTime = TimeSpan.FromMilliseconds(dryMs).ToString(@"m\:ss\.fff");
-            LapTimeSourceInfo = "source: dry avg";
+            LapTimeSourceInfo = "source: profile avg (dry)";
         }
         else
         {
             // If there's no data at all, use the UI default
             EstimatedLapTime = "2:45.500";
-            LapTimeSourceInfo = "source: manual";
+            LapTimeSourceInfo = "source: manual (user entry)";
         }
 
         // --- Load historical/track-specific data ---

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -257,8 +257,14 @@
                             <Button Grid.Row="0" Grid.Column="2" Content="↺" Command="{Binding ResetEstimatedLapTimeToSourceCommand}" Margin="4,0,0,0" ToolTip="Reset to planning source" Visibility="{Binding IsEstimatedLapTimeManual, Converter={StaticResource BoolToVisibilityConverter}}" />
                             <TextBlock Grid.Row="0" Grid.Column="3" Grid.ColumnSpan="2" Text="{Binding LapTimeSourceInfo}" Margin="8,0,0,0" VerticalAlignment="Center"/>
                             <StackPanel Grid.Row="1" Grid.Column="3" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,2,0,0">
-                                <TextBlock Text="{Binding LiveLapPaceInfo}" Foreground="Gray" FontStyle="Italic" Margin="0,0,12,0" VerticalAlignment="Center" ToolTip="Live rolling average lap time."/>
-                                <TextBlock Text="{Binding ProfileAvgDryLapTimeDisplay}" Foreground="Gray" FontStyle="Italic" VerticalAlignment="Center" ToolTip="Saved average dry lap time from profile."/>
+                                <TextBlock Foreground="Gray" FontStyle="Italic" Margin="0,0,12,0" VerticalAlignment="Center" ToolTip="Live rolling average lap time.">
+                                    <Run Text="Live avg: " />
+                                    <Run Text="{Binding LiveLapPaceInfo}" />
+                                </TextBlock>
+                                <TextBlock Foreground="Gray" FontStyle="Italic" VerticalAlignment="Center" ToolTip="Saved average dry lap time from profile.">
+                                    <Run Text="Profile avg: " />
+                                    <Run Text="{Binding ProfileAvgDryLapTimeDisplay}" />
+                                </TextBlock>
                             </StackPanel>
 
                         </Grid>
@@ -303,11 +309,6 @@
                 Margin="10,0,0,0"
                 MinWidth="35"
                 TextAlignment="Right"/>
-
-                                    <TextBlock Grid.Column="2"
-                 Text="{Binding LiveLeaderDeltaSeconds, StringFormat='Live delta: {0:0.000}s'}"
-                 VerticalAlignment="Center"
-                 Margin="8,0,0,0" />
 
                                     <Button Grid.Column="3"
                         Content="Reset to live"


### PR DESCRIPTION
## Summary
- label live and profile average lap time helpers for clarity
- standardize lap time source text across manual, live, and profile values
- remove redundant live delta label from leader slider

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246a83b724832f94f78607f850bb65)