### PR TITLE
Add helper showing active Fuel tab preset on Presets tab

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -607,6 +607,8 @@ namespace LaunchPlugin
         get { return _selectedPreset != null; }
     }
 
+    public RacePreset AppliedPreset => _appliedPreset;
+
     // Last applied preset (for badge + modified flag)
     private RacePreset _appliedPreset;
 
@@ -730,6 +732,7 @@ namespace LaunchPlugin
 
     private void RaisePresetStateChanged()
     {
+        OnPropertyChanged(nameof(AppliedPreset));
         OnPropertyChanged(nameof(PresetBadge));
         OnPropertyChanged(nameof(IsPresetModifiedFlag));
     }

--- a/PresetsManagerView.xaml
+++ b/PresetsManagerView.xaml
@@ -105,6 +105,25 @@
                         <TextBlock Grid.Column="0" Text="Preset Name:" VerticalAlignment="Center" FontWeight="Bold"/>
                         <TextBox Grid.Column="1"
                      Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBlock Grid.Column="2"
+                                   Text="{Binding ActivePresetHelperText, ElementName=Root}"
+                                   VerticalAlignment="Center"
+                                   FontStyle="Italic"
+                                   Foreground="#888">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="FontStyle" Value="Italic"/>
+                                    <Setter Property="Foreground" Value="#888"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsEditingActivePreset, ElementName=Root}" Value="True">
+                                            <Setter Property="FontStyle" Value="Normal"/>
+                                            <Setter Property="FontWeight" Value="Bold"/>
+                                            <Setter Property="Foreground" Value="#28A745"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                     </Grid>
 
                     <!-- Race Type -->


### PR DESCRIPTION
## Summary
- expose the applied preset from FuelCalcs so UI bindings can show the active template
- add Presets tab helper text indicating which preset is active on the Fuel tab
- style the helper to highlight when the edited preset matches the active fuel preset

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e34f7f338832fa3eeb550e98c459d)