### PR TITLE
Follow live wet track telemetry

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1098,9 +1098,18 @@ namespace LaunchPlugin
     private void ApplyLiveSurfaceSummary(bool? isDeclaredWet, string summary)
     {
         bool wasWetVisible = ShowWetSnapshotRows;
+        bool wasWetCondition = IsWet;
 
         _liveWeatherIsWet = isDeclaredWet;
         _liveSurfaceSummary = string.IsNullOrWhiteSpace(summary) ? null : summary.Trim();
+
+        bool shouldFollowLiveSurface = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot;
+        bool shouldSetWetFromLive = isDeclaredWet == true && shouldFollowLiveSurface;
+
+        if (shouldSetWetFromLive && !IsWet)
+        {
+            SelectedTrackCondition = TrackCondition.Wet;
+        }
 
         bool isWetVisible = ShowWetSnapshotRows;
         if (isWetVisible != wasWetVisible)
@@ -1108,6 +1117,11 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(ShowWetSnapshotRows));
             UpdateLapTimeSummaries();
             UpdatePaceSummaries();
+        }
+
+        if (IsWet != wasWetCondition && shouldFollowLiveSurface)
+        {
+            ApplyPlanningSourceToAutoFields(applyLapTime: true, applyFuel: true);
         }
 
         UpdateSurfaceModeLabel();

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -253,7 +253,7 @@
                             </Grid>
 
                             <!-- Track condition (Profile planning only) -->
-                            <StackPanel Grid.Row="3" Margin="0,5,0,5" Visibility="{Binding IsPlanningSourceProfile,Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel Grid.Row="3" Margin="0,5,0,5" IsEnabled="{Binding IsPlanningSourceProfile}">
                                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                                 <TextBlock Text="Track Condition:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                                 <RadioButton Content="Dry" IsChecked="{Binding IsDry, Mode=TwoWay}" GroupName="TrackCondition"/>


### PR DESCRIPTION
## Summary
- follow live surface summaries by flipping the planner to wet when telemetry declares it (unless using profile mode)
- refresh auto-populated lap/fuel fields when live-driven wetness changes
- keep the track condition radios visible so live changes are reflected, while still only editable in profile mode

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692999301d08832f9c0c311cc8fc8d87)