### PR TITLE
Add Fuel.Live.TotalStopLoss SimHub property

### DIFF
--- a/Docs/PitSimHubProperties.md
+++ b/Docs/PitSimHubProperties.md
@@ -72,6 +72,7 @@ The plugin exposes a mix of pit-lane timing, loss calculations, PitLite telemetr
 | `Fuel.Pit.DeltaAfterStop` | Core | Laps delta after refuel (`FuelOnExit/LapsPerLap - lapsRemaining`). | Driver strategy. |
 | `Fuel.Pit.FuelOnExit` | Core | Estimated fuel after stop. | Driver strategy. |
 | `Fuel.Pit.StopsRequiredToEnd` | Core | Integer stops needed to finish. | Driver strategy. |
+| `Fuel.Live.TotalStopLoss` | Core | Pit lane loss plus concurrent box time from fuel/tyre selections. | Driver strategy. |
 | `Fuel.IsPitWindowOpen` | Core | Boolean pit window flag. | Driver strategy. |
 | `Fuel.PitWindowOpeningLap` | Core | Lap when pit window opens. | Driver strategy. |
 | `Fuel.LastPitLaneTravelTime` | Core | Alias noted above; also fuels consumption model. | Driver strategy. |

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -26,8 +26,9 @@ This document maps every custom SimHub-exported parameter defined in `LalaLaunch
 | Fuel.Pit.FuelOnExit | double | Liters | 500 ms fuel update | Predicted post-stop fuel | Pit/fuel |
 | Fuel.Pit.StopsRequiredToEnd | int | Count | 500 ms fuel update | FuelCalcs | Pit/fuel |
 | Fuel.Live.RefuelRate_Lps | double | Liters/sec | Per-tick | FuelCalcs effective refuel rate (profile or default) | Fuel strategy |
-| Fuel.Live.TireChangeTime_S | double | Seconds | Per-tick | FuelCalcs tyre change time currently used | Fuel strategy |
+| Fuel.Live.TireChangeTime_S | double | Seconds | Per-tick | FuelCalcs tyre change time currently used (0 if no tyre change selected) | Fuel strategy |
 | Fuel.Live.PitLaneLoss_S | double | Seconds | Per-tick | FuelCalcs pit lane loss (DTL) currently used | Fuel strategy |
+| Fuel.Live.TotalStopLoss | double | Seconds | Per-tick | Pit lane loss plus concurrent box time (fuel vs. tyres) | Fuel strategy |
 | Pace.StintAvgLapTimeSec | double | Seconds | 500 ms update | Rolling stint average from live laps | Pace |
 | Pace.Last5LapAvgSec | double | Seconds | 500 ms update | Rolling 5-lap average | Pace |
 | Pace.PaceConfidence | int | Score | 500 ms update | Internal confidence heuristics | Pace |


### PR DESCRIPTION
## Summary
- compute a live total stop loss property that combines pit-lane loss with concurrent fuel and tyre box timing
- gate fuel addition and tyre change timing on pit selections to avoid stale values and expose the effective tyre time
- document the new SimHub property and selection-aware tyre timing

## Testing
- Not run (dotnet not installed in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a6952b38832f89fe74310e58dae9)