### PR TITLE
Fix fuel profile state updates and preserve tire change time

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -497,7 +497,19 @@ namespace LaunchPlugin
     }
 
     // ---- Profile/live availability flags for buttons ----
-    public bool HasProfileFuelPerLap { get; private set; }
+    private bool _hasProfileFuelPerLap;
+    public bool HasProfileFuelPerLap
+    {
+        get => _hasProfileFuelPerLap;
+        private set
+        {
+            if (_hasProfileFuelPerLap != value)
+            {
+                _hasProfileFuelPerLap = value;
+                OnPropertyChanged();
+            }
+        }
+    }
     public bool IsProfileFuelSaveAvailable { get; private set; }
     public bool IsProfileFuelMaxAvailable { get; private set; }
     public bool HasProfilePitLaneLoss { get; private set; }
@@ -3055,7 +3067,6 @@ namespace LaunchPlugin
             this.ContingencyValue = car.FuelContingencyValue;
             this.IsContingencyInLaps = car.IsContingencyInLaps;
             this.WetFactorPercent = car.WetFuelMultiplier;
-            this.TireChangeTime = car.TireChangeTime;
         }
 
         if (ts?.BestLapMs is int ms && ms > 0)
@@ -3268,7 +3279,6 @@ namespace LaunchPlugin
         OnPropertyChanged(nameof(ProfileAvgFuelDisplay));
         OnPropertyChanged(nameof(ProfileAvgDryLapTimeDisplay));
         OnPropertyChanged(nameof(ProfileAvgDryFuelDisplay));
-        OnPropertyChanged(nameof(HasProfileFuelPerLap));
         OnPropertyChanged(nameof(ShowProfileLapHelper));
     }
 


### PR DESCRIPTION
## Summary
- raise property change notifications when profile fuel availability toggles to keep fuel choice buttons in sync
- avoid overwriting tire change time when swapping car profiles so strategy settings stay user-controlled

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b494bccd0832fa95ce80b29f0d702)