### PR TITLE
Add live weather surface summary

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -88,6 +88,12 @@ namespace LaunchPlugin
     private int _liveFuelConfidence;
     private int _livePaceConfidence;
     private int _liveOverallConfidence;
+    private bool? _liveWeatherIsWet;
+    private double? _liveAirTempC;
+    private double? _liveTrackTempC;
+    private double? _liveHumidityPct;
+    private string _liveRubberState;
+    private string _livePrecipitation;
     private bool _isLiveSessionActive;
     private bool _isLiveSessionSnapshotExpanded;
     private string _liveCarName = "—";
@@ -968,6 +974,51 @@ namespace LaunchPlugin
         }
         OnPropertyChanged(nameof(MaxFuelPerLapDisplay));
         OnPropertyChanged(nameof(IsMaxFuelAvailable));
+    }
+
+    public void SetLiveWeatherConditions(bool isDeclaredWet, double airTempC, double trackTempC, double humidityPercent, string rubberState, string precipitation)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.CheckAccess())
+        {
+            ApplyLiveWeatherConditions(isDeclaredWet, airTempC, trackTempC, humidityPercent, rubberState, precipitation);
+        }
+        else
+        {
+            disp.Invoke(() => ApplyLiveWeatherConditions(isDeclaredWet, airTempC, trackTempC, humidityPercent, rubberState, precipitation));
+        }
+    }
+
+    private void ApplyLiveWeatherConditions(bool isDeclaredWet, double airTempC, double trackTempC, double humidityPercent, string rubberState, string precipitation)
+    {
+        _liveWeatherIsWet = isDeclaredWet;
+        _liveAirTempC = NormalizeTemperature(airTempC);
+        _liveTrackTempC = NormalizeTemperature(trackTempC);
+        _liveHumidityPct = NormalizeHumidity(humidityPercent);
+        _liveRubberState = string.IsNullOrWhiteSpace(rubberState) ? null : rubberState.Trim();
+        _livePrecipitation = string.IsNullOrWhiteSpace(precipitation) ? null : precipitation.Trim();
+
+        UpdateSurfaceModeLabel();
+    }
+
+    private static double? NormalizeTemperature(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < -200)
+        {
+            return null;
+        }
+
+        return value;
+    }
+
+    private static double? NormalizeHumidity(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0)
+        {
+            return null;
+        }
+
+        return value;
     }
 
     public void SetConditionRefuelParameters(double baseSeconds, double secondsPerLiter, double secondsPerSquare)
@@ -2126,8 +2177,46 @@ namespace LaunchPlugin
 
     private void UpdateSurfaceModeLabel()
     {
-        string mode = IsWet ? "Wet" : "Dry";
-        LiveSurfaceModeDisplay = IsLiveSessionActive ? $"{mode} • Live" : mode;
+        if (!IsLiveSessionActive)
+        {
+            LiveSurfaceModeDisplay = "-";
+            return;
+        }
+
+        var parts = new List<string>();
+
+        bool isWet = _liveWeatherIsWet ?? IsWet;
+        parts.Add(isWet ? "Wet" : "Dry");
+
+        if (_liveAirTempC.HasValue && _liveTrackTempC.HasValue)
+        {
+            parts.Add($"{_liveAirTempC.Value:F0}/{_liveTrackTempC.Value:F0}°C");
+        }
+        else if (_liveAirTempC.HasValue)
+        {
+            parts.Add($"{_liveAirTempC.Value:F0}°C air");
+        }
+        else if (_liveTrackTempC.HasValue)
+        {
+            parts.Add($"{_liveTrackTempC.Value:F0}°C track");
+        }
+
+        if (_liveHumidityPct.HasValue)
+        {
+            parts.Add($"{_liveHumidityPct.Value:F0}% RH");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_liveRubberState))
+        {
+            parts.Add($"Rubber {_liveRubberState}");
+        }
+
+        if (isWet && !string.IsNullOrWhiteSpace(_livePrecipitation))
+        {
+            parts.Add($"Rain {_livePrecipitation}");
+        }
+
+        LiveSurfaceModeDisplay = parts.Count > 0 ? string.Join(" | ", parts) : "-";
     }
 
     private void ResetSnapshotDisplays()
@@ -2156,6 +2245,12 @@ namespace LaunchPlugin
         LastPitDriveThroughDisplay = "-";
         LastRefuelRateDisplay = "-";
         LastTyreChangeDisplay = "-";
+        _liveWeatherIsWet = null;
+        _liveAirTempC = null;
+        _liveTrackTempC = null;
+        _liveHumidityPct = null;
+        _liveRubberState = null;
+        _livePrecipitation = null;
         LiveSurfaceModeDisplay = "-";
         ConditionRefuelBaseSeconds = 0;
         ConditionRefuelSecondsPerLiter = 0;


### PR DESCRIPTION
## Summary
- add dispatcher-safe live weather input API to FuelCalcs
- build a richer surface mode label with weather, temps, humidity, rubber, and rain details
- clear live weather caches when resetting live snapshots

## Testing
- Not run (dotnet SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e56468cc832fb79f29ac69b0554b)