### PR TITLE
Add drive-time fuel projections and push/save deltas

### DIFF
--- a/Docs/PitSimHubProperties.md
+++ b/Docs/PitSimHubProperties.md
@@ -70,9 +70,14 @@ The plugin exposes a mix of pit-lane timing, loss calculations, PitLite telemetr
 | `Fuel.Pit.TankSpaceAvailable` | Core | Max fuel that fits given tank size. | Driver strategy. |
 | `Fuel.Pit.WillAdd` | Core | Planned fuel to add this stop. | Driver strategy. |
 | `Fuel.Pit.DeltaAfterStop` | Core | Laps delta after refuel (`FuelOnExit/LapsPerLap - lapsRemaining`). | Driver strategy. |
+| `Fuel.Pit.FuelSaveDeltaAfterStop` | Core | Laps delta after refuel using low-burn profile. | Driver strategy. |
+| `Fuel.Pit.PushDeltaAfterStop` | Core | Laps delta after refuel using push/max-burn profile. | Driver strategy. |
 | `Fuel.Pit.FuelOnExit` | Core | Estimated fuel after stop. | Driver strategy. |
 | `Fuel.Pit.StopsRequiredToEnd` | Core | Integer stops needed to finish. | Driver strategy. |
+| `Fuel.FuelSavePerLap` | Core | Current low-burn per-lap estimate. | Driver strategy. |
 | `Fuel.Live.TotalStopLoss` | Core | Pit lane loss plus concurrent box time from fuel/tyre selections. | Driver strategy. |
+| `Fuel.Live.DriveTimeAfterZero` | Core | Projected driving time once the race clock reaches 0. | Driver strategy. |
+| `Fuel.Live.ProjectedDriveSecondsRemaining` | Core | Projected wall time remaining including after-zero driving. | Driver strategy. |
 | `Fuel.IsPitWindowOpen` | Core | Boolean pit window flag. | Driver strategy. |
 | `Fuel.PitWindowOpeningLap` | Core | Lap when pit window opens. | Driver strategy. |
 | `Fuel.LastPitLaneTravelTime` | Core | Alias noted above; also fuels consumption model. | Driver strategy. |

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -16,6 +16,7 @@ This document maps every custom SimHub-exported parameter defined in `LalaLaunch
 | Fuel.LapsRemainingInTank | double | Laps | 500 ms fuel update | FuelCalcs | Fuel strategy |
 | Fuel.Confidence | int | Score | 500 ms fuel update | FuelCalcs confidence logic | Fuel strategy |
 | Fuel.PushFuelPerLap | double | L/lap | 500 ms fuel update | Live rolling max fuel | Fuel strategy |
+| Fuel.FuelSavePerLap | double | L/lap | 500 ms fuel update | Rolling min/low-burn estimate | Fuel strategy |
 | Fuel.DeltaLapsIfPush | double | Laps | 500 ms fuel update | Push fuel vs. target | Fuel strategy |
 | Fuel.CanAffordToPush | bool | Flag | 500 ms fuel update | Push analysis | Fuel strategy |
 | Fuel.Pit.TotalNeededToEnd | double | Liters | 500 ms fuel update | FuelCalcs total fill needed | Pit/fuel |
@@ -23,12 +24,16 @@ This document maps every custom SimHub-exported parameter defined in `LalaLaunch
 | Fuel.Pit.TankSpaceAvailable | double | Liters | 500 ms fuel update | Live fuel level vs. max | Pit/fuel |
 | Fuel.Pit.WillAdd | double | Liters | 500 ms fuel update | Clamped planned add | Pit/fuel |
 | Fuel.Pit.DeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop lap delta | Pit/fuel |
+| Fuel.Pit.FuelSaveDeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop lap delta using low-burn rate | Pit/fuel |
+| Fuel.Pit.PushDeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop lap delta using push rate | Pit/fuel |
 | Fuel.Pit.FuelOnExit | double | Liters | 500 ms fuel update | Predicted post-stop fuel | Pit/fuel |
 | Fuel.Pit.StopsRequiredToEnd | int | Count | 500 ms fuel update | FuelCalcs | Pit/fuel |
 | Fuel.Live.RefuelRate_Lps | double | Liters/sec | Per-tick | FuelCalcs effective refuel rate (profile or default) | Fuel strategy |
 | Fuel.Live.TireChangeTime_S | double | Seconds | Per-tick | FuelCalcs tyre change time currently used (0 if no tyre change selected) | Fuel strategy |
 | Fuel.Live.PitLaneLoss_S | double | Seconds | Per-tick | FuelCalcs pit lane loss (DTL) currently used | Fuel strategy |
 | Fuel.Live.TotalStopLoss | double | Seconds | Per-tick | Pit lane loss plus concurrent box time (fuel vs. tyres) | Fuel strategy |
