### PR TITLE
Decouple profile saves from apply and track fuel planner changes

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -586,13 +586,24 @@
 
                     </StackPanel>
                     </Grid>
-                    <styles:SHButtonPrimary
-                    Content="Save All to Profile" 
-                    Command="{Binding SavePlannerDataToProfileCommand}" 
-                    Padding="8,2" 
-                    HorizontalAlignment="Left" 
-                    Margin="0,10,0,0" 
-                    ToolTip="Save the current Race and Strategy parameters to the selected car/track profile."/>
+                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                        <styles:SHButtonPrimary
+                            Content="Save All to Profile"
+                            Command="{Binding SavePlannerDataToProfileCommand}"
+                            Padding="8,2"
+                            HorizontalAlignment="Left"
+                            ToolTip="Save the current Race and Strategy parameters to the selected car/track profile."/>
+                        <TextBlock Text="(modified)"
+                                   Foreground="Yellow"
+                                   Margin="10,0,0,0"
+                                   VerticalAlignment="Center"
+                                   FontStyle="Italic" Opacity="0.8">
+                            <TextBlock.Visibility>
+                               <Binding Path="IsPlannerDirty"
+                                 Converter="{StaticResource BooleanToVisibilityConverter}"/>
+                            </TextBlock.Visibility>
+                        </TextBlock>
+                    </StackPanel>
                 </StackPanel>
             </styles:SHSection>
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -2182,6 +2182,8 @@ namespace LaunchPlugin
             // Optionally discard only if you really want to delete last file on exit
             // _telemetryTraceLogger?.DiscardCurrentTrace();
 
+            FuelCalculator?.PromptToSaveLiveFuelOnExit();
+
             // Persist settings
             this.SaveCommonSettings("GlobalSettings_V2", Settings);
             ProfilesViewModel.SaveProfiles();

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -631,27 +631,6 @@ namespace LaunchPlugin
                 string json = Newtonsoft.Json.JsonConvert.SerializeObject(CarProfiles, Newtonsoft.Json.Formatting.Indented);
                 File.WriteAllText(_profilesFilePath, json);
                 SimHub.Logging.Current.Info("[Profiles] All car profiles saved to JSON file.");
-
-                if (SelectedProfile != null)
-                {
-                    string activeCar = _getCurrentCarModel();
-                    string selectedName = SelectedProfile.ProfileName;
-
-                    // --- MODIFIED LOGIC ---
-                    // Condition to auto-apply:
-                    // 1. The profile being saved is the same as the active car.
-                    // OR
-                    // 2. There is no active car, AND the profile being saved is the "Default Settings" profile.
-                    bool isActiveCarMatch = selectedName.Equals(activeCar, StringComparison.OrdinalIgnoreCase);
-                    bool isEditingDefaultsWithNoCar = (activeCar == "Unknown" || string.IsNullOrEmpty(activeCar))
-                                                      && selectedName.Equals("Default Settings", StringComparison.OrdinalIgnoreCase);
-
-                    if (SelectedProfile != null)
-                    {
-                        _applyProfileToLiveAction(SelectedProfile);
-                        SimHub.Logging.Current.Info($"[Profiles] Saved profile '{selectedName}' changes applied to live session.");
-                    }
-                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- remove the implicit apply logic from profile saves so only the explicit Apply to Live action changes the active profile
- add planner dirty tracking in FuelCalcs with a Save All to Profile modified indicator and reset handling on save/load
- prompt on shutdown to persist higher-quality live fuel data back to the active profile when available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e182c4158832fbfa508e1be7ea86e)