### PR TITLE
Fix finish timing latching

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3417,9 +3417,11 @@ namespace LaunchPlugin
                 "DataCorePlugin.GameData.LeaderHasFinished"
             );
 
-            bool leaderFinished = LeaderHasFinished || leaderFinishSignal;
+            bool leaderWasFinished = LeaderHasFinished;
+            LeaderHasFinished = leaderFinishSignal;
+            bool leaderFinishTransition = LeaderHasFinished && !leaderWasFinished;
 
-            if (leaderFinished && !_leaderFinishedSeen)
+            if (leaderFinishTransition && !_leaderFinishedSeen)
             {
                 _leaderFinishedSeen = true;
                 _leaderCheckeredSessionTime = sessionTime;


### PR DESCRIPTION
## Summary
- edge-latch timer zero using previous remaining time to avoid late latching
- record leader finish timing on the LeaderHasFinished transition and track driver finish normally
- reset all finish timing state including new latch helpers for race changes

## Testing
- Not run (dotnet command unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dea573af0832f9e1b0ed0242d2205)