### PR TITLE
Improve live max tank capture and split pit stop counts

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1446,7 +1446,7 @@ namespace LaunchPlugin
                     if (!reject)
                     {
                         // coarse cap: 20% of tank or 10 L, whichever is larger
-                        double maxPlausibleHard = Math.Max(10.0, 0.20 * Math.Max(maxFuel, 50.0));
+                        double maxPlausibleHard = Math.Max(10.0, 0.20 * Math.Max(effectiveMaxTank, 50.0));
                         if (fuelUsed <= 0.05)
                         {
                             reject = true;
@@ -1884,8 +1884,6 @@ namespace LaunchPlugin
                     Pit_PushDeltaAfterStop = 0.0;
                 }
 
-                double stableLapsRemaining = LiveLapsRemainingInRace_Stable;
-                double stableFuelPerLap = LiveFuelPerLap_Stable;
                 double fuelPlanExit = currentFuel + requestedAddLitres;
                 double fuelWillAddExit = currentFuel + Pit_WillAdd;
 


### PR DESCRIPTION
## Summary
- Read the max tank base and BoP percentage from `DataCorePlugin.GameData.MaxFuel` and `DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverCarMaxFuelPct` on the 250ms loop and keep a short recheck window to latch the first reliable `LiveCarMaxFuel` value with jitter guards.
- Introduce an `EffectiveLiveMaxTank` helper that reuses `LiveCarMaxFuel` or recomputes from the SimHub properties in the same tick, falling back to the last known good value, and apply it across live pit math (tank space, will add, pit window, stop fallback) instead of `data.NewData.MaxFuel`.
- Add distinct exports for `Fuel.PitStopsRequiredByFuel` and `Fuel.PitStopsRequiredByPlan`, compute fuel-based needs from stable laps/fuel-per-lap and the effective tank, and map `Fuel.Pit.StopsRequiredToEnd` to the plan value for backward compatibility.

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f196cb6c8832fafa47235e2a4b35f)