### PR TITLE
Align track editor core data layout

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -235,7 +235,7 @@
                         </DockPanel>
 
                         <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                            <StackPanel DataContext="{Binding SelectedTrack}" IsEnabled="{Binding DataContext.IsTrackSelected, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                            <StackPanel DataContext="{Binding SelectedTrack}" Grid.IsSharedSizeScope="True" IsEnabled="{Binding DataContext.IsTrackSelected, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                 <TextBlock FontWeight="Bold">
                                     <Run Text="Editing Data for: "/>
                                     <Run Text="{Binding DisplayName}"/>
@@ -243,9 +243,19 @@
                                 <Border Height="1" Background="#444" Margin="0,5,0,10"/>
 
                                 <TextBlock Text="Core Data" FontWeight="Bold" Margin="0,5,0,2"/>
-                                <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                    <TextBlock Text="Best Lap Time (m:ss.fff):" VerticalAlignment="Center" Margin="0,0,10,0" Width="150"/>
-                                    <TextBox Width="100" TextAlignment="Right">
+                                <Grid Margin="0,2,0,6" Grid.IsSharedSizeScope="True">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="InputColumn" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Best Lap Time (m:ss.fff):" VerticalAlignment="Center" Margin="0,0,10,0" MinWidth="150" />
+                                    <TextBox Grid.Row="0" Grid.Column="1" Width="120" MinWidth="110" TextAlignment="Right">
                                         <TextBox.Text>
                                             <Binding Path="BestLapMsText"
                                                      Mode="TwoWay"
@@ -258,32 +268,16 @@
                                             </Binding>
                                         </TextBox.Text>
                                     </TextBox>
-                                </StackPanel>
-                                <!-- inside the track details pane -->
-                                <StackPanel Margin="0,8,0,0">
-                                    <!-- Pit Lane Loss row (identical layout to other rows) -->
-                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                                        <!-- same label width + gap as other rows -->
-                                        <TextBlock Text="Pit Lane Loss (s):"
-                                             Width="150" Margin="0,0,10,0"
-                                             VerticalAlignment="Center"/>
-                                        <TextBox Width="100"
-                                           TextAlignment="Right"
-                                           Padding="2,0,2,0"
-                                           Text="{Binding PitLaneLossSecondsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}"/>
-                                    </StackPanel>
 
-                                    <!-- meta line: sits under the input, indented to the input column -->
-                                    <TextBlock Margin="160,2,0,0" 
-                                       FontStyle="Italic"
-                                       Foreground="#FF9AA0A6"
-                                       TextWrapping="Wrap">
-                                      <Run Text="{Binding PitLaneLossSource, TargetNullValue=unknown}"/>
-                                      <Run Text=" — Updated (UTC): "/>
-                                      <Run Text="{Binding PitLaneLossUpdatedUtc, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Pit Lane Loss (s):" Margin="0,0,10,0" VerticalAlignment="Center" MinWidth="150" />
+                                    <TextBox Grid.Row="1" Grid.Column="1" Width="120" MinWidth="110" TextAlignment="Right" Padding="2,0,2,0"
+                                             Text="{Binding PitLaneLossSecondsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}" />
+                                    <TextBlock Grid.Row="1" Grid.Column="2" Margin="10,2,0,0" FontStyle="Italic" Foreground="#FF9AA0A6" TextWrapping="Wrap">
+                                        <Run Text="{Binding PitLaneLossSource, TargetNullValue=unknown}"/>
+                                        <Run Text=" — Updated (UTC): "/>
+                                        <Run Text="{Binding PitLaneLossUpdatedUtc, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
                                     </TextBlock>
-
-                                </StackPanel>
+                                </Grid>
 
                                 <!-- Dry Conditions Data -->
                                 <TextBlock Text="Dry Conditions Data" FontWeight="Bold" Margin="0,10,0,2"/>
@@ -314,20 +308,30 @@
                                 </Grid>
 
                                 <!-- Avg Fuel/Lap (2dp, right-aligned) -->
-                                <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                    <TextBlock Text="Avg Fuel/Lap:" VerticalAlignment="Center" Margin="0,0,10,0" Width="150"/>
-                                    <TextBox Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}"
-                                        TextAlignment="Right" Width="100"/>
-                                </StackPanel>
-                                <StackPanel Orientation="Horizontal" Margin="160,2,0,0">
-                                    <TextBlock Text="&#xE946;" FontFamily="Segoe MDL2 Assets" Foreground="#FF9AA0A6" Margin="0,0,6,0"/>
-                                    <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6"/>
-                                </StackPanel>
+                                <Grid Margin="0,2,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="InputColumn" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Avg Fuel/Lap:" VerticalAlignment="Center" Margin="0,0,10,0" MinWidth="150"/>
+                                    <TextBox Grid.Column="1" Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}"
+                                             TextAlignment="Right" Width="120" MinWidth="110"/>
+                                    <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="10,0,0,0" VerticalAlignment="Center">
+                                        <TextBlock Text="&#xE946;" FontFamily="Segoe MDL2 Assets" Foreground="#FF9AA0A6" Margin="0,0,6,0"/>
+                                        <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6"/>
+                                    </StackPanel>
+                                </Grid>
 
                                 <!-- Avg Lap Time (m:ss.fff), right-aligned -->
