### PR TITLE
Add refresh action for fuel planner

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -588,6 +588,13 @@
                     </Grid>
                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                         <styles:SHButtonPrimary
+                            Content="Refresh"
+                            Command="{Binding RefreshPlannerViewCommand}"
+                            Padding="8,2"
+                            Margin="0,0,10,0"
+                            HorizontalAlignment="Left"
+                            ToolTip="Reload the planner from the active profile and live session without clearing live samples."/>
+                        <styles:SHButtonPrimary
                             Content="Save All to Profile"
                             Command="{Binding SavePlannerDataToProfileCommand}"
                             Padding="8,2"


### PR DESCRIPTION
## Summary
- add a Refresh button next to Save All to Profile on the Fuel tab
- implement a RefreshPlannerView command that reloads profile/track data, reapplies current context, and recalculates strategy without clearing live samples
- keep the planner UI in sync with the active profile and live data sources during manual refreshes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1b69fc54832fb1c84355e47516a0)