### PR TITLE
Reset live max fuel display on session reset

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1998,6 +1998,13 @@ namespace LaunchPlugin
             FuelCalculator.SetLiveSession(carName, trackLabel);
             _lastSnapshotCar = carName;
             _lastSnapshotTrack = trackLabel;
+
+            // Reset max fuel announcement throttle so the live display refreshes immediately for the new snapshot
+            _lastAnnouncedMaxFuel = -1;
+            if (LiveCarMaxFuel > 0)
+            {
+                FuelCalculator.UpdateLiveDisplay(LiveCarMaxFuel);
+            }
         }
 
         public void DataUpdate(PluginManager pluginManager, ref GameData data)
@@ -2072,6 +2079,7 @@ namespace LaunchPlugin
                 _lastSeenTrack = string.Empty;
                 _lastSnapshotCar = string.Empty;
                 _lastSnapshotTrack = string.Empty;
+                _lastAnnouncedMaxFuel = -1;
                 _lastSessionId = currentSessionId;
                 FuelCalculator.ForceProfileDataReload();
 


### PR DESCRIPTION
## Summary
- reset the max fuel announcement throttle whenever a live snapshot or session changes
- trigger an immediate live display refresh with the current detected max fuel when pushing a new snapshot

## Testing
- dotnet build LaunchPlugin.sln (fails: dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273c92486c832fbee1561d0124f3ec)