-                                <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                    <TextBlock Text="Avg Lap Time (m:ss.fff):" VerticalAlignment="Center" Margin="0,0,10,0" Width="150"/>
-                                    <TextBox TextAlignment="Right" Width="100">
+                                <Grid Margin="0,2,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="InputColumn" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Avg Lap Time (m:ss.fff):" VerticalAlignment="Center" Margin="0,0,10,0" MinWidth="150"/>
+                                    <TextBox Grid.Column="1" TextAlignment="Right" Width="120" MinWidth="110">
                                         <TextBox.Text>
                                             <Binding Path="AvgLapTimeDryText"
                                                      Mode="TwoWay"
@@ -340,7 +344,7 @@
                                             </Binding>
                                         </TextBox.Text>
                                     </TextBox>
-                                </StackPanel>
+                                </Grid>
 
 
                                 <!-- Wet Conditions Data -->
@@ -372,16 +376,26 @@
                                 </Grid>
 
                                 <!-- Avg Fuel/Lap (2dp, right-aligned) -->
-                                <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                    <TextBlock Text="Avg Fuel/Lap:" VerticalAlignment="Center" Margin="0,0,10,0" Width="150"/>
-                                    <TextBox Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}"
-                                        TextAlignment="Right" Width="100"/>
-                                </StackPanel>
+                                <Grid Margin="0,2,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="InputColumn" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Avg Fuel/Lap:" VerticalAlignment="Center" Margin="0,0,10,0" MinWidth="150"/>
+                                    <TextBox Grid.Column="1" Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}"
+                                             TextAlignment="Right" Width="120" MinWidth="110"/>
+                                </Grid>
 
                                 <!-- Avg Lap Time (m:ss.fff), right-aligned -->
-                                <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                    <TextBlock Text="Avg Lap Time (m:ss.fff):" VerticalAlignment="Center" Margin="0,0,10,0" Width="150"/>
-                                    <TextBox TextAlignment="Right" Width="100">
+                                <Grid Margin="0,2,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="InputColumn" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Avg Lap Time (m:ss.fff):" VerticalAlignment="Center" Margin="0,0,10,0" MinWidth="150"/>
+                                    <TextBox Grid.Column="1" TextAlignment="Right" Width="120" MinWidth="110">
                                         <TextBox.Text>
                                             <Binding Path="AvgLapTimeWetText"
                                                      Mode="TwoWay"
@@ -394,7 +408,7 @@
                                             </Binding>
                                         </TextBox.Text>
                                     </TextBox>
-                                </StackPanel>
+                                </Grid>
 
                             </StackPanel>
                         </ScrollViewer>


### PR DESCRIPTION
## Summary
- align core data labels and text boxes in the track editor with shared width groups for consistent sizing
- place helper metadata inline within rows to keep hints compact while resizing gracefully
- apply shared sizing scope so fields retain alignment as the window width changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692966dcb10c832fa4fcaa67135d2392)