### PR TITLE
Add wet telemetry rows to live session expander

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -991,8 +991,18 @@ namespace LaunchPlugin
 
     private void ApplyLiveSurfaceSummary(bool? isDeclaredWet, string summary)
     {
+        bool wasWetVisible = ShowWetSnapshotRows;
+
         _liveWeatherIsWet = isDeclaredWet;
         _liveSurfaceSummary = string.IsNullOrWhiteSpace(summary) ? null : summary.Trim();
+
+        bool isWetVisible = ShowWetSnapshotRows;
+        if (isWetVisible != wasWetVisible)
+        {
+            OnPropertyChanged(nameof(ShowWetSnapshotRows));
+            UpdateLapTimeSummaries();
+            UpdatePaceSummaries();
+        }
 
         UpdateSurfaceModeLabel();
     }
@@ -1157,7 +1167,7 @@ namespace LaunchPlugin
         set { if (value) SelectedTrackCondition = TrackCondition.Wet; }
     }
     public bool ShowDrySnapshotRows => IsDry;
-    public bool ShowWetSnapshotRows => IsWet;
+    public bool ShowWetSnapshotRows => (_liveWeatherIsWet == true) || IsWet;
 
     public double MaxFuelOverride
     {
@@ -2209,9 +2219,16 @@ namespace LaunchPlugin
         LastPitDriveThroughDisplay = "-";
         LastRefuelRateDisplay = "-";
         LastTyreChangeDisplay = "-";
+        bool wasWetVisible = ShowWetSnapshotRows;
         _liveWeatherIsWet = null;
         _liveSurfaceSummary = null;
         LiveSurfaceModeDisplay = "-";
+        if (ShowWetSnapshotRows != wasWetVisible)
+        {
+            OnPropertyChanged(nameof(ShowWetSnapshotRows));
+            UpdateLapTimeSummaries();
+            UpdatePaceSummaries();
+        }
         ConditionRefuelBaseSeconds = 0;
         ConditionRefuelSecondsPerLiter = 0;
         ConditionRefuelSecondsPerSquare = 0;

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -123,6 +123,9 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Row="0" Grid.Column="0"
@@ -162,6 +165,30 @@
                                        Text="{Binding LiveConfidenceSummary}"
                                        Style="{StaticResource SnapshotValueStyle}"
                                        TextWrapping="Wrap" />
+                                    <TextBlock Grid.Row="6" Grid.Column="0"
+                                       Text="Wet Lap Times"
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="6" Grid.Column="1"
+                                       Text="{Binding WetLapTimeSummary}"
+                                       Style="{StaticResource SnapshotValueStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="7" Grid.Column="0"
+                                       Text="Wet Pace Delta"
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="7" Grid.Column="1"
+                                       Text="{Binding WetPaceDeltaSummary}"
+                                       Style="{StaticResource SnapshotValueStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="0"
+                                       Text="Wet Fuel Burn"
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="1"
+                                       Text="{Binding WetFuelBurnSummary}"
+                                       Style="{StaticResource SnapshotValueStyle}"
+                                       Visibility="{Binding ShowWetSnapshotRows, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </Grid>
                             </styles:SHExpander>
 


### PR DESCRIPTION
## Summary
- extend live session telemetry grid to include wet lap time, pace delta, and fuel burn rows
- show wet telemetry rows when the live session reports a wet track condition and refresh summaries when that visibility toggles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692651fd06e0832fa67abd95c082a789)