### PR TITLE
Refine source info labels and update logging levels

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -74,7 +74,7 @@ namespace LaunchPlugin
         private bool _hasLiveLeaderDelta;
         private bool _isLeaderDeltaManual;
 
-    private string _lapTimeSourceInfo = "source: manual (user entry)";
+    private string _lapTimeSourceInfo = "Manual (user entry)";
     private bool _isLiveLapPaceAvailable;
 
     private bool _isEstimatedLapTimeManual;
@@ -157,7 +157,7 @@ namespace LaunchPlugin
         get => _isEstimatedLapTimeManual;
         set { if (_isEstimatedLapTimeManual != value) { _isEstimatedLapTimeManual = value; OnPropertyChanged(); } }
     }
-    private string _fuelPerLapSourceInfo = "source: manual";
+    private string _fuelPerLapSourceInfo = "Manual";
     public string FuelPerLapSourceInfo
     {
         get => _fuelPerLapSourceInfo;
@@ -173,16 +173,16 @@ namespace LaunchPlugin
     }
 
     public bool IsProfileFuelChoiceActive => SelectedPlanningSourceMode == PlanningSourceMode.Profile
-        && FuelPerLapSourceInfo?.Contains("profile") == true;
+        && FuelPerLapSourceInfo?.Contains("Profile") == true;
 
     public bool IsLiveAverageFuelChoiceActive => SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
-        && FuelPerLapSourceInfo?.Contains("live average") == true;
+        && FuelPerLapSourceInfo?.Contains("Live avg") == true;
 
     public bool IsLiveSaveFuelChoiceActive => SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
-        && FuelPerLapSourceInfo?.Contains("live save") == true;
+        && FuelPerLapSourceInfo?.Contains("Live save") == true;
 
     public bool IsLiveMaxFuelChoiceActive => SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
-        && FuelPerLapSourceInfo?.Contains("max") == true;
+        && FuelPerLapSourceInfo?.Contains("Max") == true;
 
     private void RaiseFuelChoiceIndicators()
     {
@@ -303,7 +303,7 @@ namespace LaunchPlugin
         public int LiveFuelConfidence { get; private set; }
     public int LivePaceConfidence { get; private set; }
     public int LiveOverallConfidence { get; private set; }
-    public string LiveConfidenceSummary { get; private set; } = "Live reliability: n/a";
+    public string LiveConfidenceSummary { get; private set; } = "n/a";
     public bool IsLiveSessionActive
     {
         get => _isLiveSessionActive;
@@ -655,7 +655,7 @@ namespace LaunchPlugin
             if (!_isApplyingPlanningSourceUpdates)
             {
                 IsFuelPerLapManual = true;
-                FuelPerLapSourceInfo = "source: manual";
+                FuelPerLapSourceInfo = "Manual";
             }
 
             // Accept partial inputs like "2.", ".8", "2," while typing.
@@ -837,7 +837,7 @@ namespace LaunchPlugin
                 if (!_isApplyingPlanningSourceUpdates)
                 {
                     IsEstimatedLapTimeManual = true;
-                    LapTimeSourceInfo = "source: manual (user entry)";
+                    LapTimeSourceInfo = "Manual (user entry)";
                 }
                 CalculateStrategy();
             }
@@ -922,7 +922,7 @@ namespace LaunchPlugin
                 if (!_isApplyingPlanningSourceUpdates)
                 {
                     IsFuelPerLapManual = true;
-                    FuelPerLapSourceInfo = "source: manual";
+                    FuelPerLapSourceInfo = "Manual";
                 }
 
                 if (IsDry) { _baseDryFuelPerLap = _fuelPerLap; }
@@ -981,7 +981,7 @@ namespace LaunchPlugin
         if (min.HasValue)
         {
             FuelPerLap = min.Value;
-            FuelPerLapSourceInfo = "source: live save";
+            FuelPerLapSourceInfo = "Live save";
         }
     }
 
@@ -991,14 +991,14 @@ namespace LaunchPlugin
         if (liveMax.HasValue)
         {
             FuelPerLap = liveMax.Value;
-            FuelPerLapSourceInfo = "source: live max";
+            FuelPerLapSourceInfo = "Live max";
             return;
         }
 
         if (_plugin.MaxFuelPerLapDisplay > 0)
         {
             FuelPerLap = _plugin.MaxFuelPerLapDisplay;
-            FuelPerLapSourceInfo = "source: max";
+            FuelPerLapSourceInfo = "Max";
         }
     }
 
