### PR TITLE
Fix session time handling in fuel calculations

### DIFF
--- a/Docs/PitSimHubProperties.md
+++ b/Docs/PitSimHubProperties.md
@@ -70,9 +70,14 @@ The plugin exposes a mix of pit-lane timing, loss calculations, PitLite telemetr
 | `Fuel.Pit.TankSpaceAvailable` | Core | Max fuel that fits given tank size. | Driver strategy. |
 | `Fuel.Pit.WillAdd` | Core | Planned fuel to add this stop. | Driver strategy. |
 | `Fuel.Pit.DeltaAfterStop` | Core | Laps delta after refuel (`FuelOnExit/LapsPerLap - lapsRemaining`). | Driver strategy. |
+| `Fuel.Pit.FuelSaveDeltaAfterStop` | Core | Laps delta after refuel using low-burn profile. | Driver strategy. |
+| `Fuel.Pit.PushDeltaAfterStop` | Core | Laps delta after refuel using push/max-burn profile. | Driver strategy. |
 | `Fuel.Pit.FuelOnExit` | Core | Estimated fuel after stop. | Driver strategy. |
 | `Fuel.Pit.StopsRequiredToEnd` | Core | Integer stops needed to finish. | Driver strategy. |
+| `Fuel.FuelSavePerLap` | Core | Current low-burn per-lap estimate. | Driver strategy. |
 | `Fuel.Live.TotalStopLoss` | Core | Pit lane loss plus concurrent box time from fuel/tyre selections. | Driver strategy. |
+| `Fuel.Live.DriveTimeAfterZero` | Core | Projected driving time once the race clock reaches 0. | Driver strategy. |
+| `Fuel.Live.ProjectedDriveSecondsRemaining` | Core | Projected wall time remaining including after-zero driving. | Driver strategy. |
 | `Fuel.IsPitWindowOpen` | Core | Boolean pit window flag. | Driver strategy. |
 | `Fuel.PitWindowOpeningLap` | Core | Lap when pit window opens. | Driver strategy. |
 | `Fuel.LastPitLaneTravelTime` | Core | Alias noted above; also fuels consumption model. | Driver strategy. |

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -16,6 +16,7 @@ This document maps every custom SimHub-exported parameter defined in `LalaLaunch
 | Fuel.LapsRemainingInTank | double | Laps | 500 ms fuel update | FuelCalcs | Fuel strategy |
 | Fuel.Confidence | int | Score | 500 ms fuel update | FuelCalcs confidence logic | Fuel strategy |
 | Fuel.PushFuelPerLap | double | L/lap | 500 ms fuel update | Live rolling max fuel | Fuel strategy |
+| Fuel.FuelSavePerLap | double | L/lap | 500 ms fuel update | Rolling min/low-burn estimate | Fuel strategy |
 | Fuel.DeltaLapsIfPush | double | Laps | 500 ms fuel update | Push fuel vs. target | Fuel strategy |
 | Fuel.CanAffordToPush | bool | Flag | 500 ms fuel update | Push analysis | Fuel strategy |
 | Fuel.Pit.TotalNeededToEnd | double | Liters | 500 ms fuel update | FuelCalcs total fill needed | Pit/fuel |
@@ -23,12 +24,16 @@ This document maps every custom SimHub-exported parameter defined in `LalaLaunch
 | Fuel.Pit.TankSpaceAvailable | double | Liters | 500 ms fuel update | Live fuel level vs. max | Pit/fuel |
 | Fuel.Pit.WillAdd | double | Liters | 500 ms fuel update | Clamped planned add | Pit/fuel |
 | Fuel.Pit.DeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop lap delta | Pit/fuel |
+| Fuel.Pit.FuelSaveDeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop lap delta using low-burn rate | Pit/fuel |
+| Fuel.Pit.PushDeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop lap delta using push rate | Pit/fuel |
 | Fuel.Pit.FuelOnExit | double | Liters | 500 ms fuel update | Predicted post-stop fuel | Pit/fuel |
 | Fuel.Pit.StopsRequiredToEnd | int | Count | 500 ms fuel update | FuelCalcs | Pit/fuel |
 | Fuel.Live.RefuelRate_Lps | double | Liters/sec | Per-tick | FuelCalcs effective refuel rate (profile or default) | Fuel strategy |
 | Fuel.Live.TireChangeTime_S | double | Seconds | Per-tick | FuelCalcs tyre change time currently used (0 if no tyre change selected) | Fuel strategy |
 | Fuel.Live.PitLaneLoss_S | double | Seconds | Per-tick | FuelCalcs pit lane loss (DTL) currently used | Fuel strategy |
 | Fuel.Live.TotalStopLoss | double | Seconds | Per-tick | Pit lane loss plus concurrent box time (fuel vs. tyres) | Fuel strategy |
