### PR TITLE
Add wet telemetry rows to live session expander

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -123,6 +123,9 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Row="0" Grid.Column="0"
@@ -162,6 +165,30 @@
                                        Text="{Binding LiveConfidenceSummary}"
                                        Style="{StaticResource SnapshotValueStyle}"
                                        TextWrapping="Wrap" />
+                                    <TextBlock Grid.Row="6" Grid.Column="0"
+                                       Text="Wet Lap Times"
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="6" Grid.Column="1"
+                                       Text="{Binding WetLapTimeSummary}"
+                                       Style="{StaticResource SnapshotValueStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="7" Grid.Column="0"
+                                       Text="Wet Pace Delta"
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="7" Grid.Column="1"
+                                       Text="{Binding WetPaceDeltaSummary}"
+                                       Style="{StaticResource SnapshotValueStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="0"
+                                       Text="Wet Fuel Burn"
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="1"
+                                       Text="{Binding WetFuelBurnSummary}"
+                                       Style="{StaticResource SnapshotValueStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </Grid>
                             </styles:SHExpander>
 


### PR DESCRIPTION
## Summary
- extend live session telemetry grid to include wet lap time, pace delta, and fuel burn rows
- conditionally show wet data using existing visibility helper while keeping styling consistent with dry rows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692651fd06e0832fa67abd95c082a789)