### PR TITLE
Update live telemetry header and snapshot grid

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1430,6 +1430,20 @@ namespace LaunchPlugin
         private set { if (_seenTrackName != value) { _seenTrackName = value; OnPropertyChanged(nameof(SeenTrackName)); } }
     }
 
+    private string _liveSessionHeader = "LIVE SESSION TELEMETRY (no live data)";
+    public string LiveSessionHeader
+    {
+        get => _liveSessionHeader;
+        private set
+        {
+            if (_liveSessionHeader != value)
+            {
+                _liveSessionHeader = value;
+                OnPropertyChanged(nameof(LiveSessionHeader));
+            }
+        }
+    }
+
     private string _seenSessionSummary = "No Live Data";
     public string SeenSessionSummary
     {
@@ -2163,6 +2177,7 @@ namespace LaunchPlugin
         SeenCarName = LiveCarName;
         SeenTrackName = LiveTrackName;
         SeenSessionSummary = "No Live Data";
+        LiveSessionHeader = "LIVE SESSION TELEMETRY (no live data)";
         OnPropertyChanged(nameof(HasLiveMaxFuelSuggestion));
         OnPropertyChanged(nameof(IsMaxFuelOverrideTooHigh));
     }
@@ -2322,6 +2337,9 @@ namespace LaunchPlugin
         SeenSessionSummary = (hasCar || hasTrack)
             ? $"Live: {FormatLabel(displayCarName, "-")} @ {FormatLabel(displayTrackName, "-")}"
             : "No Live Data";
+        LiveSessionHeader = (IsLiveSessionActive && (hasCar || hasTrack))
+            ? $"LIVE SESSION TELEMETRY FOR {FormatLabel(displayCarName, "-")} @ {FormatLabel(displayTrackName, "-")}"
+            : "LIVE SESSION TELEMETRY (no live data)";
 
         UpdateTrackDerivedSummaries();
 

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -46,7 +46,7 @@
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <StackPanel Margin="10">
-            <local:LaunchSummaryExpander Header="LIVE SESSION SNAPSHOT"
+            <local:LaunchSummaryExpander Header="{Binding LiveSessionHeader}"
                                          Margin="0,0,0,15"
                                          IsExpanded="{Binding IsLiveSessionSnapshotExpanded}"
                                          IsHighlighted="{Binding IsLiveSessionActive}">
@@ -66,57 +66,46 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Car" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding LiveCarName}" Style="{StaticResource SnapshotValueStyle}"/>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Fuel Tank Size (max factored)" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding LiveFuelTankSizeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Track" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding LiveTrackName}" Style="{StaticResource SnapshotValueStyle}"/>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Surface" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding LiveSurfaceModeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Fuel Tank Size (max factored)" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding LiveFuelTankSizeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
-
-                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Surface" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding LiveSurfaceModeDisplay}" Style="{StaticResource SnapshotValueStyle}"/>
-
-                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Dry Lap Times" Style="{StaticResource SnapshotLabelStyle}"
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Dry Lap Times" Style="{StaticResource SnapshotLabelStyle}"
                                    Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding DryLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
+                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding DryLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
                                    Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Wet Lap Times" Style="{StaticResource SnapshotLabelStyle}"
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Wet Lap Times" Style="{StaticResource SnapshotLabelStyle}"
                                    Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding WetLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
-                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-
-                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Dry Pace Delta" Style="{StaticResource SnapshotLabelStyle}"
-                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding DryPaceDeltaSummary}" Style="{StaticResource SnapshotValueStyle}"
-                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-
-                        <TextBlock Grid.Row="8" Grid.Column="0" Text="Wet Pace Delta" Style="{StaticResource SnapshotLabelStyle}"
-                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding WetPaceDeltaSummary}" Style="{StaticResource SnapshotValueStyle}"
+                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding WetLapTimeSummary}" Style="{StaticResource SnapshotValueStyle}"
                                    Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-                        <TextBlock Grid.Row="9" Grid.Column="0" Text="Dry Fuel Burn" Style="{StaticResource SnapshotLabelStyle}"
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Dry Pace Delta" Style="{StaticResource SnapshotLabelStyle}"
                                    Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Grid.Row="9" Grid.Column="1" Text="{Binding DryFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
+                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding DryPaceDeltaSummary}" Style="{StaticResource SnapshotValueStyle}"
                                    Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-                        <TextBlock Grid.Row="10" Grid.Column="0" Text="Wet Fuel Burn" Style="{StaticResource SnapshotLabelStyle}"
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Wet Pace Delta" Style="{StaticResource SnapshotLabelStyle}"
                                    Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding WetFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
+                        <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding WetPaceDeltaSummary}" Style="{StaticResource SnapshotValueStyle}"
                                    Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-                        <TextBlock Grid.Row="13" Grid.Column="0" Text="Live Reliability" Style="{StaticResource SnapshotLabelStyle}"/>
-                        <TextBlock Grid.Row="13" Grid.Column="1" Text="{Binding LiveConfidenceSummary}" Style="{StaticResource SnapshotValueStyle}" TextWrapping="Wrap"/>
+                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Dry Fuel Burn" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding DryFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowDrySnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Wet Fuel Burn" Style="{StaticResource SnapshotLabelStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding WetFuelBurnSummary}" Style="{StaticResource SnapshotValueStyle}"
+                                   Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                        <TextBlock Grid.Row="8" Grid.Column="0" Text="Live Reliability" Style="{StaticResource SnapshotLabelStyle}"/>
+                        <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding LiveConfidenceSummary}" Style="{StaticResource SnapshotValueStyle}" TextWrapping="Wrap"/>
                     </Grid>
                 </local:LaunchSummaryExpander.BodyContent>
             </local:LaunchSummaryExpander>


### PR DESCRIPTION
## Summary
- add LiveSessionHeader binding to surface car/track in the snapshot header
- reset header when live data is cleared and format it with live car/track names when available
- remove duplicate car/track rows from the snapshot grid and collapse row spacing

## Testing
- dotnet build LaunchPlugin.sln (fails: dotnet not installed in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e8cbb804832fa0ce30e9c901f3d6)