### PR TITLE
Add dry and wet min/max fuel track stats

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -339,6 +339,14 @@ namespace LaunchPlugin
         private string _avgFuelPerLapDryText;
         private bool _suppressDryFuelSync = false;
 
+        private double? _minFuelPerLapDry;
+        private string _minFuelPerLapDryText;
+        private bool _suppressDryMinFuelSync = false;
+
+        private double? _maxFuelPerLapDry;
+        private string _maxFuelPerLapDryText;
+        private bool _suppressDryMaxFuelSync = false;
+
         [JsonProperty]
         public double? AvgFuelPerLapDry
         {
@@ -372,6 +380,82 @@ namespace LaunchPlugin
                         _suppressDryFuelSync = true;
                         AvgFuelPerLapDry = parsedValue;
                         _suppressDryFuelSync = false;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty]
+        public double? MinFuelPerLapDry
+        {
+            get => _minFuelPerLapDry;
+            set
+            {
+                if (_minFuelPerLapDry != value)
+                {
+                    _minFuelPerLapDry = value;
+                    OnPropertyChanged();
+                    if (!_suppressDryMinFuelSync)
+                    {
+                        MinFuelPerLapDryText = _minFuelPerLapDry?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+        }
+
+        public string MinFuelPerLapDryText
+        {
+            get => _minFuelPerLapDryText;
+            set
+            {
+                if (_minFuelPerLapDryText != value)
+                {
+                    _minFuelPerLapDryText = value;
+                    OnPropertyChanged();
+                    var parsedValue = StringToNullableDouble(value);
+                    if (parsedValue.HasValue)
+                    {
+                        _suppressDryMinFuelSync = true;
+                        MinFuelPerLapDry = parsedValue;
+                        _suppressDryMinFuelSync = false;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty]
+        public double? MaxFuelPerLapDry
+        {
+            get => _maxFuelPerLapDry;
+            set
+            {
+                if (_maxFuelPerLapDry != value)
+                {
+                    _maxFuelPerLapDry = value;
+                    OnPropertyChanged();
+                    if (!_suppressDryMaxFuelSync)
+                    {
+                        MaxFuelPerLapDryText = _maxFuelPerLapDry?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+        }
+
+        public string MaxFuelPerLapDryText
+        {
+            get => _maxFuelPerLapDryText;
+            set
+            {
+                if (_maxFuelPerLapDryText != value)
+                {
+                    _maxFuelPerLapDryText = value;
+                    OnPropertyChanged();
+                    var parsedValue = StringToNullableDouble(value);
+                    if (parsedValue.HasValue)
+                    {
+                        _suppressDryMaxFuelSync = true;
+                        MaxFuelPerLapDry = parsedValue;
+                        _suppressDryMaxFuelSync = false;
                     }
                 }
             }
@@ -441,6 +525,14 @@ namespace LaunchPlugin
         private string _avgFuelPerLapWetText;
         private bool _suppressWetFuelSync = false;
 
+        private double? _minFuelPerLapWet;
+        private string _minFuelPerLapWetText;
+        private bool _suppressWetMinFuelSync = false;
+
+        private double? _maxFuelPerLapWet;
+        private string _maxFuelPerLapWetText;
+        private bool _suppressWetMaxFuelSync = false;
+
         [JsonProperty]
         public double? AvgFuelPerLapWet
         {
@@ -474,6 +566,82 @@ namespace LaunchPlugin
                         _suppressWetFuelSync = true;
                         AvgFuelPerLapWet = parsedValue;
                         _suppressWetFuelSync = false;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty]
+        public double? MinFuelPerLapWet
+        {
+            get => _minFuelPerLapWet;
+            set
+            {
+                if (_minFuelPerLapWet != value)
+                {
+                    _minFuelPerLapWet = value;
+                    OnPropertyChanged();
+                    if (!_suppressWetMinFuelSync)
+                    {
+                        MinFuelPerLapWetText = _minFuelPerLapWet?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+        }
+
+        public string MinFuelPerLapWetText
+        {
+            get => _minFuelPerLapWetText;
+            set
+            {
+                if (_minFuelPerLapWetText != value)
+                {
+                    _minFuelPerLapWetText = value;
+                    OnPropertyChanged();
+                    var parsedValue = StringToNullableDouble(value);
+                    if (parsedValue.HasValue)
+                    {
+                        _suppressWetMinFuelSync = true;
+                        MinFuelPerLapWet = parsedValue;
+                        _suppressWetMinFuelSync = false;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty]
+        public double? MaxFuelPerLapWet
+        {
+            get => _maxFuelPerLapWet;
+            set
+            {
+                if (_maxFuelPerLapWet != value)
+                {
+                    _maxFuelPerLapWet = value;
+                    OnPropertyChanged();
+                    if (!_suppressWetMaxFuelSync)
+                    {
+                        MaxFuelPerLapWetText = _maxFuelPerLapWet?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+        }
+
+        public string MaxFuelPerLapWetText
+        {
+            get => _maxFuelPerLapWetText;
+            set
+            {
+                if (_maxFuelPerLapWetText != value)
+                {
+                    _maxFuelPerLapWetText = value;
+                    OnPropertyChanged();
+                    var parsedValue = StringToNullableDouble(value);
+                    if (parsedValue.HasValue)
+                    {
+                        _suppressWetMaxFuelSync = true;
+                        MaxFuelPerLapWet = parsedValue;
+                        _suppressWetMaxFuelSync = false;
                     }
                 }
             }

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -181,7 +181,11 @@ namespace LaunchPlugin
             ts.AvgLapTimeWetText = ts.MillisecondsToLapTimeString(ts.AvgLapTimeWet);
             ts.PitLaneLossSecondsText = ts.PitLaneLossSeconds?.ToString(System.Globalization.CultureInfo.InvariantCulture);
             ts.AvgFuelPerLapDryText = ts.AvgFuelPerLapDry?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            ts.MinFuelPerLapDryText = ts.MinFuelPerLapDry?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            ts.MaxFuelPerLapDryText = ts.MaxFuelPerLapDry?.ToString(System.Globalization.CultureInfo.InvariantCulture);
             ts.AvgFuelPerLapWetText = ts.AvgFuelPerLapWet?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            ts.MinFuelPerLapWetText = ts.MinFuelPerLapWet?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            ts.MaxFuelPerLapWetText = ts.MaxFuelPerLapWet?.ToString(System.Globalization.CultureInfo.InvariantCulture);
             ts.AvgDryTrackTempText = ts.AvgDryTrackTemp?.ToString(System.Globalization.CultureInfo.InvariantCulture);
             ts.AvgWetTrackTempText = ts.AvgWetTrackTemp?.ToString(System.Globalization.CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
## Summary
- add nullable dry/wet min and max fuel properties to track statistics with JSON serialization and text helpers
- initialize the new text properties when creating or resolving track entries to keep profile bindings synchronized

## Testing
- `dotnet build LaunchPlugin.sln` *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69284f760d3c832fb0d4a7d3c30e1d05)