+| Fuel.Live.DriveTimeAfterZero | double | Seconds | 500 ms fuel update | Projected driving time once race clock hits zero | Fuel strategy |
+| Fuel.Live.ProjectedDriveSecondsRemaining | double | Seconds | 500 ms fuel update | Projected wall time remaining including overrun | Fuel strategy |
 | Pace.StintAvgLapTimeSec | double | Seconds | 500 ms update | Rolling stint average from live laps | Pace |
 | Pace.Last5LapAvgSec | double | Seconds | 500 ms update | Rolling 5-lap average | Pace |
 | Pace.PaceConfidence | int | Score | 500 ms update | Internal confidence heuristics | Pace |

--- a/FuelProjectionMath.cs
+++ b/FuelProjectionMath.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+
+namespace LaunchPlugin
+{
+    internal static class FuelProjectionMath
+    {
+        public static double EstimateDriveTimeAfterZero(
+            double sessionTime,
+            double sessionTimeRemain,
+            double lapSeconds,
+            double strategyProjection,
+            bool timerZeroSeen,
+            double timerZeroSessionTime)
+        {
+            double observedAfterZero = (!double.IsNaN(sessionTimeRemain) && sessionTimeRemain < 0.0)
+                ? Math.Abs(sessionTimeRemain)
+                : 0.0;
+
+            if (timerZeroSeen && !double.IsNaN(timerZeroSessionTime) && sessionTime > timerZeroSessionTime)
+            {
+                observedAfterZero = Math.Max(observedAfterZero, sessionTime - timerZeroSessionTime);
+            }
+
+            double lapBasedProjection = (lapSeconds > 0.0) ? lapSeconds : 0.0;
+
+            double projected = Math.Max(observedAfterZero, strategyProjection);
+            projected = Math.Max(projected, lapBasedProjection);
+
+            return projected;
+        }
+
+        public static double ProjectLapsRemaining(
+            double lapSeconds,
+            double sessionTimeRemain,
+            double driveTimeAfterZero,
+            double simLapsRemaining,
+            out double projectedSecondsRemaining)
+        {
+            double timePortion = (!double.IsNaN(sessionTimeRemain) && sessionTimeRemain > 0.0)
+                ? sessionTimeRemain
+                : 0.0;
+
+            projectedSecondsRemaining = timePortion + Math.Max(0.0, driveTimeAfterZero);
+
+            if (lapSeconds > 0.0 && projectedSecondsRemaining > 0.0)
+            {
+                double projectedLaps = projectedSecondsRemaining / lapSeconds;
+                if (projectedLaps > 0.0)
+                {
+                    return projectedLaps;
+                }
+            }
+
+            return simLapsRemaining;
+        }
+
+#if DEBUG
+        public static void RunSelfTests()
+        {
+            double projectedSeconds;
+
+            double laps = ProjectLapsRemaining(60.0, 120.0, 60.0, 0.0, out projectedSeconds);
+            Debug.Assert(Math.Abs(laps - 3.0) < 0.001, "Timed race projection should include after-zero lap");
+            Debug.Assert(Math.Abs(projectedSeconds - 180.0) < 0.001, "Projected seconds should include extra drive time");
+
+            double lapsFallback = ProjectLapsRemaining(0.0, double.NaN, 0.0, 5.0, out projectedSeconds);
+            Debug.Assert(Math.Abs(lapsFallback - 5.0) < 0.001, "Projection should fall back to sim laps when pace missing");
+
+            double projectedAfterZero = EstimateDriveTimeAfterZero(1810.0, -12.0, 90.0, 0.0, true, 1800.0);
+            Debug.Assert(Math.Abs(projectedAfterZero - 12.0) < 0.001, "Observed post-zero time should be honoured");
+
+            double lapBasedAfterZero = EstimateDriveTimeAfterZero(0.0, 50.0, 100.0, 0.0, false, double.NaN);
+            Debug.Assert(Math.Abs(lapBasedAfterZero - 100.0) < 0.001, "Lap-based projection should be used before timer zero");
+        }
+#endif
+    }
+}

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -235,10 +235,17 @@ namespace LaunchPlugin
         public double Pit_WillAdd { get; private set; }
         public double Pit_DeltaAfterStop { get; private set; }
         public double Pit_FuelOnExit { get; private set; }
