### PR TITLE
Refine lap detection and pit exit confirmation

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -115,6 +115,15 @@ namespace LaunchPlugin
         private double _lastFuelLevel = -1;
         private double _lapStartFuel = -1;
         private double _lastLapDistPct = -1;
+        private int _lapDetectorLastCompleted = -1;
+        private string _lapDetectorLastSessionState = string.Empty;
+        private bool _lapDetectorPending;
+        private int _lapDetectorPendingLapTarget = -1;
+        private string _lapDetectorPendingSessionState = string.Empty;
+        private DateTime _lapDetectorPendingExpiresUtc = DateTime.MinValue;
+        private double _lapDetectorPendingLastPct = -1.0;
+        private DateTime _lapDetectorLastLogUtc = DateTime.MinValue;
+        private string _lapDetectorLastLogKey = string.Empty;
 
         // New per-mode rolling windows
         private readonly List<double> _recentDryFuelLaps = new List<double>();
@@ -180,10 +189,12 @@ namespace LaunchPlugin
         private double _lastLoggedLeaderAvgPaceSeconds = 0.0;
         private int _lastLoggedLeaderLapCount = 0;
         private bool _leaderSourceUnavailableLogged = false;
+        private bool _leaderPaceClearedLogged = false;
         public double LiveLeaderAvgPaceSeconds { get; private set; }
         private double _lastPitLossSaved = 0.0;
         private DateTime _lastPitLossSavedAtUtc = DateTime.MinValue;
         private string _lastPitLossSource = "";
+        private DateTime _lastPitLaneSeenUtc = DateTime.MinValue;
 
         // --- Stint / Pace tracking ---
         public double Pace_StintAvgLapTimeSec { get; private set; }
@@ -469,11 +480,21 @@ namespace LaunchPlugin
             _lastFuelLevel = -1.0;
             _lapStartFuel = -1.0;
             _lastLapDistPct = -1.0;
+            _lapDetectorLastCompleted = -1;
+            _lapDetectorLastSessionState = string.Empty;
+            _lapDetectorPending = false;
+            _lapDetectorPendingLapTarget = -1;
+            _lapDetectorPendingSessionState = string.Empty;
+            _lapDetectorPendingExpiresUtc = DateTime.MinValue;
+            _lapDetectorPendingLastPct = -1.0;
+            _lapDetectorLastLogUtc = DateTime.MinValue;
+            _lapDetectorLastLogKey = string.Empty;
             _lastCompletedFuelLap = -1;
             _lapsSincePitExit = int.MaxValue;
             _wasInPitThisLap = false;
             _hadOffTrackThisLap = false;
             _latchedIncidentReason = null;
+            _lastPitLaneSeenUtc = DateTime.MinValue;
 
             // Clear pace tracking alongside fuel model resets so session transitions don't carry stale data
             _recentLapTimes.Clear();
@@ -481,6 +502,7 @@ namespace LaunchPlugin
             _lastLeaderLapTimeSec = 0.0;
             LiveLeaderAvgPaceSeconds = 0.0;
             _leaderSourceUnavailableLogged = false;
+            _leaderPaceClearedLogged = false;
             Pace_StintAvgLapTimeSec = 0.0;
             Pace_Last5LapAvgSec = 0.0;
             PaceConfidence = 0;
@@ -583,6 +605,183 @@ namespace LaunchPlugin
             }
         }
 