@@ -1251,7 +1251,7 @@ namespace LaunchPlugin
                     if (lapTimeMs.HasValue && lapTimeMs > 0)
                     {
                         EstimatedLapTime = TimeSpan.FromMilliseconds(lapTimeMs.Value).ToString(@"m\:ss\.fff");
-                        LapTimeSourceInfo = "source: profile avg (dry)";
+                        LapTimeSourceInfo = "Profile avg (dry)";
                     }
                 }
                 UpdateTrackDerivedSummaries();
@@ -1438,7 +1438,7 @@ namespace LaunchPlugin
         if (lapMs.HasValue && lapMs.Value > 0)
         {
             EstimatedLapTime = TimeSpan.FromMilliseconds(lapMs.Value).ToString(@"m\:ss\.fff");
-            LapTimeSourceInfo = "source: profile avg (dry)";
+            LapTimeSourceInfo = "Profile avg (dry)";
             OnPropertyChanged(nameof(EstimatedLapTime));
             OnPropertyChanged(nameof(LapTimeSourceInfo));
             CalculateStrategy();
@@ -1530,7 +1530,7 @@ namespace LaunchPlugin
         if (ts.AvgFuelPerLapDry.HasValue && ts.AvgFuelPerLapDry > 0)
         {
             FuelPerLap = ts.AvgFuelPerLapDry.Value;
-            FuelPerLapSourceInfo = "source: profile";
+            FuelPerLapSourceInfo = "Profile";
         }
     }
     public double TotalFuelNeeded { get => _totalFuelNeeded; private set { _totalFuelNeeded = value; OnPropertyChanged("TotalFuelNeeded"); } }
@@ -1608,7 +1608,7 @@ namespace LaunchPlugin
         if (LiveFuelPerLap > 0)
         {
             FuelPerLap = LiveFuelPerLap;
-            FuelPerLapSourceInfo = "source: live average";
+            FuelPerLapSourceInfo = "Live avg";
         }
     }
 
@@ -1623,7 +1623,7 @@ namespace LaunchPlugin
         // Smartly default Max Fuel: use the live detected value if available, otherwise use 120L
         this.MaxFuelOverride = _liveMaxFuel > 0 ? Math.Round(_liveMaxFuel) : 120.0;
 
-        SimHub.Logging.Current.Debug("FuelCalcs: Race strategy inputs have been reset to defaults.");
+        SimHub.Logging.Current.Info("FuelCalcs: Race strategy inputs have been reset to defaults.");
     }
 
     private void SavePlannerDataToProfile()
@@ -2012,8 +2012,8 @@ namespace LaunchPlugin
                     EstimatedLapTime = lap.Value.ToString("m\\:ss\\.fff");
                     IsEstimatedLapTimeManual = false;
                     LapTimeSourceInfo = SelectedPlanningSourceMode == PlanningSourceMode.Profile
-                        ? "source: profile avg (dry)"
-                        : "source: live avg";
+                        ? "Profile avg (dry)"
+                        : "Live avg";
                 }
             }
 
@@ -2033,11 +2033,11 @@ namespace LaunchPlugin
                 if (fuel.HasValue)
                 {
                     FuelPerLap = fuel.Value;
-                    FuelPerLapText = fuel.Value.ToString("0.000", CultureInfo.InvariantCulture);
+                    FuelPerLapText = fuel.Value.ToString("0.00", CultureInfo.InvariantCulture);
                     IsFuelPerLapManual = false;
                     FuelPerLapSourceInfo = SelectedPlanningSourceMode == PlanningSourceMode.Profile
-                        ? "source: profile average"
-                        : "source: live average";
+                        ? "Profile"
+                        : "Live";
                 }
             }
         }
@@ -2137,7 +2137,7 @@ namespace LaunchPlugin
             EstimatedLapTime = TimeSpan.FromSeconds(estSeconds).ToString(@"m\:ss\.fff");
 
             // This is explicitly “live average”, not manual
-            LapTimeSourceInfo = "source: live avg";
+            LapTimeSourceInfo = "Live avg";
             IsEstimatedLapTimeManual = false;
         }
         finally
@@ -2281,10 +2281,10 @@ namespace LaunchPlugin
     {
         if (LiveFuelConfidence <= 0 && LivePaceConfidence <= 0 && LiveOverallConfidence <= 0)
         {
-            return "Live reliability: n/a";
+            return "n/a";
         }
 
-        return $"Live reliability: Fuel {LiveFuelConfidence}% | Pace {LivePaceConfidence}% | Overall {LiveOverallConfidence}%";
+        return $"Fuel {LiveFuelConfidence}% | Pace {LivePaceConfidence}% | Overall {LiveOverallConfidence}%";
     }
 
     private void UpdateSurfaceModeLabel()
