### PR TITLE
Remove post-race analysis code remnants

### DIFF
--- a/Docs/FuelTabAnalysis.md
+++ b/Docs/FuelTabAnalysis.md
@@ -30,7 +30,6 @@
 | Save all to profile button | styles:SHButtonPrimary | "Save All to Profile" | `SavePlannerDataToProfileCommand` | persist profile | Writes current planner settings to car/track profile. 【F:FuelCalculatorView.xaml†L502-L508】【F:FuelCalcs.cs†L1739-L1744】 |
 | Fuel save target slider | Slider | "Fuel Save Target (L/Lap):" | `FuelSaveTarget` (TwoWay) | L/lap | Used in simulator calc. 【F:FuelCalculatorView.xaml†L573-L585】【F:FuelCalcs.cs†L53-L60】 |
 | Fuel save time-loss textbox | TextBox | "Est. Time Loss per Lap" | `TimeLossPerLapOfFuelSave` (TwoWay) | time | Manual entry for simulator. 【F:FuelCalculatorView.xaml†L584-L585】【F:FuelCalcs.cs†L54-L60】 |
-| Load last session button | Button | "Load Last Session Data for Comparison" | `LoadLastSessionCommand` | post-race | Loads analysis grid. 【F:FuelCalculatorView.xaml†L595-L606】【F:FuelCalcs.cs†L67-L71】 |
 
 ## Data Source Wiring – Live vs Profile vs Manual
 - **Live telemetry ingestion:** `SetLiveSession` selects the live car/track, rebuilds the track list, and updates snapshot labels; it runs on the UI dispatcher and marks the session active. 【F:FuelCalcs.cs†L1758-L1784】【F:FuelCalcs.cs†L2053-L2087】

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -147,9 +147,7 @@ namespace LaunchPlugin
     public ObservableCollection<CarProfile> AvailableCarProfiles { get; set; } // CHANGED
     public ObservableCollection<string> AvailableTracks { get; set; } = new ObservableCollection<string>();
     public string DetectedMaxFuelDisplay { get; private set; }
-    public ICommand LoadLastSessionCommand { get; }
     public ICommand ResetLeaderDeltaToLiveCommand { get; }
-    public ObservableCollection<AnalysisDataRow> AnalysisData { get; set; } = new ObservableCollection<AnalysisDataRow>();
     private string _fuelPerLapText = "";
     private bool _suppressFuelTextSync = false;
     public string LapTimeSourceInfo
@@ -3611,28 +3609,5 @@ namespace LaunchPlugin
     }
 
 
-    private void LoadLastSessionData()
-    {
-        AnalysisData.Clear();
-        AnalysisData.Add(new AnalysisDataRow { Metric = "Total Fuel Used", Predicted = "140.5 L", Actual = "142.1 L", Delta = "+1.6 L" });
-        AnalysisData.Add(new AnalysisDataRow { Metric = "Avg Fuel/Lap", Predicted = "2.81 L", Actual = "2.84 L", Delta = "+0.03 L" });
-        AnalysisData.Add(new AnalysisDataRow { Metric = "Pit Stops", Predicted = "1", Actual = "1", Delta = "0" });
-    }
-
-    public class AnalysisDataRow
-    {
-        public string Metric { get; set; } = string.Empty;
-        public string Predicted { get; set; } = string.Empty;
-        public string Actual { get; set; } = string.Empty;
-        public string Delta { get; set; } = string.Empty;
-        public AnalysisDataRow() { }
-        public AnalysisDataRow(string metric, string predicted, string actual, string delta)
-        {
-            Metric = metric ?? string.Empty;
-            Predicted = predicted ?? string.Empty;
-            Actual = actual ?? string.Empty;
-            Delta = delta ?? string.Empty;
-        }
-    }
 }
 }

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -668,19 +668,6 @@
                 </StackPanel>
             </styles:SHSection>
 
-            <styles:SHSection Title="POST-RACE ANALYSIS" ShowSeparator="True" Margin="0,15,0,0">
-                <StackPanel Margin="5,10,5,5">
-                    <Button Content="Load Last Session Data for Comparison" HorizontalAlignment="Left" Command="{Binding LoadLastSessionCommand}"/>
-                    <DataGrid Margin="0,10,0,0" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" ItemsSource="{Binding AnalysisData, Mode=OneWay}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Metric" Binding="{Binding Metric}" Width="*"/>
-                            <DataGridTextColumn Header="Predicted" Binding="{Binding Predicted}" Width="100"/>
-                            <DataGridTextColumn Header="Actual" Binding="{Binding Actual}" Width="100"/>
-                            <DataGridTextColumn Header="Delta" Binding="{Binding Delta}" Width="100"/>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                </StackPanel>
-            </styles:SHSection>
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary
- remove unused post-race analysis bindings and stub data from the fuel calculator view model
- update fuel tab wiring docs to drop the removed analysis controls

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692871d283a0832f9aa9f7321c80053f)