### PR TITLE
Rearrange tracks tab layout to match reference

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -278,7 +278,7 @@
                                         <TextBlock Grid.Column="0" Text="Pit Lane Loss (s):" Margin="0,0,10,0" VerticalAlignment="Center" />
                                         <TextBox Grid.Column="1" TextAlignment="Right" Padding="2,0,2,0" MinWidth="110"
                                                  Text="{Binding PitLaneLossSecondsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}" />
-                                        <TextBlock Grid.Column="2" Margin="12,0,0,0" FontStyle="Italic" Foreground="#FF9AA0A6" TextWrapping="Wrap">
+                                        <TextBlock Grid.Column="2" Margin="12,0,0,0" FontStyle="Italic" Foreground="#FF9AA0A6" VerticalAlignment="Center" TextWrapping="Wrap">
                                             <Run Text="{Binding PitLaneLossSource, TargetNullValue=Manual}"/>
                                             <Run Text=": "/>
                                             <Run Text="{Binding PitLaneLossUpdatedUtc, StringFormat={}{0:yyyy-MM-dd HH:mm}}"/>
@@ -311,7 +311,7 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Grid.Column="2" Text="{Binding DryLapTimeSampleCount, StringFormat=Samples: {0}}" Margin="12,0,0,0" />
+                                        <TextBlock Grid.Column="2" Text="{Binding DryLapTimeSampleCount, StringFormat=Sample: {0}}" Margin="12,0,0,0" VerticalAlignment="Center"/>
                                     </Grid>
 
                                     <Grid>
@@ -321,44 +321,44 @@
                                             <ColumnDefinition Width="*" SharedSizeGroup="InfoColumn" MinWidth="220" />
                                         </Grid.ColumnDefinitions>
 
-                                        <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,0,10,0">
+                                        <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,0,10,0" >
                                             <TextBlock Text="Fuel Burn (L/lap):" />
-                                            <TextBlock Text="{Binding DryFuelSampleCount, StringFormat= Samples {0}}" Margin="4,0,0,0" />
+                                            <TextBlock Text="{Binding DryFuelSampleCount, StringFormat= Sample: {0}}" Margin="4,0,0,0" VerticalAlignment="Center"/>
                                         </StackPanel>
 
                                         <StackPanel Grid.Column="1" Margin="0,0,0,0">
                                             <Grid Margin="0,0,0,2">
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="60" />
                                                     <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="70" />
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="ECO" FontWeight="SemiBold" />
-                                                <TextBox Grid.Column="1" Text="{Binding MinFuelPerLapDryText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" />
+                                                <TextBlock Grid.Column="0" Text="ECO" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <TextBox Grid.Column="1" Text="{Binding MinFuelPerLapDryText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" VerticalAlignment="Center"/>
                                             </Grid>
                                             <Grid Margin="0,0,0,2">
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="60" />
                                                     <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="70" />
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="AVG" FontWeight="SemiBold" />
-                                                <TextBox Grid.Column="1" Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" />
+                                                <TextBlock Grid.Column="0" Text="AVG" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <TextBox Grid.Column="1" Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" VerticalAlignment="Center"/>
                                             </Grid>
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="60" />
                                                     <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="70" />
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="MAX" FontWeight="SemiBold" />
-                                                <TextBox Grid.Column="1" Text="{Binding MaxFuelPerLapDryText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" />
+                                                <TextBlock Grid.Column="0" Text="MAX" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <TextBox Grid.Column="1" Text="{Binding MaxFuelPerLapDryText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" VerticalAlignment="Center"/>
                                             </Grid>
                                         </StackPanel>
 
-                                        <StackPanel Grid.Column="2" Margin="12,0,0,0">
-                                            <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6" />
+                                        <StackPanel Grid.Column="2" Margin="12,0,0,0" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </Grid>
                                 </StackPanel>
-<!-- Wet Conditions Data -->
+                                <!-- Wet Conditions Data -->
                                 <TextBlock Text="Wet Conditions Data" FontWeight="Bold" Margin="0,10,0,4"/>
 
                                 <StackPanel Margin="0,0,0,6" Grid.IsSharedSizeScope="True">
