### PR TITLE
Handle live wet/dry selection during snapshots

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1160,11 +1160,14 @@ namespace LaunchPlugin
         _liveSurfaceSummary = string.IsNullOrWhiteSpace(summary) ? null : summary.Trim();
 
         bool shouldFollowLiveSurface = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot;
-        bool shouldSetWetFromLive = isDeclaredWet == true && shouldFollowLiveSurface;
 
-        if (shouldSetWetFromLive && !IsWet)
+        if (shouldFollowLiveSurface && isDeclaredWet.HasValue)
         {
-            SelectedTrackCondition = TrackCondition.Wet;
+            var liveCondition = isDeclaredWet.Value ? TrackCondition.Wet : TrackCondition.Dry;
+            if (SelectedTrackCondition != liveCondition)
+            {
+                SelectedTrackCondition = liveCondition;
+            }
         }
 
         bool isWetVisible = ShowWetSnapshotRows;

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -253,7 +253,7 @@
                             </Grid>
 
                             <!-- Track condition (Profile planning only) -->
-                            <StackPanel Grid.Row="3" Margin="0,5,0,5" IsEnabled="{Binding IsPlanningSourceProfile}">
+                            <StackPanel Grid.Row="3" Margin="0,5,0,5">
                                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                                     <TextBlock Text="Track Condition:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                                     <RadioButton Content="Dry" IsChecked="{Binding IsDry, Mode=TwoWay}" GroupName="TrackCondition"/>


### PR DESCRIPTION
## Summary
- allow track condition radios to remain enabled during live planning so users can override the detected condition
- follow live session wet/dry detection in both directions when using live snapshots so condition-specific data saves correctly

## Testing
- ⚠️ `dotnet build LaunchPlugin.sln` (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2b1356c4832f8169112a102d6456)