@@ -2615,13 +2615,13 @@ namespace LaunchPlugin
         if (ts?.AvgLapTimeDry is int dryMs && dryMs > 0)
         {
             EstimatedLapTime = TimeSpan.FromMilliseconds(dryMs).ToString(@"m\:ss\.fff");
-            LapTimeSourceInfo = "source: profile avg (dry)";
+            LapTimeSourceInfo = "Profile avg (dry)";
         }
         else
         {
             // If there's no data at all, use the UI default
             EstimatedLapTime = "2:45.500";
-            LapTimeSourceInfo = "source: manual (user entry)";
+            LapTimeSourceInfo = "Manual (user entry)";
         }
 
         // --- Load historical/track-specific data ---
@@ -2629,7 +2629,7 @@ namespace LaunchPlugin
         {
             _baseDryFuelPerLap = avg;
             FuelPerLap = IsDry ? avg : avg * (WetFactorPercent / 100.0);
-            FuelPerLapSourceInfo = "source: profile";
+            FuelPerLapSourceInfo = "Profile";
         }
         else
         {
@@ -2638,7 +2638,7 @@ namespace LaunchPlugin
             var defaultProfile = _plugin.ProfilesViewModel.GetProfileForCar("Default Settings");
             var defaultFuel = defaultProfile?.TrackStats?["default"]?.AvgFuelPerLapDry ?? 2.8;
             FuelPerLap = defaultFuel;
-            FuelPerLapSourceInfo = "source: default";
+            FuelPerLapSourceInfo = "Default";
         }
 
         if (ts?.PitLaneLossSeconds is double pll && pll > 0)
