### PR TITLE
Add automatic track condition switching with manual override

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -259,6 +259,7 @@
                                     <RadioButton Content="Dry" IsChecked="{Binding IsDry, Mode=TwoWay}" GroupName="TrackCondition"/>
                                     <RadioButton Content="Wet" IsChecked="{Binding IsWet, Mode=TwoWay}" GroupName="TrackCondition" Margin="10,0,0,0"/>
                                 </StackPanel>
+                                <TextBlock Text="{Binding TrackConditionModeLabel}" Style="{StaticResource UnitHint}" Margin="2,2,0,0" />
                                 <ui:TitledSlider Title="Wet Factor (%):" Minimum="70" Maximum="130" Value="{Binding WetFactorPercent, Mode=TwoWay}" Visibility="{Binding IsWet, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" Margin="0,5,0,0"/>
                                 <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Visibility="{Binding IsWet, Converter={StaticResource BooleanToVisibilityConverter}}">
                                     <TextBlock Text="{Binding SourceWetFactorDisplay}" Style="{StaticResource UnitHint}" VerticalAlignment="Center" Visibility="{Binding HasSourceWetFactor, Converter={StaticResource BooleanToVisibilityConverter}}"/>

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -542,6 +542,8 @@ namespace LaunchPlugin
             _latchedIncidentReason = null;
             _lastPitLaneSeenUtc = DateTime.MinValue;
 
+            FuelCalculator?.ResetTrackConditionOverrideForSessionChange();
+
             // Clear pace tracking alongside fuel model resets so session transitions don't carry stale data
             _recentLapTimes.Clear();
             _recentLeaderLapTimes.Clear();


### PR DESCRIPTION
## Summary
- add telemetry-driven automatic track condition switching with explicit manual override state
- reset the override when car, track, or session changes and surface the active mode in the Fuel tab UI
- ensure calculations stay aligned with the active track condition while showing helper text

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e164a67c0832f95715ade448702a4)