+        public double Pit_FuelSaveDeltaAfterStop { get; private set; }
+        public double Pit_PushDeltaAfterStop { get; private set; }
         public int Pit_StopsRequiredToEnd { get; private set; }
         private bool _isRefuelSelected = true;
         private bool _isTireChangeSelected = true;
         public double LiveCarMaxFuel { get; private set; }
+
+        public double FuelSaveFuelPerLap { get; private set; }
+
+        public double LiveProjectedDriveTimeAfterZero { get; private set; }
+        public double LiveProjectedDriveSecondsRemaining { get; private set; }
 
         // Push / max-burn guidance
         public double PushFuelPerLap { get; private set; }
@@ -261,6 +268,8 @@ namespace LaunchPlugin
         private DateTime _lastPitLossSavedAtUtc = DateTime.MinValue;
         private string _lastPitLossSource = "";
         private DateTime _lastPitLaneSeenUtc = DateTime.MinValue;
+        private double _lastLoggedProjectedLaps = double.NaN;
+        private DateTime _lastProjectionLogUtc = DateTime.MinValue;
 
         // --- Stint / Pace tracking ---
         public double Pace_StintAvgLapTimeSec { get; private set; }
@@ -1574,11 +1583,17 @@ namespace LaunchPlugin
                 Pit_WillAdd = 0;
                 Pit_FuelOnExit = 0;
                 Pit_DeltaAfterStop = 0;
+                Pit_FuelSaveDeltaAfterStop = 0;
+                Pit_PushDeltaAfterStop = 0;
                 Pit_StopsRequiredToEnd = 0;
 
                 PushFuelPerLap = 0;
                 DeltaLapsIfPush = 0;
                 CanAffordToPush = false;
+
+                FuelSaveFuelPerLap = 0;
+                LiveProjectedDriveTimeAfterZero = 0;
+                LiveProjectedDriveSecondsRemaining = 0;
 
                 Pace_StintAvgLapTimeSec = 0.0;
                 Pace_Last5LapAvgSec = 0.0;
@@ -1586,14 +1601,39 @@ namespace LaunchPlugin
                 PaceConfidence = 0;
                 FuelCalculator?.SetLiveLapPaceEstimate(0, 0);
                 FuelCalculator?.SetLiveConfidenceLevels(Confidence, PaceConfidence, OverallConfidence);
+                FuelCalculator?.SetLiveDriveTimeAfterZero(0.0);
             }
             else
             {
                 LapsRemainingInTank = currentFuel / LiveFuelPerLap;
 
-                LiveLapsRemainingInRace = Convert.ToDouble(
+                double simLapsRemaining = Convert.ToDouble(
                     PluginManager.GetPropertyValue("IRacingExtraProperties.iRacing_LapsRemainingFloat") ?? 0.0
                 );
+
+                bool isTimedRace = !double.IsNaN(sessionTimeRemain);
+                double projectionLapSeconds = GetProjectionLapSeconds(data);
+                double projectedDriveAfterZero = ComputeDriveTimeAfterZeroProjection(
+                    sessionTime,
+                    sessionTimeRemain,
+                    isTimedRace ? projectionLapSeconds : 0.0);
+                LiveProjectedDriveTimeAfterZero = projectedDriveAfterZero;
+                FuelCalculator?.SetLiveDriveTimeAfterZero(LiveProjectedDriveTimeAfterZero);
+                double projectedLapsRemaining = ComputeProjectedLapsRemaining(simLapsRemaining, projectionLapSeconds, sessionTimeRemain, projectedDriveAfterZero);
+
+                if (projectedLapsRemaining > 0.0)
+                {
+                    LiveLapsRemainingInRace = projectedLapsRemaining;
+
+                    if (ShouldLogProjection(simLapsRemaining, projectedLapsRemaining))
+                    {
+                        LogProjectionDifference(simLapsRemaining, projectedLapsRemaining, projectionLapSeconds);
+                    }
+                }
+                else
+                {
+                    LiveLapsRemainingInRace = simLapsRemaining;
+                }
 
                 double fuelNeededToEnd = LiveLapsRemainingInRace * LiveFuelPerLap;
                 DeltaLaps = LapsRemainingInTank - LiveLapsRemainingInRace;
@@ -1646,8 +1686,21 @@ namespace LaunchPlugin
                 Pit_WillAdd = Math.Min(safeFuelRequest, Pit_TankSpaceAvailable);
 
                 Pit_FuelOnExit = currentFuel + Pit_WillAdd;
+                bool isWetModeNow = FuelCalculator?.IsWet ?? false;
+                double fuelSaveRate = isWetModeNow ? _minWetFuelPerLap : _minDryFuelPerLap;
+                if (fuelSaveRate <= 0.0 && LiveFuelPerLap > 0.0)
+                {
+                    fuelSaveRate = LiveFuelPerLap * 0.97; // light saving fallback
+                }
+
+                FuelSaveFuelPerLap = fuelSaveRate;
+
                 Pit_DeltaAfterStop = (LiveFuelPerLap > 0)
                     ? (Pit_FuelOnExit / LiveFuelPerLap) - LiveLapsRemainingInRace
+                    : 0;
+
+                Pit_FuelSaveDeltaAfterStop = (fuelSaveRate > 0)
+                    ? (Pit_FuelOnExit / fuelSaveRate) - LiveLapsRemainingInRace
                     : 0;
 
                 // Pit window logic
@@ -1701,11 +1754,16 @@ namespace LaunchPlugin
                     double lapsRemainingIfPush = currentFuel / pushFuel;
                     DeltaLapsIfPush = lapsRemainingIfPush - LiveLapsRemainingInRace;
                     CanAffordToPush = DeltaLapsIfPush >= 0.0;
+
+                    Pit_PushDeltaAfterStop = (Pit_FuelOnExit > 0.0)
+                        ? (Pit_FuelOnExit / pushFuel) - LiveLapsRemainingInRace
+                        : 0.0;
                 }
                 else
                 {
                     DeltaLapsIfPush = 0.0;
                     CanAffordToPush = false;
+                    Pit_PushDeltaAfterStop = 0.0;
                 }
             }
 