@@ -2809,7 +2809,7 @@ namespace LaunchPlugin
                                  Math.Abs(LeaderDeltaSeconds - _lastLoggedLeaderDeltaSeconds) > 0.01;
                 if (shouldLog)
                 {
-                    SimHub.Logging.Current.Debug(string.Format(
+                    SimHub.Logging.Current.Info(string.Format(
                         "[FuelLeader] CalculateStrategy: estLap={0:F3}, leaderDelta={1:F3}, leaderLap={2:F3}",
                         num3,
                         LeaderDeltaSeconds,
@@ -2829,7 +2829,7 @@ namespace LaunchPlugin
                                  Math.Abs(LeaderDeltaSeconds - _lastLoggedLeaderDeltaSeconds) > 0.01;
                 if (shouldLog)
                 {
-                    SimHub.Logging.Current.Debug(string.Format(
+                    SimHub.Logging.Current.Info(string.Format(
                         "[FuelLeader] CalculateStrategy: estLap={0:F3}, leaderDelta={1:F3}, leaderLap={2:F3}",
                         num3,
                         LeaderDeltaSeconds,

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -130,11 +130,11 @@
                             <styles:SHExpander Grid.Row="1"
                                Header="{Binding LiveSessionHeader}"
                                IsExpanded="{Binding IsLiveSessionSnapshotExpanded}"
-                               Margin="0,10,0,10">
+                               Margin="0,0,0,10">
 
-                                <Grid Margin="10">
+                                <Grid Margin="5">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="190" />
+                                        <ColumnDefinition Width="125" />
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <Grid.RowDefinitions>
@@ -150,7 +150,7 @@
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Row="0" Grid.Column="0"
-                                       Text="Max Fuel Rule"
+                                       Text="Max Tank Limit"
                                        Style="{StaticResource SnapshotLabelStyle}" />
                                     <TextBlock Grid.Row="0" Grid.Column="1"
                                        Text="{Binding LiveFuelTankSizeDisplay}"
@@ -180,7 +180,7 @@
                                        Text="{Binding DryFuelBurnSummary}"
                                        Style="{StaticResource SnapshotValueStyle}" />
                                     <TextBlock Grid.Row="5" Grid.Column="0"
-                                       Text="Live Data Reliability"
+                                       Text="Data Confidence"
                                        Style="{StaticResource SnapshotLabelStyle}" />
                                     <TextBlock Grid.Row="5" Grid.Column="1"
                                        Text="{Binding LiveConfidenceSummary}"
@@ -262,6 +262,7 @@
                             <ui:TitledSlider Title="Wet Factor (%):" Minimum="70" Maximum="130" Value="{Binding WetFactorPercent, Mode=TwoWay}" Visibility="{Binding IsWet, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" Margin="0,5,0,0"/>
                             </StackPanel>
 
+                            <!-- Avg Lap Time -->
                             <Grid Grid.Row="4" Margin="0,15,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="100"/>
@@ -312,7 +313,7 @@
 
                                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,5,0,5">
                                     <TextBlock Text="Your Pace vs Leader (s):" ToolTip="How many seconds slower your average lap time is compared to the race leader."/>
-                                    <TextBlock Text=" Avg Delta to Ldr: " Foreground="Gray" FontStyle="Italic" Margin="10,1,0,5"/>
+                                    <TextBlock Text=" Live Avg Delta to Ldr: " Foreground="Gray" FontStyle="Italic" Margin="10,1,0,5"/>
                                     <TextBlock Text="{Binding AvgDeltaToLdrValue}" Foreground="Gray" FontStyle="Italic"/>
                                 </StackPanel>
 
@@ -413,7 +414,7 @@
                                                 <Setter Property="Text" Value="profile"/>
                                             </DataTrigger>
                                             <DataTrigger Binding="{Binding IsPlanningSourceLiveSnapshot}" Value="True">
-                                                <Setter Property="Text" Value="live"/>
+                                                <Setter Property="Text" Value="Live"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -197,7 +197,7 @@ namespace LaunchPlugin
             {
                 // If we have no pace confidence yet, fall back to fuel-only
                 if (PaceConfidence <= 0) return Confidence;
-                return (Confidence < PaceConfidence) ? Confidence : PaceConfidence;
+                return (Confidence * PaceConfidence);
             }
         }
 
@@ -654,7 +654,7 @@ namespace LaunchPlugin
                         if (trackRecord?.AvgLapTimeDry > 0)
                         {
                             stableAvgPace = trackRecord.AvgLapTimeDry.Value / 1000.0;
-                            SimHub.Logging.Current.Debug($"Pace Delta: No live pace available. Using profile avg lap time as fallback: {stableAvgPace:F2}s");
+                            SimHub.Logging.Current.Info($"Pace Delta: No live pace available. Using profile avg lap time as fallback: {stableAvgPace:F2}s");
                         }
                     }
                     // --- PB tertiary fallback (for replays / no live median and no profile avg) ---
@@ -662,7 +662,7 @@ namespace LaunchPlugin
                     {
                         stableAvgPace = _lastSeenBestLap.TotalSeconds;
                     }
-                    SimHub.Logging.Current.Debug($"[Pit/Pace] Baseline used = {stableAvgPace:F3}s (live median → profile avg → PB).");
+                    SimHub.Logging.Current.Info($"[Pit/Pace] Baseline used = {stableAvgPace:F3}s (live median → profile avg → PB).");
 
                     // Decide and publish baseline (profile-avg → live-median → session-pb)
                     string paceSource = "live-median"; // default to whatever stableAvgPace currently holds
@@ -791,7 +791,7 @@ namespace LaunchPlugin
                     if (currentLeaderCount != _lastLoggedLeaderLapCount ||
                         Math.Abs(currentAvgLeader - _lastLoggedLeaderAvgPaceSeconds) > 0.01)
                     {
-                        SimHub.Logging.Current.Debug(string.Format(
+                        SimHub.Logging.Current.Info(string.Format(
                             "[FuelLeader] lapCrossed: leaderLastLapSec={0:F3}, count={1}, avgLeader={2:F3}",
                             leaderLastLapSec,
                             currentLeaderCount,
@@ -3196,7 +3196,7 @@ namespace LaunchPlugin
             }
             else if (!_plugin.Settings.EnableTelemetryTracing)
             {
-                SimHub.Logging.Current.Debug("TelemetryTraceLogger: Skipping trace logging — disabled in plugin settings.");
+                //SimHub.Logging.Current.Debug("TelemetryTraceLogger: Skipping trace logging — disabled in plugin settings.");
             }
         }
 


### PR DESCRIPTION
Standardized source info strings (e.g., 'Manual', 'Profile', 'Live avg') throughout FuelCalcs.cs for consistency and improved UI clarity. Updated several SimHub logging calls from Debug to Info level in both FuelCalcs.cs and LalaLaunch.cs. Adjusted FuelCalculatorView.xaml UI labels for clarity, including renaming 'Max Fuel Rule' to 'Max Tank Limit' and 'Live Data Reliability' to 'Data Confidence'. Fixed a logic bug in LalaLaunch.cs by changing confidence calculation to use multiplication instead of min comparison.