@@ -383,7 +383,7 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Grid.Column="2" Text="{Binding WetLapTimeSampleCount, StringFormat=Samples: {0}}" Margin="12,0,0,0" />
+                                        <TextBlock Grid.Column="2" Text="{Binding WetLapTimeSampleCount, StringFormat=Sample: {0}}" Margin="12,0,0,0" VerticalAlignment="Center"/>
                                     </Grid>
 
                                     <Grid>
@@ -395,45 +395,45 @@
 
                                         <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,0,10,0">
                                             <TextBlock Text="Fuel Burn (L/lap):" />
-                                            <TextBlock Text="{Binding WetFuelSampleCount, StringFormat= Samples {0}}" Margin="4,0,0,0" />
+                                            <TextBlock Text="{Binding WetFuelSampleCount, StringFormat= Sample: {0}}" Margin="4,0,0,0" VerticalAlignment="Center"/>
                                         </StackPanel>
 
                                         <StackPanel Grid.Column="1" Margin="0,0,0,0">
                                             <Grid Margin="0,0,0,2">
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="60" />
                                                     <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="70" />
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="ECO" FontWeight="SemiBold" />
-                                                <TextBox Grid.Column="1" Text="{Binding MinFuelPerLapWetText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" />
+                                                <TextBlock Grid.Column="0" Text="ECO" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <TextBox Grid.Column="1" Text="{Binding MinFuelPerLapWetText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" VerticalAlignment="Center"/>
                                             </Grid>
                                             <Grid Margin="0,0,0,2">
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="60" />
                                                     <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="70" />
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="AVG" FontWeight="SemiBold" />
-                                                <TextBox Grid.Column="1" Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" />
+                                                <TextBlock Grid.Column="0" Text="AVG" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <TextBox Grid.Column="1" Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" VerticalAlignment="Center"/>
                                             </Grid>
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="60" />
                                                     <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="70" />
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="MAX" FontWeight="SemiBold" />
-                                                <TextBox Grid.Column="1" Text="{Binding MaxFuelPerLapWetText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" />
+                                                <TextBlock Grid.Column="0" Text="MAX" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <TextBox Grid.Column="1" Text="{Binding MaxFuelPerLapWetText, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="60" VerticalAlignment="Center"/>
                                             </Grid>
                                         </StackPanel>
 
-                                        <StackPanel Grid.Column="2" Margin="12,0,0,0">
-                                            <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6" />
+                                        <StackPanel Grid.Column="2" Margin="12,0,0,0" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding FuelLastUpdatedText}" FontStyle="Italic" Foreground="#FF9AA0A6" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </Grid>
                                 </StackPanel>
                                 <StackPanel Margin="0,10,0,0" Grid.IsSharedSizeScope="True">
-                                    <TextBlock Text="Wet vs Dry Avg Deltas:" FontWeight="Bold" Margin="0,0,0,2" />
-                                    <StackPanel Margin="10,0,0,0">
-                                        <TextBlock Text="{Binding WetVsDryAvgLapDeltaText, StringFormat=Avg Pace at {0}}" Foreground="#D9534F" />
+                                    <TextBlock Text="Wet vs Dry Avg Deltas:" FontWeight="SemiBold" Margin="0,0,0,2" />
+                                    <StackPanel Margin="5,0,0,0">
+                                        <TextBlock Text="{Binding WetVsDryAvgLapDeltaText, StringFormat=Avg Pace at {0}}"  />
                                         <TextBlock Text="{Binding WetVsDryAvgFuelDeltaText, StringFormat=Avg Fuel Burn at {0}}" />
                                     </StackPanel>
                                 </StackPanel>


### PR DESCRIPTION
## Summary
- restyled the tracks tab core, dry, and wet data sections to mirror the reference layout
- grouped lap time and fuel burn inputs into stacked rows with clearer sample/update labels
- reformatted wet vs dry delta display for readability

## Testing
- dotnet build *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692985bc7854832f98a36d76e044c30d)