### PR TITLE
Ensure lap time follows planning source selection

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -298,6 +298,7 @@ namespace LaunchPlugin
 
             // When the user changes the global planning source,
             // drop any manual overrides so the new source fully takes over.
+            IsEstimatedLapTimeManual = false;
             IsFuelPerLapManual = false;
 
             // Auto-expand/collapse the Live Session telemetry panel based on planning source.
@@ -310,7 +311,7 @@ namespace LaunchPlugin
                 IsLiveSessionSnapshotExpanded = false;
             }
 
-            ApplyPlanningSourceToAutoFields(applyLapTime: false, applyFuel: true);
+            ApplyPlanningSourceToAutoFields(applyLapTime: true, applyFuel: true);
 
             if (value == PlanningSourceMode.Profile)
             {
@@ -2797,13 +2798,12 @@ namespace LaunchPlugin
         OnPropertyChanged(nameof(AvgDeltaToPbValue));
         UpdateTrackDerivedSummaries();
 
-        if (IsLiveSessionActive
-        && IsLiveLapPaceAvailable
-        && !IsEstimatedLapTimeManual
-        && SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
-            {
-            UseLiveLapPace();
-            }
+        if (IsLiveLapPaceAvailable
+            && !IsEstimatedLapTimeManual
+            && SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
+        {
+            ApplyPlanningSourceToAutoFields(applyLapTime: true, applyFuel: false);
+        }
     }
 
     public void SetLiveConfidenceLevels(int fuelConfidence, int paceConfidence, int overallConfidence)


### PR DESCRIPTION
## Summary
- refresh both lap time and fuel when switching planning source, clearing manual lap overrides
- load average lap time from profile or live snapshots immediately with proper source labels
- keep live average lap time synced in real time when using live planning source

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e49a0b500832fbea5d25115bbb1b5)