+        private string ReadLapDetectorSessionState()
+        {
+            try
+            {
+                if (PluginManager == null) return string.Empty;
+                object raw = PluginManager.GetPropertyValue("DataCorePlugin.GameRawData.Telemetry.SessionState");
+                return raw != null ? raw.ToString() ?? string.Empty : string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private bool IsSessionRunningForLapDetector(string sessionStateToken)
+        {
+            if (string.IsNullOrWhiteSpace(sessionStateToken))
+                return true; // assume running if we can't read state
+
+            if (int.TryParse(sessionStateToken, out int numericState))
+                return numericState == 4; // iRacing "racing"
+
+            string normalized = sessionStateToken.Trim().ToLowerInvariant();
+            return normalized.Contains("race") || normalized.Contains("running") || normalized.Contains("green");
+        }
+
+        private bool DetectLapCrossing(GameData data, double curPctNormalized, double lastPctNormalized)
+        {
+            int lapCount = Convert.ToInt32(data.NewData?.CompletedLaps ?? 0);
+            string sessionStateToken = ReadLapDetectorSessionState();
+            bool sessionRunning = IsSessionRunningForLapDetector(sessionStateToken);
+
+            if (_lapDetectorPending && DateTime.UtcNow > _lapDetectorPendingExpiresUtc)
+            {
+                if (ShouldLogLapDetector("pending-expired"))
+                {
+                    SimHub.Logging.Current.Info(
+                        $"[LapDetector] Pending lap confirmation expired (lap={_lapDetectorPendingLapTarget}, pct={_lapDetectorPendingLastPct:F3}).");
+                }
+                _lapDetectorPending = false;
+                _lapDetectorPendingLapTarget = -1;
+                _lapDetectorPendingSessionState = string.Empty;
+            }
+
+            if (_lapDetectorLastCompleted < 0)
+            {
+                _lapDetectorLastSessionState = sessionStateToken;
+                _lapDetectorLastCompleted = lapCount;
+                return false;
+            }
+
+            if (_lapDetectorLastSessionState != sessionStateToken || lapCount < _lapDetectorLastCompleted)
+            {
+                _lapDetectorLastSessionState = sessionStateToken;
+                _lapDetectorLastCompleted = lapCount;
+                _lapDetectorPending = false;
+                _lapDetectorPendingLapTarget = -1;
+                _lapDetectorPendingSessionState = string.Empty;
+                return false;
+            }
+
+            int lapDelta = lapCount - _lapDetectorLastCompleted;
+            if (lapDelta > 1)
+            {
+                _lapDetectorLastSessionState = sessionStateToken;
+                _lapDetectorLastCompleted = lapCount;
+                _lapDetectorPending = false;
+                _lapDetectorPendingLapTarget = -1;
+                _lapDetectorPendingSessionState = string.Empty;
+                return false; // ignore jumps
+            }
+
+            if (lapDelta == 1 && sessionRunning)
+            {
+                double speedKmh = data.NewData?.SpeedKmh ?? 0.0;
+                bool speedTooLow = speedKmh < 8.0;
+
+                bool pctFarFromSf = lastPctNormalized > 0.15 && curPctNormalized > 0.15 &&
+                    lastPctNormalized < 0.85 && curPctNormalized < 0.85;
+                bool pctImpossible = lastPctNormalized >= 0 && curPctNormalized >= 0 &&
+                    (lastPctNormalized < 0.25 && curPctNormalized > 0.25);
+                bool nearStartFinish = lastPctNormalized > 0.95 && curPctNormalized < 0.05;
+
+                bool pendingActive = _lapDetectorPending &&
+                    _lapDetectorPendingLapTarget == lapCount &&
+                    _lapDetectorPendingSessionState == sessionStateToken;
+
+                if (pendingActive)
+                {
+                    bool pendingExpired = DateTime.UtcNow >= _lapDetectorPendingExpiresUtc;
+
+                    if (!speedTooLow && (!pctFarFromSf || pendingExpired || nearStartFinish))
+                    {
+                        _lapDetectorLastSessionState = sessionStateToken;
+                        _lapDetectorLastCompleted = lapCount;
+                        _lapDetectorPending = false;
+                        _lapDetectorPendingLapTarget = -1;
+                        _lapDetectorPendingSessionState = string.Empty;
+                        return true;
+                    }
+
+                    if (pendingExpired)
+                    {
+                        if (ShouldLogLapDetector("pending-rejected"))
+                        {
+                            SimHub.Logging.Current.Info(
+                                $"[LapDetector] Pending lap increment rejected after debounce (lap={lapCount}, lastPct={lastPctNormalized:F3}, curPct={curPctNormalized:F3}, speed={speedKmh:F1}).");
+                        }
+                        _lapDetectorLastSessionState = sessionStateToken;
+                        _lapDetectorLastCompleted = lapCount;
+                        _lapDetectorPending = false;
+                        _lapDetectorPendingLapTarget = -1;
+                        _lapDetectorPendingSessionState = string.Empty;
+                    }
+
+                    return false;
+                }
+
+                if (speedTooLow)
+                {
+                    if (ShouldLogLapDetector("low-speed"))
+                    {
+                        SimHub.Logging.Current.Info($"[LapDetector] Ignoring lap increment at low speed ({speedKmh:F1} km/h).");
+                    }
+                    _lapDetectorLastSessionState = sessionStateToken;
+                    _lapDetectorLastCompleted = lapCount;
+                    return false;
+                }
+
+                if (pctFarFromSf || pctImpossible)
+                {
+                    _lapDetectorPending = true;
+                    _lapDetectorPendingLapTarget = lapCount;
+                    _lapDetectorPendingSessionState = sessionStateToken;
+                    _lapDetectorPendingExpiresUtc = DateTime.UtcNow.AddMilliseconds(500);
+                    _lapDetectorPendingLastPct = curPctNormalized;
+
+                    if (ShouldLogLapDetector("pending-armed"))
+                    {
+                        SimHub.Logging.Current.Info(
+                            $"[LapDetector] Lap increment queued for confirmation (lap={lapCount}, lastPct={lastPctNormalized:F3}, curPct={curPctNormalized:F3}, speed={speedKmh:F1}).");
+                    }
+
+                    return false;
+                }
+
+                if (!nearStartFinish && lastPctNormalized >= 0 && curPctNormalized >= 0 && ShouldLogLapDetector("atypical"))
+                {
+                    SimHub.Logging.Current.Info($"[LapDetector] Lap increment detected via CompletedLaps with atypical track% values (last={lastPctNormalized:F3}, cur={curPctNormalized:F3}).");
+                }
+
+                _lapDetectorLastSessionState = sessionStateToken;
+                _lapDetectorLastCompleted = lapCount;
+                _lapDetectorPending = false;
+                _lapDetectorPendingLapTarget = -1;
+                _lapDetectorPendingSessionState = string.Empty;
+                return true;
+            }
+
+            _lapDetectorLastSessionState = sessionStateToken;
+            _lapDetectorLastCompleted = lapCount;
+            return false;
+        }
+
+        private bool ShouldLogLapDetector(string key)
+        {
+            var now = DateTime.UtcNow;
+            if (key != _lapDetectorLastLogKey || (now - _lapDetectorLastLogUtc).TotalSeconds > 1.0)
+            {
+                _lapDetectorLastLogKey = key;
+                _lapDetectorLastLogUtc = now;
+                return true;
+            }
+
+            return false;
+        }
+
         private void UpdateLiveFuelCalcs(GameData data)
         {
             // --- 1) Gather required data ---
@@ -600,8 +799,12 @@ namespace LaunchPlugin
             // Track per-lap pit involvement so we can reject any lap that touched pit lane
             if (inPitArea)
             {
+                _lastPitLaneSeenUtc = DateTime.UtcNow;
                 _wasInPitThisLap = true;
             }
+
+            bool pitExitRecently = (DateTime.UtcNow - _lastPitLaneSeenUtc).TotalSeconds < 1.0;
+            bool pitTripActive = _wasInPitThisLap || inPitArea || pitExitRecently;
 
             // Normalize lap % to 0..1 in case source is 0..100
             double curPct = rawLapPct;
@@ -609,8 +812,8 @@ namespace LaunchPlugin
             double lastPct = _lastLapDistPct;
             if (lastPct > 1.5) lastPct *= 0.01;
 
-            // --- 2) Detect S/F crossing & update rolling averages ---
-            bool lapCrossed = lastPct > 0.95 && curPct < 0.05;
+            // --- 2) Detect S/F crossing via lap counter (track% used only for sanity) ---
+            bool lapCrossed = DetectLapCrossing(data, curPct, lastPct);
 
             // Unfreeze once we're primed for a new pit cycle (next entry detected)
             if (_pitFreezeUntilNextCycle && _pit?.CurrentState == PitEngine.PaceDeltaState.AwaitingPitLap)
@@ -627,9 +830,13 @@ namespace LaunchPlugin
                 if (leaderLastLapSec <= 0.0 && _recentLeaderLapTimes.Count > 0)
                 {
                     // Feed dropped: clear leader pace so downstream calcs don't reuse stale values
-                    SimHub.Logging.Current.Info(string.Format(
-                        "[Leader] clearing leader pace (feed dropped), lastAvg={0:F3}",
-                        LiveLeaderAvgPaceSeconds));
+                    if (!_leaderPaceClearedLogged)
+                    {
+                        SimHub.Logging.Current.Info(string.Format(
+                            "[Leader] clearing leader pace (feed dropped), lastAvg={0:F3}",
+                            LiveLeaderAvgPaceSeconds));
+                        _leaderPaceClearedLogged = true;
+                    }
                     _recentLeaderLapTimes.Clear();
                     _lastLeaderLapTimeSec = 0.0;
                     LiveLeaderAvgPaceSeconds = 0.0;
@@ -645,7 +852,7 @@ namespace LaunchPlugin
                     double lastLapSecPit = lastLapTsPit.TotalSeconds;
 
                     // Basic validity check for the lap itself
-                    bool lastLapLooksClean = !inPitArea && lastLapSecPit > 20 && lastLapSecPit < 900;
+                    bool lastLapLooksClean = !pitTripActive && lastLapSecPit > 20 && lastLapSecPit < 900;
 
                     // Get a stable average pace to compare against
                     double stableAvgPace = ComputeStableMedian(_recentLapTimes);
@@ -775,6 +982,7 @@ namespace LaunchPlugin
                     if (leaderLastLapSec > 20.0 && leaderLastLapSec < 900.0 &&
                         Math.Abs(leaderLastLapSec - _lastLeaderLapTimeSec) > 1e-6)
                     {
+                        _leaderPaceClearedLogged = false;
                         _recentLeaderLapTimes.Add(leaderLastLapSec);
                         while (_recentLeaderLapTimes.Count > LapTimeSampleCount)
                         {
@@ -829,7 +1037,7 @@ namespace LaunchPlugin
                     }
 
                     // 2) Any pit involvement this lap? Ignore for pace.
-                    if (!paceReject && (_wasInPitThisLap || inPitArea))
+                    if (!paceReject && pitTripActive)
                     {
                         paceReject = true;
                         paceReason = "pit-lap";
@@ -972,7 +1180,7 @@ namespace LaunchPlugin
                     }
 
                     // 1) Pit involvement – any lap that touched pit lane is rejected
-                    if (_wasInPitThisLap || inPitArea)
+                    if (pitTripActive)
                     {
                         reject = true;
                         reason = "pit-lap";
@@ -1121,12 +1329,12 @@ namespace LaunchPlugin
                                 "LalaLaunch.LiveFuel: rejected {0:F3} L (reason={1}, pit={2}, lap={3})",
                                 fuelUsed,
                                 reason,
-                                (_wasInPitThisLap || inPitArea),
+                                pitTripActive,
                                 completedLapsNow));
                     }
 
                     // Per-lap resets for next lap
-                    if (_wasInPitThisLap || inPitArea)
+                    if (pitTripActive)
                     {
                         _lapsSincePitExit = 0;
                     }


### PR DESCRIPTION
## Summary
- add a debounce path for lap-count increments with speed guardrails and throttled lap-detector logging
- throttle leader-pace drop logging and clear pending lap state on session changes or jumps
- track pit-lane exit recency so laps aren’t cleared until fully out of pit lane

## Testing
- dotnet build LaunchPlugin.sln *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692821648c54832f804df67e55661851)