+| Fuel.Live.DriveTimeAfterZero | double | Seconds | 500 ms fuel update | Projected driving time once race clock hits zero | Fuel strategy |
+| Fuel.Live.ProjectedDriveSecondsRemaining | double | Seconds | 500 ms fuel update | Projected wall time remaining including overrun | Fuel strategy |
 | Pace.StintAvgLapTimeSec | double | Seconds | 500 ms update | Rolling stint average from live laps | Pace |
 | Pace.Last5LapAvgSec | double | Seconds | 500 ms update | Rolling 5-lap average | Pace |
 | Pace.PaceConfidence | int | Score | 500 ms update | Internal confidence heuristics | Pace |

--- a/FuelProjectionMath.cs
+++ b/FuelProjectionMath.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+
+namespace LaunchPlugin
+{
+    internal static class FuelProjectionMath
+    {
+        public static double EstimateDriveTimeAfterZero(
+            double sessionTime,
+            double sessionTimeRemain,
+            double lapSeconds,
+            double strategyProjection,
+            bool timerZeroSeen,
+            double timerZeroSessionTime)
+        {
+            double observedAfterZero = (!double.IsNaN(sessionTimeRemain) && sessionTimeRemain < 0.0)
+                ? Math.Abs(sessionTimeRemain)
+                : 0.0;
+
+            if (timerZeroSeen && !double.IsNaN(timerZeroSessionTime) && sessionTime > timerZeroSessionTime)
+            {
+                observedAfterZero = Math.Max(observedAfterZero, sessionTime - timerZeroSessionTime);
+            }
+
+            double lapBasedProjection = (lapSeconds > 0.0) ? lapSeconds : 0.0;
+
+            double projected = Math.Max(observedAfterZero, strategyProjection);
+            projected = Math.Max(projected, lapBasedProjection);
+
+            return projected;
+        }
+
+        public static double ProjectLapsRemaining(
+            double lapSeconds,
+            double sessionTimeRemain,
+            double driveTimeAfterZero,
+            double simLapsRemaining,
+            out double projectedSecondsRemaining)
+        {
+            double timePortion = (!double.IsNaN(sessionTimeRemain) && sessionTimeRemain > 0.0)
+                ? sessionTimeRemain
+                : 0.0;
+
+            projectedSecondsRemaining = timePortion + Math.Max(0.0, driveTimeAfterZero);
+
+            if (lapSeconds > 0.0 && projectedSecondsRemaining > 0.0)
+            {
+                double projectedLaps = projectedSecondsRemaining / lapSeconds;
+                if (projectedLaps > 0.0)
+                {
+                    return projectedLaps;
+                }
+            }
+
+            return simLapsRemaining;
+        }
+
+#if DEBUG
+        public static void RunSelfTests()
+        {
+            double projectedSeconds;
+
+            double laps = ProjectLapsRemaining(60.0, 120.0, 60.0, 0.0, out projectedSeconds);
+            Debug.Assert(Math.Abs(laps - 3.0) < 0.001, "Timed race projection should include after-zero lap");
+            Debug.Assert(Math.Abs(projectedSeconds - 180.0) < 0.001, "Projected seconds should include extra drive time");
+
+            double lapsFallback = ProjectLapsRemaining(0.0, double.NaN, 0.0, 5.0, out projectedSeconds);
+            Debug.Assert(Math.Abs(lapsFallback - 5.0) < 0.001, "Projection should fall back to sim laps when pace missing");
+
+            double projectedAfterZero = EstimateDriveTimeAfterZero(1810.0, -12.0, 90.0, 0.0, true, 1800.0);
+            Debug.Assert(Math.Abs(projectedAfterZero - 12.0) < 0.001, "Observed post-zero time should be honoured");
+
+            double lapBasedAfterZero = EstimateDriveTimeAfterZero(0.0, 50.0, 100.0, 0.0, false, double.NaN);
+            Debug.Assert(Math.Abs(lapBasedAfterZero - 100.0) < 0.001, "Lap-based projection should be used before timer zero");
+        }
+#endif
+    }
+}

--- a/LaunchPlugin.csproj
+++ b/LaunchPlugin.csproj
@@ -99,6 +99,7 @@
     </Compile>
     <Compile Include="EnumEqualsConverter.cs" />
     <Compile Include="FuelCalcs.cs" />
+    <Compile Include="FuelProjectionMath.cs" />
     <Compile Include="FuelCalculatorView.xaml.cs">
       <DependentUpon>FuelCalculatorView.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Summary
- read session time and remaining time once early in DataUpdate for shared projections
- pass session timing into live fuel calculations to support projection math
- restore finish-timing update after completed laps are known to avoid missing state

## Testing
- Not run (dotnet tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4b5e96bc832f9cad0cd4baa0fff7)