@@ -1964,6 +2022,9 @@ namespace LaunchPlugin
             // --- INITIALIZATION ---
             this.PluginManager = pluginManager;
             Settings = this.ReadCommonSettings<LaunchPluginSettings>("GlobalSettings_V2", () => new LaunchPluginSettings());
+#if DEBUG
+            FuelProjectionMath.RunSelfTests();
+#endif
             // The Action for "Apply to Live" in the Profiles tab is now simplified: just update the ActiveProfile
             ProfilesViewModel = new ProfilesManagerViewModel(
                 this.PluginManager,
@@ -2013,6 +2074,7 @@ namespace LaunchPlugin
             AttachCore("Fuel.LapsRemainingInTank", () => LapsRemainingInTank);
             AttachCore("Fuel.Confidence", () => Confidence);
             AttachCore("Fuel.PushFuelPerLap", () => PushFuelPerLap);
+            AttachCore("Fuel.FuelSavePerLap", () => FuelSaveFuelPerLap);
             AttachCore("Fuel.DeltaLapsIfPush", () => DeltaLapsIfPush);
             AttachCore("Fuel.CanAffordToPush", () => CanAffordToPush);
             AttachCore("Fuel.Pit.TotalNeededToEnd", () => Pit_TotalNeededToEnd);
@@ -2020,12 +2082,16 @@ namespace LaunchPlugin
             AttachCore("Fuel.Pit.TankSpaceAvailable", () => Pit_TankSpaceAvailable);
             AttachCore("Fuel.Pit.WillAdd", () => Pit_WillAdd);
             AttachCore("Fuel.Pit.DeltaAfterStop", () => Pit_DeltaAfterStop);
+            AttachCore("Fuel.Pit.FuelSaveDeltaAfterStop", () => Pit_FuelSaveDeltaAfterStop);
+            AttachCore("Fuel.Pit.PushDeltaAfterStop", () => Pit_PushDeltaAfterStop);
             AttachCore("Fuel.Pit.FuelOnExit", () => Pit_FuelOnExit);
             AttachCore("Fuel.Pit.StopsRequiredToEnd", () => Pit_StopsRequiredToEnd);
             AttachCore("Fuel.Live.RefuelRate_Lps", () => FuelCalculator?.EffectiveRefuelRateLps ?? 0.0);
             AttachCore("Fuel.Live.TireChangeTime_S", () => GetEffectiveTireChangeTimeSeconds());
             AttachCore("Fuel.Live.PitLaneLoss_S", () => FuelCalculator?.PitLaneTimeLoss ?? 0.0);
             AttachCore("Fuel.Live.TotalStopLoss", () => CalculateTotalStopLossSeconds());
+            AttachCore("Fuel.Live.DriveTimeAfterZero", () => LiveProjectedDriveTimeAfterZero);
+            AttachCore("Fuel.Live.ProjectedDriveSecondsRemaining", () => LiveProjectedDriveSecondsRemaining);
 
             // --- Pace metrics (CORE) ---
             AttachCore("Pace.StintAvgLapTimeSec", () => Pace_StintAvgLapTimeSec);
@@ -3044,6 +3110,77 @@ namespace LaunchPlugin
             return (double.IsNaN(seconds) || double.IsInfinity(seconds))
                 ? "n/a"
                 : seconds.ToString("F1", CultureInfo.InvariantCulture);
+        }
+
+        private double GetProjectionLapSeconds(GameData data)
+        {
+            if (Pace_StintAvgLapTimeSec > 0.0)
+                return Pace_StintAvgLapTimeSec;
+
+            if (Pace_Last5LapAvgSec > 0.0)
+                return Pace_Last5LapAvgSec;
+
+            double lastLapSeconds = (data.NewData?.LastLapTime ?? TimeSpan.Zero).TotalSeconds;
+            if (lastLapSeconds > 0.0)
+                return lastLapSeconds;
+
+            string estimatedLap = FuelCalculator?.EstimatedLapTime ?? string.Empty;
+            if (TimeSpan.TryParse(estimatedLap, out var ts) && ts.TotalSeconds > 0.0)
+                return ts.TotalSeconds;
+
+            return 0.0;
+        }
+
+        private double ComputeDriveTimeAfterZeroProjection(double sessionTime, double sessionTimeRemain, double lapSeconds)
+        {
+            double strategyProjection = FuelCalculator?.StrategyDriverExtraSecondsAfterZero ?? 0.0;
+
+            return FuelProjectionMath.EstimateDriveTimeAfterZero(
+                sessionTime,
+                sessionTimeRemain,
+                lapSeconds,
+                strategyProjection,
+                _timerZeroSeen,
+                _timerZeroSessionTime);
+        }
+
+        private double ComputeProjectedLapsRemaining(double simLapsRemaining, double lapSeconds, double sessionTimeRemain, double driveTimeAfterZero)
+        {
+            double projectedSeconds;
+            double projectedLaps = FuelProjectionMath.ProjectLapsRemaining(
+                lapSeconds,
+                sessionTimeRemain,
+                driveTimeAfterZero,
+                simLapsRemaining,
+                out projectedSeconds);
+
+            LiveProjectedDriveSecondsRemaining = projectedSeconds;
+            return projectedLaps;
+        }
+
+        private bool ShouldLogProjection(double simLapsRemaining, double projectedLapsRemaining)
+        {
+            double diff = Math.Abs(projectedLapsRemaining - simLapsRemaining);
+            if (diff < 0.25)
+                return false;
+
+            if ((DateTime.UtcNow - _lastProjectionLogUtc) < TimeSpan.FromSeconds(20))
+                return false;
+
+            if (!double.IsNaN(_lastLoggedProjectedLaps) && Math.Abs(projectedLapsRemaining - _lastLoggedProjectedLaps) < 0.25)
+                return false;
+
+            return true;
+        }
+
+        private void LogProjectionDifference(double simLapsRemaining, double projectedLapsRemaining, double lapSeconds)
+        {
+            _lastProjectionLogUtc = DateTime.UtcNow;
+            _lastLoggedProjectedLaps = projectedLapsRemaining;
+
+            SimHub.Logging.Current.Info(
+                $"[FuelProjection] using drive-time projection laps={projectedLapsRemaining:F2} (sim={simLapsRemaining:F2}, lap={lapSeconds:F2}s, after0={LiveProjectedDriveTimeAfterZero:F1}s)"
+            );
         }
 
         private double ComputeObservedExtraSeconds(double finishSessionTime, double sessionTimeRemain)

--- a/LaunchPlugin.csproj
+++ b/LaunchPlugin.csproj
@@ -99,6 +99,7 @@
     </Compile>
     <Compile Include="EnumEqualsConverter.cs" />
     <Compile Include="FuelCalcs.cs" />
+    <Compile Include="FuelProjectionMath.cs" />
     <Compile Include="FuelCalculatorView.xaml.cs">
       <DependentUpon>FuelCalculatorView.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Summary
- add drive-time-after-zero projection feeding live laps remaining, pit window, and strategy calculations
- expose fuel-save and push deltas with corresponding burn-rate signals for dashboards
- add reusable projection math helper with debug self-tests and document the new SimHub properties

## Testing
- Not run (not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4b5e96bc832f9cad0cd4baa0fff7)