### PR TITLE
Ensure live max fuel display stays in sync and add set-live override

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -361,6 +361,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
 
                                 <TextBlock Text="Max Fuel Override (litres):" VerticalAlignment="Center"/>
@@ -378,6 +379,11 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
+
+                                <Button Grid.Column="2" Content="Set live" Margin="10,0,0,0" VerticalAlignment="Center"
+                                        Command="{Binding SetLiveMaxFuelOverrideCommand}"
+                                        Visibility="{Binding HasLiveMaxFuelSuggestion, Converter={StaticResource BoolToVisibilityConverter}}"
+                                        IsEnabled="{Binding HasLiveMaxFuelSuggestion}" />
                             </Grid>
 
                             <ui:TitledSlider Title="" Minimum="1" Maximum="150" Value="{Binding MaxFuelOverride, Mode=TwoWay}" ToolTip="Limit the car's tank size for races with restricted fuel.">


### PR DESCRIPTION
## Summary
- ensure live max fuel snapshot and helper text stay in sync and clear to defaults when live data is missing
- always raise updates for live max fuel display fields when UpdateLiveDisplay is called
- add a Set live control for the max fuel override to apply live tank detection when available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e11898b3c832fbc2928bfa438042f)