### PR TITLE
Add fuel burn stats to track details

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -332,6 +332,31 @@
                                 <!-- Dry Conditions Data -->
                                 <TextBlock Text="Dry Conditions Data" FontWeight="Bold" Margin="0,10,0,2"/>
 
+                                <Grid Margin="0,2,0,6">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="150" />
+                                        <ColumnDefinition Width="70" />
+                                        <ColumnDefinition Width="70" />
+                                        <ColumnDefinition Width="70" />
+                                        <ColumnDefinition Width="70" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Fuel Burn (L/lap):" Margin="0,0,10,0" VerticalAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Eco" FontWeight="SemiBold" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Avg" FontWeight="SemiBold" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="Max" FontWeight="SemiBold" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="4" Text="Samples" FontWeight="SemiBold" TextAlignment="Center" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding DryEcoFuel, StringFormat={}{0:0.00}}" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding DryAvgFuel, StringFormat={}{0:0.00}}" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding DryMaxFuel, StringFormat={}{0:0.00}}" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="1" Grid.Column="4" Text="{Binding DrySamples}" TextAlignment="Center" />
+                                </Grid>
+
                                 <!-- Avg Fuel/Lap (2dp, right-aligned) -->
                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
                                     <TextBlock Text="Avg Fuel/Lap:" VerticalAlignment="Center" Margin="0,0,10,0" Width="150"/>
@@ -356,6 +381,31 @@
 
                                 <!-- Wet Conditions Data -->
                                 <TextBlock Text="Wet Conditions Data" FontWeight="Bold" Margin="0,10,0,2"/>
+
+                                <Grid Margin="0,2,0,6">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="150" />
+                                        <ColumnDefinition Width="70" />
+                                        <ColumnDefinition Width="70" />
+                                        <ColumnDefinition Width="70" />
+                                        <ColumnDefinition Width="70" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Fuel Burn (L/lap):" Margin="0,0,10,0" VerticalAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Eco" FontWeight="SemiBold" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Avg" FontWeight="SemiBold" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="Max" FontWeight="SemiBold" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="0" Grid.Column="4" Text="Samples" FontWeight="SemiBold" TextAlignment="Center" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding WetEcoFuel, StringFormat={}{0:0.00}}" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding WetAvgFuel, StringFormat={}{0:0.00}}" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding WetMaxFuel, StringFormat={}{0:0.00}}" TextAlignment="Center" />
+                                    <TextBlock Grid.Row="1" Grid.Column="4" Text="{Binding WetSamples}" TextAlignment="Center" />
+                                </Grid>
 
                                 <!-- Avg Fuel/Lap (2dp, right-aligned) -->
                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">


### PR DESCRIPTION
## Summary
- add fuel burn summary grid for dry track conditions with eco/avg/max/sample columns
- mirror the fuel burn summary grid for wet conditions bound to new TrackStats properties

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692855943954832fa7d88961feeaaf61)