### PR TITLE
Add fuel update timestamps to track profiles

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -333,6 +333,57 @@ namespace LaunchPlugin
             set { if (_pitLaneLossUpdatedUtc != value) { _pitLaneLossUpdatedUtc = value; OnPropertyChanged(); } }
         }
 
+        private string _fuelUpdatedSource;
+        [JsonProperty]
+        public string FuelUpdatedSource
+        {
+            get => _fuelUpdatedSource;
+            set
+            {
+                if (_fuelUpdatedSource != value)
+                {
+                    _fuelUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(FuelLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _fuelUpdatedUtc;
+        [JsonProperty]
+        public DateTime? FuelUpdatedUtc
+        {
+            get => _fuelUpdatedUtc;
+            set
+            {
+                if (_fuelUpdatedUtc != value)
+                {
+                    _fuelUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(FuelLastUpdatedText));
+                }
+            }
+        }
+
+        [JsonIgnore]
+        public string FuelLastUpdatedText
+        {
+            get
+            {
+                if (!_fuelUpdatedUtc.HasValue) return string.Empty;
+                var sourceLabel = string.IsNullOrWhiteSpace(_fuelUpdatedSource)
+                    ? "Last updated"
+                    : _fuelUpdatedSource;
+                return $"{sourceLabel}: {_fuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+            }
+        }
+
+        public void MarkFuelUpdated(string source, DateTime? whenUtc = null)
+        {
+            FuelUpdatedSource = source;
+            FuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
 
         /// --- Dry Conditions Data ---
         private double? _avgFuelPerLapDry;
@@ -391,6 +442,10 @@ namespace LaunchPlugin
                     var parsedValue = StringToNullableDouble(value);
                     if (parsedValue.HasValue)
                     {
+                        if (!_suppressDryFuelSync)
+                        {
+                            MarkFuelUpdated("Manual fuel edit");
+                        }
                         _suppressDryFuelSync = true;
                         AvgFuelPerLapDry = parsedValue;
                         _suppressDryFuelSync = false;
@@ -591,6 +646,10 @@ namespace LaunchPlugin
                     var parsedValue = StringToNullableDouble(value);
                     if (parsedValue.HasValue)
                     {
+                        if (!_suppressWetFuelSync)
+                        {
+                            MarkFuelUpdated("Manual fuel edit");
+                        }
                         _suppressWetFuelSync = true;
                         AvgFuelPerLapWet = parsedValue;
                         _suppressWetFuelSync = false;

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1708,20 +1708,37 @@ namespace LaunchPlugin
         // 6) Save track-specific settings
         var lapTimeMs = trackRecord.LapTimeStringToMilliseconds(EstimatedLapTime);
         double.TryParse(FuelPerLapText.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out double fuelVal);
+        bool fuelStamped = false;
 
         if (IsDry)
         {
             if (lapTimeMs.HasValue) trackRecord.AvgLapTimeDry = lapTimeMs;
-            if (fuelVal > 0) trackRecord.AvgFuelPerLapDry = fuelVal;
+            if (fuelVal > 0)
+            {
+                trackRecord.AvgFuelPerLapDry = fuelVal;
+                fuelStamped = true;
+            }
         }
         else // Wet
         {
             if (lapTimeMs.HasValue) trackRecord.AvgLapTimeWet = lapTimeMs;
-            if (fuelVal > 0) trackRecord.AvgFuelPerLapWet = fuelVal;
+            if (fuelVal > 0)
+            {
+                trackRecord.AvgFuelPerLapWet = fuelVal;
+                fuelStamped = true;
+            }
         }
 
-        if (_liveDryFuelAvg > 0) trackRecord.AvgFuelPerLapDry = _liveDryFuelAvg;
-        if (_liveWetFuelAvg > 0) trackRecord.AvgFuelPerLapWet = _liveWetFuelAvg;
+        if (_liveDryFuelAvg > 0)
+        {
+            trackRecord.AvgFuelPerLapDry = _liveDryFuelAvg;
+            fuelStamped = true;
+        }
+        if (_liveWetFuelAvg > 0)
+        {
+            trackRecord.AvgFuelPerLapWet = _liveWetFuelAvg;
+            fuelStamped = true;
+        }
 
         if (_liveDryFuelMin > 0) trackRecord.MinFuelPerLapDry = _liveDryFuelMin;
         if (_liveDryFuelMax > 0) trackRecord.MaxFuelPerLapDry = _liveDryFuelMax;
@@ -1730,6 +1747,12 @@ namespace LaunchPlugin
         if (_liveWetFuelMin > 0) trackRecord.MinFuelPerLapWet = _liveWetFuelMin;
         if (_liveWetFuelMax > 0) trackRecord.MaxFuelPerLapWet = _liveWetFuelMax;
         if (_liveWetSamples > 0) trackRecord.WetFuelSampleCount = _liveWetSamples;
+
+        if (fuelStamped)
+        {
+            var source = isLiveSession ? "Telemetry fuel" : "Planner save";
+            trackRecord.MarkFuelUpdated(source);
+        }
 
         trackRecord.PitLaneLossSeconds = this.PitLaneTimeLoss;
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1309,6 +1309,7 @@ namespace LaunchPlugin
                             if (trackRecord != null)
                             {
                                 trackRecord.AvgFuelPerLapDry = _avgDryFuelPerLap;
+                                trackRecord.MarkFuelUpdated("Telemetry fuel");
                             }
                         }
 

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -338,6 +338,10 @@
                                     <TextBox Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                         TextAlignment="Right" Width="100"/>
                                 </StackPanel>
+                                <StackPanel Orientation="Horizontal" Margin="160,2,0,0">
+                                    <TextBlock Text="&#xE946;" FontFamily="Segoe MDL2 Assets" Foreground="#FF9AA0A6" Margin="0,0,6,0"/>
+                                    <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6"/>
+                                </StackPanel>
 
                                 <!-- Avg Lap Time (m:ss.fff), right-aligned -->
                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">


### PR DESCRIPTION
## Summary
- add source and timestamp tracking for fuel values on track profiles, including manual edits
- stamp fuel updates when telemetry or planner saves push new fuel numbers
- display a subtle hint next to fuel inputs showing the last update source and time

## Testing
- dotnet build LaunchPlugin.sln *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69285596e73c832fab85f460bd8646be)