### PR TITLE
Update SimHub documentation and log references

### DIFF
--- a/Docs/BRANCHES.md
+++ b/Docs/BRANCHES.md
@@ -1,3 +1,0 @@
-# Branches
-
-- `live-suggestion-gate`: Tracks the live telemetry suggestion gating and per-condition multiplier work so it can be reviewed independently of the `work` branch.

--- a/Docs/Branching.md
+++ b/Docs/Branching.md
@@ -1,8 +1,0 @@
-# Branching Notes
-
-The live telemetry snapshot work (LaunchSummaryExpander, FuelCalcs bindings, and telemetry plumbing)
-now lives directly on the local `main` branch in this checkout (the old `work`/`live-telemetry-snapshot`
-references are historical). Use `main` for any follow-up fixes or reviews so everything stays in one
-place and avoids future branch conflicts.
-has been moved to the `live-telemetry-snapshot` branch. Use this branch for any follow-up fixes or
-reviews so the work remains isolated from the `work` branch history.

--- a/Docs/FuelProperties_Spec.md
+++ b/Docs/FuelProperties_Spec.md
@@ -1,275 +1,29 @@
 # Fuel Properties Technical Specification
 
-This document is the single source of truth for all fuel-related SimHub properties exposed by LalaLaunch. Property names are shown with the implicit `LalaLaunch.` plugin prefix that SimHub adds to every exported delegate.
+This document summarizes how the fuel- and pit-related SimHub properties are computed inside `LalaLaunch.cs`. Names include the implicit `LalaLaunch.` prefix.
 
-> CSV export: the same content is available in tabular form at `Docs/FuelProperties_Spec.csv` for spreadsheet use.
+## Live consumption and stability
+- **Fuel.LiveFuelPerLap** — Rolling average of accepted lap burns. Laps are rejected for pit contact, incidents, tiny/huge fuel deltas, or falling outside a 50–150% profile bracket. Accepted laps update wet/dry windows, mins/maxes, and confidence before sending the value to `FuelCalculator`.【F:LalaLaunch.cs†L1500-L1714】
+- **Fuel.LiveFuelPerLap_Stable / StableSource / StableConfidence** — Smoothed burn selected from live, profile, or sim fallback to mitigate early-lap noise; refreshed each tick alongside the live burn.【F:LalaLaunch.cs†L1714-L1767】
 
-## Dependency overview
+## Race length projection
+- **Fuel.LiveLapsRemainingInRace / _Stable / _S variants** — Computed every 500 ms using projected lap time and a timed-race overrun model; falls back to the sim’s laps-remaining when projection is invalid. Stable variants mirror the same calculation but prefer the stable burn/pace inputs.【F:LalaLaunch.cs†L1720-L1804】
+- **Fuel.Live.ProjectedDriveSecondsRemaining / Fuel.Live.DriveTimeAfterZero** — Wall time remaining including expected post–timer-zero driving, derived from session time, projection lap time, and the extra-overrun allowance.【F:LalaLaunch.cs†L1777-L1788】
 
-Tank capacity → `Fuel.Pit.TankSpaceAvailable` → `Fuel.Pit.WillAdd` → `Fuel.Pit.FuelOnExit` → `Fuel.Pit.DeltaAfterStop`
+## Tank state, deltas, and pacing
+- **Fuel.LapsRemainingInTank** — Current fuel divided by the stable burn (or live burn when stable is unavailable).【F:LalaLaunch.cs†L1770-L1778】
+- **Fuel.DeltaLaps / Fuel.Delta.* liters** — Surplus or deficit vs. race distance in laps and liters for current, planned, push, and save scenarios; zeros out when no valid burn exists.【F:LalaLaunch.cs†L1722-L1756】
+- **Fuel.PushFuelPerLap / Fuel.FuelSavePerLap / Fuel.DeltaLapsIfPush / Fuel.CanAffordToPush** — Push burn uses observed/session max; save burn uses window minima or 97% fallback. Delta/afford flags compare those burns to projected laps remaining.【F:LalaLaunch.cs†L1754-L1870】
+- **Pace.StintAvgLapTimeSec / Pace.Last5LapAvgSec / Pace.LeaderDeltaToPlayerSec** — Rolling pace feeds for projection; reset when fuel model is invalid to avoid stale projections.【F:LalaLaunch.cs†L1758-L1766】
 
-Timed race projection → `Fuel.Live.DriveTimeAfterZero` → `Fuel.Live.ProjectedDriveSecondsRemaining` → `Fuel.LiveLapsRemainingInRace` → fuel needed / deltas
+## Pit projections and stop timing
+- **Fuel.Pit.TotalNeededToEnd / NeedToAdd** — Total liters required to finish at current/stable burn and the shortfall vs. current fuel.【F:LalaLaunch.cs†L1806-L1854】
+- **Fuel.Pit.TankSpaceAvailable / WillAdd / FuelOnExit** — Capacity-aware add clamped to BoP/override tank size and whether refuel is selected; projected post-stop fuel uses the clamped add.【F:LalaLaunch.cs†L1837-L1855】
+- **Fuel.Pit.DeltaAfterStop / Fuel.Pit.FuelSaveDeltaAfterStop** — Lap surplus after the planned stop using current or save burn; push delta mirrors the same pattern (calculated alongside save delta).【F:LalaLaunch.cs†L1862-L1870】
+- **Fuel.Live.TotalStopLoss / Fuel.Live.RefuelRate_Lps / Fuel.Live.TireChangeTime_S / Fuel.Live.PitLaneLoss_S** — Strategy-facing timing components sourced from `FuelCalculator` each tick; combined to estimate total pit stop loss.【F:LalaLaunch.cs†L2319-L2326】
 
-## Live consumption and pacing
+## Pit window and stop counts
+- **Fuel.IsPitWindowOpen / Fuel.PitWindowOpeningLap** — Single-stop helper comparing requested add vs. tank space and current burn to determine whether the stop fits this lap or when it will.【F:LalaLaunch.cs†L1872-L1879】【F:LalaLaunch.cs†L2289-L2299】
+- **Fuel.PitStopsRequiredByFuel / Fuel.PitStopsRequiredByPlan / Fuel.Pit.StopsRequiredToEnd** — Capacity-based and strategy-based stop counts; the published value favors the plan when available, otherwise the capacity calculation.【F:LalaLaunch.cs†L1874-L1880】【F:LalaLaunch.cs†L2320-L2322】
 
-### LalaLaunch.Fuel.LiveFuelPerLap
-- **Unit:** L/lap
-- **Meaning:** Current best estimate of per-lap fuel burn for the active track condition (dry/wet), using rolling accepted laps.
-- **Formula:** Rolling average of accepted lap burns. On lap crossing, `fuelUsed = lapStartFuel - currentFuel`. If wet mode: average of `_recentWetFuelLaps`; else `_recentDryFuelLaps`. Falls back to SimHub `DataCorePlugin.Computed.Fuel_LitersPerLap` when no accepted laps exist.【F:LalaLaunch.cs†L1323-L1477】
-- **Inputs:**
-  - Telemetry: `data.NewData.Fuel`, `data.NewData.MaxFuel`, `data.NewData.LastLapTime`, pit-lane flags, completed laps.
-  - Internal state: `_recentDryFuelLaps` / `_recentWetFuelLaps`, seeds, `_lapStartFuel`, `FuelCalculator.IsWet`, profile baselines from `GetProfileFuelBaselines()`.
-- **Gating / validity:** Lap rejected when in pit, warm-up, first lap after pit exit, incident flagged, fuel delta ≤0.05 L, fuel delta >20% tank or >baseline×[0.5,1.5].【F:LalaLaunch.cs†L1334-L1397】
-- **Clamping:** Max window size 5 samples; max fuel-per-lap tracked only if within [0.7,1.8]×baseline.【F:LalaLaunch.cs†L1408-L1463】
-- **Update cadence:** Computed at every completed lap; fallback read on 500 ms `UpdateLiveFuelCalcs` tick until first accepted lap.【F:LalaLaunch.cs†L963-L977】【F:LalaLaunch.cs†L1323-L1477】
-- **Code location:** `UpdateLiveFuelCalcs` in `LalaLaunch.cs` lines ~963–1477.
-- **Edge cases:** Clears to 0 when no valid fuel per lap; seeds from previous session can pre-populate window when available.
-
-### LalaLaunch.Fuel.LapsRemainingInTank
-- **Unit:** Laps
-- **Meaning:** How many laps the current fuel load can cover using `Fuel.LiveFuelPerLap`.
-- **Formula:** `currentFuel / LiveFuelPerLap` when `LiveFuelPerLap > 0`, else 0.【F:LalaLaunch.cs†L1598-L1667】
-- **Inputs:** Telemetry `data.NewData.Fuel`; `LiveFuelPerLap`.
-- **Gating / validity:** Only non-zero when `LiveFuelPerLap > 0`.
-- **Clamping:** None beyond zero guard.
-- **Update cadence:** 500 ms `UpdateLiveFuelCalcs` tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1598–1667.
-- **Edge cases:** Resets to 0 when live fuel per lap unavailable.
-
-### LalaLaunch.Fuel.LiveLapsRemainingInRace
-- **Unit:** Laps
-- **Meaning:** Projected race distance remaining (laps) using timed-race overrun logic.
-- **Formula:** `ComputeProjectedLapsRemaining(simLapsRemaining, projectionLapSeconds, sessionTimeRemain, projectedDriveAfterZero)`; defaults to SimHub laps if projection invalid.【F:LalaLaunch.cs†L1608-L1637】【F:LalaLaunch.cs†L3185-L3201】
-- **Inputs:** SimHub `IRacingExtraProperties.iRacing_LapsRemainingFloat`; telemetry lap times via `GetProjectionLapSeconds`; session time remaining; `FuelCalculator.StrategyDriverExtraSecondsAfterZero`.
-- **Gating / validity:** Requires `LiveFuelPerLap > 0` to publish; falls back to sim estimate if projection returns 0.
-- **Clamping:** None beyond fallback.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` and helper `ComputeProjectedLapsRemaining` lines ~1608–1637 and 3185–3201.
-- **Edge cases:** Logging throttled when projection deviates >0.25 laps from sim; handles negative session time (after zero) by including observed overrun.
-
-### LalaLaunch.Fuel.DeltaLaps
-- **Unit:** Laps (positive = surplus, negative = deficit)
-- **Meaning:** Surplus/deficit to finish at current burn.
-- **Formula:** `DeltaLaps = LapsRemainingInTank - LiveLapsRemainingInRace`.【F:LalaLaunch.cs†L1639-L1644】
-- **Inputs:** `LapsRemainingInTank`, `LiveLapsRemainingInRace`.
-- **Gating / validity:** Only computed when `LiveFuelPerLap > 0`.
-- **Clamping:** None.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1639–1644.
-
-### LalaLaunch.Fuel.TargetFuelPerLap
-- **Unit:** L/lap
-- **Meaning:** Max-allowed burn to reach finish when fuel short.
-- **Formula:** If `DeltaLaps < 0`: `raw = currentFuel / LiveLapsRemainingInRace`; clamp to ≥90% of `LiveFuelPerLap` (max 10% saving). Otherwise 0.【F:LalaLaunch.cs†L1646-L1664】
-- **Inputs:** `currentFuel`, `LiveLapsRemainingInRace`, `LiveFuelPerLap`.
-- **Gating / validity:** Only when deficit and valid fuel per lap.
-- **Clamping:** Lower bound 0.9×`LiveFuelPerLap`.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1646–1664.
-
-### LalaLaunch.Fuel.PushFuelPerLap / Fuel.FuelSavePerLap
-- **Unit:** L/lap
-- **Meaning:** Push = aggressive burn guidance; FuelSave = conservative burn using minima.
-- **Formula (Push):** Use `_maxFuelPerLapSession` if ≥ `LiveFuelPerLap`; else `LiveFuelPerLap * 1.02`.【F:LalaLaunch.cs†L1752-L1762】
-- **Formula (FuelSave):** Minimum of wet/dry rolling windows; if none, 97% of `LiveFuelPerLap`.【F:LalaLaunch.cs†L1688-L1703】
-- **Inputs:** `_maxFuelPerLapSession`, `LiveFuelPerLap`, `_minDryFuelPerLap`, `_minWetFuelPerLap`, `FuelCalculator.IsWet`.
-- **Gating / validity:** Require `LiveFuelPerLap > 0` for meaningful values.
-- **Clamping:** Implicit via window min/max and non-negative guard.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1688–1703 and 1752–1762.
-
-### LalaLaunch.Fuel.DeltaLapsIfPush
-- **Unit:** Laps
-- **Meaning:** Surplus/deficit if driving at push burn.
-- **Formula:** `lapsRemainingIfPush = currentFuel / PushFuelPerLap`; `DeltaLapsIfPush = lapsRemainingIfPush - LiveLapsRemainingInRace`.【F:LalaLaunch.cs†L1764-L1773】
-- **Inputs:** `currentFuel`, `PushFuelPerLap`, `LiveLapsRemainingInRace`.
-- **Gating / validity:** Only when push fuel >0.
-- **Clamping:** None beyond zero guards.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1752–1773.
-
-### LalaLaunch.Fuel.CanAffordToPush
-- **Unit:** Bool
-- **Meaning:** True if `DeltaLapsIfPush >= 0` (no deficit when pushing).【F:LalaLaunch.cs†L1764-L1773】
-- **Inputs:** `DeltaLapsIfPush`.
-- **Gating / validity:** Requires push fuel >0.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1752–1773.
-
-### LalaLaunch.Fuel.Confidence
-- **Unit:** Percent (int)
-- **Meaning:** Stability of the live fuel model.
-- **Formula:** `ComputeFuelModelConfidence` uses window size, min/max spread and baseline sanity to assign score 0–100.【F:LalaLaunch.cs†L413-L439】【F:LalaLaunch.cs†L1470-L1477】
-- **Inputs:** Rolling windows, baseline fuel, wet/dry mode.
-- **Gating / validity:** 0 when using fallback SimHub estimator.
-- **Update cadence:** Once per accepted lap; pushed to UI each tick.
-- **Code location:** `ComputeFuelModelConfidence` and `UpdateLiveFuelCalcs` lines ~413–439 and 1470–1477.
-
-## Pace inputs used by fuel projection
-
-### LalaLaunch.Pace.StintAvgLapTimeSec / Pace.Last5LapAvgSec
-- **Unit:** Seconds
-- **Meaning:** Rolling pace metrics used for projection when available.
-- **Formula:** `Pace.StintAvgLapTimeSec` = median-filtered average of clean laps; `Pace.Last5LapAvgSec` = mean of last up to 5 clean laps.【F:LalaLaunch.cs†L1220-L1305】
-- **Inputs:** Clean lap times excluding pit/incident laps; leader deltas for logging.
-- **Gating / validity:** Ignored early laps, pit laps, incident laps.【F:LalaLaunch.cs†L1208-L1260】【F:LalaLaunch.cs†L1334-L1363】
-- **Update cadence:** On lap crossing.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1208–1305.
-
-### LalaLaunch.Pace.LeaderAvgLapTimeSec / Pace.LeaderDeltaToPlayerSec
-- **Unit:** Seconds
-- **Meaning:** Leader pace used only for debug/logging of projection differences.
-- **Formula:** Rolling average of recent leader laps read at each lap crossing; delta = leader avg − player avg pace.【F:LalaLaunch.cs†L1115-L1189】
-- **Inputs:** Telemetry leader lap times via `ReadLeaderLapTimeSeconds` (multiple candidates).【F:LalaLaunch.cs†L3257-L3334】
-- **Gating / validity:** Leader feed cleared if stale or zero; only computed on new laps.【F:LalaLaunch.cs†L1001-L1041】
-- **Update cadence:** Lap crossing.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1001–1189; `ReadLeaderLapTimeSeconds` lines ~3257–3334.
-
-## Pit and strategy properties
-
-### LalaLaunch.Fuel.Pit.TotalNeededToEnd
-- **Unit:** Litres
-- **Meaning:** Total fuel required from now to finish at current burn rate.
-- **Formula:** `fuelNeededToEnd = LiveLapsRemainingInRace * LiveFuelPerLap`.【F:LalaLaunch.cs†L1633-L1644】
-- **Inputs:** `LiveLapsRemainingInRace`, `LiveFuelPerLap`.
-- **Gating / validity:** Zero when `LiveFuelPerLap <= 0`.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1633–1644.
-
-### LalaLaunch.Fuel.Pit.NeedToAdd
-- **Unit:** Litres
-- **Meaning:** Additional fuel required to reach finish.
-- **Formula:** `max(0, Fuel.Pit.TotalNeededToEnd - currentFuel)`.【F:LalaLaunch.cs†L1666-L1677】
-- **Inputs:** `currentFuel`, `Fuel.Pit.TotalNeededToEnd`.
-- **Gating / validity:** Requires valid fuel per lap.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1666–1677.
-
-### LalaLaunch.Fuel.Pit.TankSpaceAvailable
-- **Unit:** Litres
-- **Meaning:** Free capacity in tank respecting BoP and overrides.
-- **Formula:** `max(0, maxTankCapacity - currentFuel)` where `maxTankCapacity = FuelCalculator.MaxFuelOverride` or telemetry `MaxFuel * DriverCarMaxFuelPct`.【F:LalaLaunch.cs†L1679-L1701】【F:LalaLaunch.cs†L2823-L2833】
-- **Inputs:** `currentFuel`, `FuelCalculator.MaxFuelOverride`, telemetry `DataCorePlugin.GameData.MaxFuel`, `DriverInfo.DriverCarMaxFuelPct`.
-- **Gating / validity:** Zero if no capacity info.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1679–1701; max detection lines ~2823–2833.
-
-### LalaLaunch.Fuel.Pit.WillAdd
-- **Unit:** Litres
-- **Meaning:** Actual fuel volume expected to be added given MFD request and capacity.
-- **Formula:** `requestedAddLitres` (converted from `PitSvFuel` gallons) clamped to `TankSpaceAvailable`. If refuel not selected, request is forced to 0.【F:LalaLaunch.cs†L1669-L1698】
-- **Inputs:** Telemetry `DataCorePlugin.GameRawData.Telemetry.PitSvFuel`, `dpFuelFill` (refuel selected), unit conversion `DataCorePlugin.GameData.Units`. Tank space as above.
-- **Gating / validity:** Zero when refuel not selected or no tank space.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1669–1698; `IsRefuelSelected` lines ~3044–3058.
-
-### LalaLaunch.Fuel.Pit.FuelOnExit
-- **Unit:** Litres
-- **Meaning:** Expected fuel in tank after pit stop completes.
-- **Formula:** `currentFuel + Fuel.Pit.WillAdd`.【F:LalaLaunch.cs†L1685-L1703】
-- **Inputs:** `currentFuel`, `Fuel.Pit.WillAdd`.
-- **Gating / validity:** Zero when invalid fuel per lap.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1685–1703.
-
-### LalaLaunch.Fuel.Pit.DeltaAfterStop / Fuel.Pit.FuelSaveDeltaAfterStop / Fuel.Pit.PushDeltaAfterStop
-- **Unit:** Laps (post-stop surplus/deficit)
-- **Meaning:** Projected lap surplus at current, save, or push burn after executing the planned stop.
-- **Formula:** `(Fuel.Pit.FuelOnExit / burnRate) - LiveLapsRemainingInRace`, where burnRate is `LiveFuelPerLap`, `FuelSaveFuelPerLap`, or `PushFuelPerLap` respectively.【F:LalaLaunch.cs†L1695-L1704】【F:LalaLaunch.cs†L1764-L1773】
-- **Inputs:** `Fuel.Pit.FuelOnExit`, burn rates, `LiveLapsRemainingInRace`.
-- **Gating / validity:** Zero when burn rate <=0 or no valid projection.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1695–1704 and 1764–1773.
-
-### LalaLaunch.Fuel.Pit.StopsRequiredToEnd
-- **Unit:** Count (int)
-- **Meaning:** Planned number of remaining stops from FuelCalculator strategy or inferred from capacity.
-- **Formula:** Use `FuelCalculator.RequiredPitStops`; if <=0 and `maxTankCapacity > 0`, compute `ceil((fuelNeededToEnd - currentFuel) / maxTankCapacity)` then clamp ≥0.【F:LalaLaunch.cs†L1706-L1721】
-- **Inputs:** `FuelCalculator.RequiredPitStops`, `fuelNeededToEnd`, `currentFuel`, `maxTankCapacity`.
-- **Gating / validity:** Zero when no valid inputs.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1706–1721.
-
-### LalaLaunch.Fuel.IsPitWindowOpen / Fuel.PitWindowOpeningLap
-- **Unit:** Bool / Lap number (int)
-- **Meaning:** Whether a single-stop plan can pit now for the requested add; opening lap when not yet available.
-- **Formula:** For single-stop strategy with refuel selected and valid burn: if `TankSpaceAvailable >= requestedAddLitres` then open and `PitWindowOpeningLap = currentLapNumber`; else compute `lapsToOpen = ceil((requestedAddLitres - tankSpace)/LiveFuelPerLap)` and opening lap = current lap + lapsToOpen.【F:LalaLaunch.cs†L1723-L1751】
-- **Inputs:** `FuelCalculator.RequiredPitStops`, refuel selection, `requestedAddLitres`, `TankSpaceAvailable`, `LiveFuelPerLap`, completed lap count.
-- **Gating / validity:** Only for strategies requiring exactly one stop and refuel selected; otherwise false/0.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1723–1751.
-
-### LalaLaunch.Fuel.Live.RefuelRate_Lps
-- **Unit:** L/s
-- **Meaning:** Effective refuel rate considering profile/telemetry.
-- **Formula:** Delegates to `FuelCalcs.EffectiveRefuelRateLps` (profile-configured or measured). No further math in `LalaLaunch.cs`.【F:LalaLaunch.cs†L2101-L2101】【F:FuelCalcs.cs†L2740-L2795】
-- **Inputs:** Internal FuelCalcs state (measured refuel events via `_refuelStartFuel`/`_refuelLastFuel`).
-- **Gating / validity:** 0 when unknown.
-- **Update cadence:** Published each tick from latest FuelCalcs value.
-- **Code location:** Attach in `LalaLaunch.cs` line ~2101; refuel detection lines ~2699–2801.
-
-### LalaLaunch.Fuel.Live.TireChangeTime_S
-- **Unit:** Seconds
-- **Meaning:** Box time for tyre change if selected in MFD.
-- **Formula:** `FuelCalculator.TireChangeTime` if any tyre change selected; else 0. Negative values clamped to 0.【F:LalaLaunch.cs†L3058-L3085】
-- **Inputs:** Telemetry tire change flags (`dpLFTireChange`, `dpRFTireChange`, `dpLRTireChange`, `dpRRTireChange`), FuelCalcs tyre time.
-- **Gating / validity:** Assumes tyre change selected when telemetry missing (returns true if no flags present).【F:LalaLaunch.cs†L3028-L3056】
-- **Update cadence:** 500 ms tick.
-- **Code location:** `GetEffectiveTireChangeTimeSeconds` lines ~3058–3085.
-
-### LalaLaunch.Fuel.Live.PitLaneLoss_S
-- **Unit:** Seconds
-- **Meaning:** Latest pit-lane travel time loss (DTL) used for planning.
-- **Formula:** Directly exposes `FuelCalculator.PitLaneTimeLoss` (computed by `PitEngine`).【F:LalaLaunch.cs†L2103-L2103】【F:PitEngine.cs†L1-L200】
-- **Inputs:** PitEngine measurements (`LastTotalPitCycleTimeLoss` etc.).
-- **Gating / validity:** 0 when not measured.
-- **Update cadence:** 500 ms tick.
-- **Code location:** Attach in `LalaLaunch.cs` line ~2103.
-
-### LalaLaunch.Fuel.Live.TotalStopLoss
-- **Unit:** Seconds
-- **Meaning:** Expected total time loss for an upcoming stop including lane travel and box work (fuel vs tyres).
-- **Formula:** `pitLaneLoss + max(fuelTime, tireTime)` where `fuelTime = WillAdd / refuelRate` when both >0; `tireTime` from `GetEffectiveTireChangeTimeSeconds`. Negative/NaN guarded to 0.【F:LalaLaunch.cs†L3094-L3130】
-- **Inputs:** `FuelCalculator.PitLaneTimeLoss`, `Fuel.Pit.WillAdd`, `Fuel.Live.RefuelRate_Lps`, tyre selection.
-- **Gating / validity:** Requires pit lane loss and refuel/tire selections; zeros otherwise.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `CalculateTotalStopLossSeconds` lines ~3094–3130.
-
-### LalaLaunch.Fuel.Live.DriveTimeAfterZero
-- **Unit:** Seconds
-- **Meaning:** Projected additional drive time once race clock hits zero, combining observed overrun, strategy projection, and lap-based fallback.
-- **Formula:** `EstimateDriveTimeAfterZero(sessionTime, sessionTimeRemain, lapSeconds, strategyProjection, timerZeroSeen, timerZeroSessionTime)`; max of observed after-zero, strategy projection, and lap time as floor.【F:LalaLaunch.cs†L1604-L1620】【F:FuelProjectionMath.cs†L8-L41】
-- **Inputs:** Session time/remaining telemetry, `GetProjectionLapSeconds`, `FuelCalculator.StrategyDriverExtraSecondsAfterZero`, internal timer-zero tracking.
-- **Gating / validity:** Uses 0 when telemetry missing.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1604–1620; helper in `FuelProjectionMath.cs` lines ~8–41.
-
-### LalaLaunch.Fuel.Live.ProjectedDriveSecondsRemaining
-- **Unit:** Seconds
-- **Meaning:** Wall-clock drive time expected to finish, including overrun beyond zero.
-- **Formula:** From `FuelProjectionMath.ProjectLapsRemaining`, returned `projectedSecondsRemaining = max(sessionTimeRemain,0) + max(driveTimeAfterZero,0)`.【F:LalaLaunch.cs†L1618-L1637】【F:FuelProjectionMath.cs†L23-L49】
-- **Inputs:** Session time remaining telemetry, `Fuel.Live.DriveTimeAfterZero`, lap pace.
-- **Gating / validity:** 0 when projection invalid.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `ComputeProjectedLapsRemaining` lines ~3185–3201; `FuelProjectionMath` lines ~23–49.
-
-### LalaLaunch.Fuel.Pit.Tank capacity (LiveCarMaxFuel / MaxFuelOverride)
-- **Unit:** Litres
-- **Meaning:** Effective tank size used for all pit math and window logic.
-- **Formula:** `LiveCarMaxFuel = GameData.MaxFuel * DriverCarMaxFuelPct`; overrides applied via `FuelCalculator.MaxFuelOverride`/suggestions. Updates pushed to FuelCalculator display when changed.【F:LalaLaunch.cs†L2823-L2833】【F:LalaLaunch.cs†L2521-L2531】
-- **Inputs:** Telemetry `DataCorePlugin.GameData.MaxFuel`, `DriverInfo.DriverCarMaxFuelPct`; FuelCalcs overrides.
-- **Update cadence:** 500 ms tick.
-- **Code location:** `DataUpdate` loop lines ~2819–2833; UI update lines ~2521–2531.
-
-### LalaLaunch.Fuel.LastPitLaneTravelTime
-- **Unit:** Seconds
-- **Meaning:** Last measured direct pit-lane travel (no stop) time from PitEngine; exposed for dashboards.
-- **Formula:** Delegated from `_pit.LastDirectTravelTime` captured after out-lap completes in PitEngine state machine.【F:LalaLaunch.cs†L1149-L1189】【F:LalaLaunch.cs†L2301-L2301】
-- **Inputs:** PitEngine lap crossing timings (`FinalizePaceDeltaCalculation`).
-- **Update cadence:** On pit cycle completion.
-- **Code location:** `UpdateLiveFuelCalcs` lines ~1043–1189; attached at line ~2301.
-
-## Findings / Suspected Issues
-
-- Refuel selection defaults to true when telemetry fields are missing, which may overestimate `Fuel.Pit.WillAdd` on sims that omit `dpFuelFill`. Follow-up: confirm desired default per sim and possibly guard with session type check.【F:LalaLaunch.cs†L3044-L3058】
-- Leader pace is cleared when feed drops, but delta-based projection logging might still reflect older `Pace_StintAvgLapTimeSec` values. Consider marking projection confidence accordingly.【F:LalaLaunch.cs†L1001-L1041】【F:LalaLaunch.cs†L1608-L1637】
+These calculations are exported through the delegates registered in `AttachCore`/`AttachVerbose` near the plugin initialization block.【F:LalaLaunch.cs†L2280-L2330】

--- a/Docs/PitSimHubProperties.md
+++ b/Docs/PitSimHubProperties.md
@@ -1,88 +1,65 @@
 # Pit-related SimHub Properties
 
-The plugin exposes a mix of pit-lane timing, loss calculations, PitLite telemetry, rejoin phase state, and fuel/pit window helpers. Properties are grouped by their SimHub channel (Core vs. Verbose) and marked for expected use.
+The plugin exposes lane timers, pit-cycle losses, pit-lite telemetry, rejoin phase state, and fuel/pit-window helpers. Core parameters are always published; verbose parameters require `SimhubPublish.VERBOSE`.
 
-## Time-loss & pit timers
-| Property | Channel | Source/Calculation | Intended use |
-| --- | --- | --- | --- |
-| `Pit.LastDirectTravelTime` | Core | PitEngine direct lane travel computed at pit exit: `TimeOnPitRoad - PitStopDuration`, clamped to 0–300s and latched on exit. | Driver-facing: raw limiter-to-limiter travel time (drive-through style). |
-| `Pit.LastTotalPitCycleTimeLoss` | Core | PitEngine DTL formula on lap completion: `(pitLap - stop + outLap) - 2*avgPace`, floored at 0. | Driver-facing: overall pit cycle time-loss vs. baseline pace. |
-| `Pit.LastPaceDeltaNetLoss` | Core | PitEngine net loss excluding stop: `LastTotalPitCycleTimeLoss - stop`, floored at 0. | Mostly diagnostic; secondary driver metric. |
-| `PitLite.TotalLossSec` | Core | PitLite publishes either DTL (when baseline available) or direct lane loss on out-lap completion. | Driver-facing: single preferred pit loss output. |
-| `PitLite.TotalLossPlusBoxSec` | Core | `PitLite.TotalLossSec + TimePitBoxSec`; combines the chosen loss with stopped time. | Driver-facing: total pit delta including stationary time. |
-| `PitLite.Live.TimeOnPitRoadSec` | Core | Passthrough of PitEngine `TimeOnPitRoad.TotalSeconds` (running). | Driver-facing: live pit-lane timer during stop. |
-| `PitLite.Live.TimeInBoxSec` | Core | Passthrough of PitEngine `PitStopElapsedSec` (running box timer). | Driver-facing: live stationary timer. |
-| `Fuel.LastPitLaneTravelTime` | Core | Alias to `LastDirectTravelTime` used by fuel calculator. | Driver-facing/fuel integration. |
+## Time-loss & pit timers (core)
+| Property | Source / calculation | Intended use |
+| --- | --- | --- |
+| `Pit.LastDirectTravelTime` | PitEngine limiter-to-limiter travel captured at pit exit (`TimeOnPitRoad - PitStopDuration`, clamped 0–300 s). | Driver-facing raw lane time; also fuels consumption model. |
+| `Pit.LastTotalPitCycleTimeLoss` | PitEngine DTL on lap completion: `(pitLap - stop + outLap) - 2*avgPace`, floored at 0. | Driver-facing overall pit cycle delta. |
+| `Pit.LastPaceDeltaNetLoss` | PitEngine DTL minus stopped time. | Secondary driver metric / validation. |
+| `PitLite.TotalLossSec` | PitCycleLite publishes preferred loss (DTL when valid; otherwise direct lane loss). | Single pit-loss output for dashes. |
+| `PitLite.TotalLossPlusBoxSec` | `TotalLossSec + TimePitBoxSec`. | Total pit delta including stopped time. |
+| `PitLite.Live.TimeOnPitRoadSec` | Passthrough of PitEngine running lane timer. | Live pit-lane timer during stop. |
+| `PitLite.Live.TimeInBoxSec` | Passthrough of PitEngine running box timer. | Live stationary timer. |
+| `RejoinIsExitingPits` / `RejoinCurrentPitPhase(Name)` | Current pit phase from PitEngine. | Dash overlays / rejoin warnings. |
 
-### Verbose pit/loss diagnostics
-| Property | Channel | Source/Calculation | Intended use |
-| --- | --- | --- | --- |
-| `Pit.Debug.TimeOnPitRoad` | Verbose | PitEngine `TimeOnPitRoad.TotalSeconds`. | Debug. |
-| `Pit.Debug.LastPitStopDuration` | Verbose | PitEngine `PitStopElapsedSec`. | Debug. |
-| `Lala.Pit.AvgPaceUsedSec` | Verbose | Baseline pace fed into PitEngine DTL. | Debug. |
-| `Lala.Pit.AvgPaceSource` | Verbose | Text label for the baseline source. | Debug. |
-| `Lala.Pit.Raw.PitLapSec` | Verbose | Pit lap (includes stop) captured by PitEngine. | Debug. |
-| `Lala.Pit.Raw.DTLFormulaSec` | Verbose | Raw DTL formula result before flooring. | Debug. |
-| `Lala.Pit.InLapSec` | Verbose | PitEngine stored pit-lap seconds. | Debug. |
-| `Lala.Pit.OutLapSec` | Verbose | PitEngine stored out-lap seconds. | Debug. |
-| `Lala.Pit.DeltaInSec` | Verbose | Pit lap delta vs. baseline. | Debug. |
-| `Lala.Pit.DeltaOutSec` | Verbose | Out-lap delta vs. baseline. | Debug. |
-| `Lala.Pit.DriveThroughLossSec` | Verbose | Mirrors `LastTotalPitCycleTimeLoss`. | Debug. |
-| `Lala.Pit.DirectTravelSec` | Verbose | Mirrors `LastDirectTravelTime`. | Debug. |
-| `Lala.Pit.StopSeconds` | Verbose | PitEngine stop duration. | Debug. |
-| `Lala.Pit.ServiceStopLossSec` | Verbose | Derived: `LastTotalPitCycleTimeLoss + stop`, floored at 0. | Debug/service analysis. |
-| `Lala.Pit.Profile.PitLaneLossSec` | Verbose | Active profile’s saved pit lane loss for current track. | Debug/validation. |
-| `Lala.Pit.CandidateSavedSec` | Verbose | Last saved pit loss candidate. | Debug. |
-| `Lala.Pit.CandidateSource` | Verbose | Source label for saved candidate. | Debug. |
+## Fuel & pit-window helpers (core)
+| Property | Source / calculation | Intended use |
+| --- | --- | --- |
+| `Fuel.Pit.TotalNeededToEnd` / `_S` | `LiveLapsRemainingInRace × LiveFuelPerLap` (string version is formatted). | Driver strategy: total liters required. |
+| `Fuel.Pit.NeedToAdd` | `max(0, TotalNeededToEnd - currentFuel)`. | Strategy add needed. |
+| `Fuel.Pit.TankSpaceAvailable` | `max(0, capacity - currentFuel)` using BoP/override. | Capacity check. |
+| `Fuel.Pit.WillAdd` | Telemetry MFD refuel request clamped to `TankSpaceAvailable` (0 if refuel not selected). | Strategy validation. |
+| `Fuel.Pit.FuelOnExit` | `currentFuel + WillAdd`. | Post-stop projection. |
+| `Fuel.Pit.DeltaAfterStop` / `_S` | Lap surplus after stop at current burn. | Finish viability check. |
+| `Fuel.Pit.FuelSaveDeltaAfterStop` / `_S` | Lap surplus using fuel-save burn. | Conservative projection. |
+| `Fuel.Pit.PushDeltaAfterStop` / `_S` | Lap surplus using push burn. | Aggressive projection. |
+| `Fuel.PitStopsRequiredByFuel` / `Fuel.PitStopsRequiredByPlan` | Capacity-inferred vs. strategy-requested stop counts. | Strategy debugging. |
+| `Fuel.Pit.StopsRequiredToEnd` | Final required stops (plan or capacity). | Driver strategy. |
+| `Fuel.Live.TotalStopLoss` | Pit lane loss plus concurrent service time. | Strategy timing. |
+| `Fuel.Live.RefuelRate_Lps` | Effective refuel rate used in stop timing. | Strategy timing / validation. |
+| `Fuel.Live.TireChangeTime_S` | Time to change tyres if selected. | Strategy timing / validation. |
+| `Fuel.Live.PitLaneLoss_S` | Lane loss used by fuel/strategy calculators. | Strategy timing / validation. |
 
-### PitLite verbose telemetry
-| Property | Channel | Source/Calculation | Intended use |
-| --- | --- | --- | --- |
-| `PitLite.InLapSec` | Verbose | PitLite latched in-lap seconds (pit lap). | Debug/analysis. |
-| `PitLite.OutLapSec` | Verbose | PitLite latched out-lap seconds. | Debug/analysis. |
-| `PitLite.DeltaInSec` | Verbose | PitLite in-lap delta vs. average pace. | Debug/analysis. |
-| `PitLite.DeltaOutSec` | Verbose | PitLite out-lap delta vs. average pace. | Debug/analysis. |
-| `PitLite.TimePitLaneSec` | Verbose | Latched limiter-to-limiter time from PitEngine at exit. | Debug/analysis. |
-| `PitLite.TimePitBoxSec` | Verbose | Latched stationary time from PitEngine at exit. | Debug/analysis. |
-| `PitLite.DirectSec` | Verbose | `TimePitLaneSec - TimePitBoxSec`, floored at 0. | Debug/analysis. |
-| `PitLite.DTLSec` | Verbose | PitLite computed DTL: `(In + Out) - 2*avg - TimePitBoxSec`, floored at 0. | Debug/analysis. |
-| `PitLite.Status` | Verbose | PitLite status enum (`DriveThrough`, `StopValid`, etc.). | Debug. |
-| `PitLite.CurrentLapType` | Verbose | Current lap classification. | Debug. |
-| `PitLite.LastLapType` | Verbose | Prior lap classification. | Debug. |
-| `PitLite.LossSource` | Verbose | Which loss was published (`dtl`/`direct`). | Debug. |
-| `PitLite.LastSaved.Sec` | Verbose | Last saved candidate seconds. | Debug. |
-| `PitLite.LastSaved.Source` | Verbose | Source label for last saved candidate. | Debug. |
-| `PitLite.Live.SeenEntryThisLap` | Verbose | Entry edge flag for current lap. | Debug. |
-| `PitLite.Live.SeenExitThisLap` | Verbose | Exit edge flag for current lap. | Debug. |
+## Verbose pit/loss diagnostics
+| Property | Source / calculation | Intended use |
+| --- | --- | --- |
+| `Pit.Debug.TimeOnPitRoad` | PitEngine `TimeOnPitRoad.TotalSeconds`. | Debug timer. |
+| `Pit.Debug.LastPitStopDuration` | PitEngine `PitStopElapsedSec`. | Debug timer. |
+| `Lala.Pit.AvgPaceUsedSec` / `AvgPaceSource` | Baseline pace used for DTL + source label. | Debug. |
+| `Lala.Pit.Raw.PitLapSec` / `Raw.DTLFormulaSec` | Captured pit lap and raw DTL before flooring. | Debug. |
+| `Lala.Pit.InLapSec` / `OutLapSec` / `DeltaInSec` / `DeltaOutSec` | Stored in/out laps and deltas vs. baseline. | Debug. |
+| `Lala.Pit.DriveThroughLossSec` | Mirrors final DTL. | Debug. |
+| `Lala.Pit.DirectTravelSec` | Mirrors direct lane time. | Debug. |
+| `Lala.Pit.StopSeconds` | Stationary time. | Debug. |
+| `Lala.Pit.ServiceStopLossSec` | `LastTotalPitCycleTimeLoss + stop`, floored. | Debug/service analysis. |
+| `Lala.Pit.Profile.PitLaneLossSec` | Active profile’s saved pit lane loss. | Validation. |
+| `Lala.Pit.CandidateSavedSec` / `CandidateSource` | Last saved pit-loss candidate + provenance. | Debug. |
 
-## Rejoin/pit phase properties
-| Property | Channel | Source/Calculation | Intended use |
-| --- | --- | --- | --- |
-| `RejoinIsExitingPits` | Core | True when `PitEngine.CurrentPitPhase == ExitingPits`. | Driver dash/rejoin overlays. |
-| `RejoinCurrentPitPhaseName` | Core | Current `PitPhase` enum name from PitEngine. | Driver dash/rejoin overlays. |
-| `RejoinCurrentPitPhase` | Core | Numeric `PitPhase` value. | Driver dash/rejoin overlays. |
+## PitLite verbose telemetry
+| Property | Source / calculation | Intended use |
+| --- | --- | --- |
+| `PitLite.InLapSec` / `OutLapSec` | Latched pit-lite lap times. | Debug/analysis. |
+| `PitLite.DeltaInSec` / `DeltaOutSec` | Pit-lite deltas vs. average pace. | Debug/analysis. |
+| `PitLite.TimePitLaneSec` / `TimePitBoxSec` | Latched timers from PitEngine. | Debug/analysis. |
+| `PitLite.DirectSec` | `TimePitLaneSec - TimePitBoxSec`, floored at 0. | Debug/analysis. |
+| `PitLite.DTLSec` | Pit-lite computed DTL. | Debug/analysis. |
+| `PitLite.Status` / `CurrentLapType` / `LastLapType` | Pit-lite status and lap classifications. | Debug/analysis. |
+| `PitLite.LossSource` | Which loss was published (`dtl`/`direct`). | Debug/analysis. |
+| `PitLite.LastSaved.Sec` / `LastSaved.Source` | Last saved candidate seconds and source. | Debug/analysis. |
+| `PitLite.Live.SeenEntryThisLap` / `SeenExitThisLap` | Entry/exit edge flags for current lap. | Debug/analysis. |
 
-## Fuel & pit window helpers
-| Property | Channel | Source/Calculation | Intended use |
-| --- | --- | --- | --- |
-| `Fuel.Pit.TotalNeededToEnd` | Core | Fuel calculator total fuel required to finish. | Driver strategy. |
-| `Fuel.Pit.NeedToAdd` | Core | Fuel required at next stop. | Driver strategy. |
-| `Fuel.Pit.TankSpaceAvailable` | Core | Max fuel that fits given tank size. | Driver strategy. |
-| `Fuel.Pit.WillAdd` | Core | Planned fuel to add this stop. | Driver strategy. |
-| `Fuel.Pit.DeltaAfterStop` | Core | Laps delta after refuel (`FuelOnExit/LapsPerLap - lapsRemaining`). | Driver strategy. |
-| `Fuel.Pit.FuelSaveDeltaAfterStop` | Core | Laps delta after refuel using low-burn profile. | Driver strategy. |
-| `Fuel.Pit.PushDeltaAfterStop` | Core | Laps delta after refuel using push/max-burn profile. | Driver strategy. |
-| `Fuel.Pit.FuelOnExit` | Core | Estimated fuel after stop. | Driver strategy. |
-| `Fuel.Pit.StopsRequiredToEnd` | Core | Integer stops needed to finish. | Driver strategy. |
-| `Fuel.FuelSavePerLap` | Core | Current low-burn per-lap estimate. | Driver strategy. |
-| `Fuel.Live.TotalStopLoss` | Core | Pit lane loss plus concurrent box time from fuel/tyre selections. | Driver strategy. |
-| `Fuel.Live.DriveTimeAfterZero` | Core | Projected driving time once the race clock reaches 0. | Driver strategy. |
-| `Fuel.Live.ProjectedDriveSecondsRemaining` | Core | Projected wall time remaining including after-zero driving. | Driver strategy. |
-| `Fuel.IsPitWindowOpen` | Core | Boolean pit window flag. | Driver strategy. |
-| `Fuel.PitWindowOpeningLap` | Core | Lap when pit window opens. | Driver strategy. |
-| `Fuel.LastPitLaneTravelTime` | Core | Alias noted above; also fuels consumption model. | Driver strategy. |
-
-## Debug vs. driver-facing
-- **Driver-facing (dash-worthy):** Core pit loss/timer outputs (`Pit.LastDirectTravelTime`, `Pit.LastTotalPitCycleTimeLoss`, `PitLite.TotalLossSec`, live lane/box timers), pit phase core properties, and fuel/pit window helpers.
-- **Primarily debug:** All `Pit.Debug.*`, `Lala.Pit.*`, and `PitLite.*` verbose properties are intended for diagnostics/validation and can be hidden from dashboards unless troubleshooting.
-
+## Driver vs. debug guidance
+- **Driver-facing:** Core pit loss/timer outputs, pit phase flags, and fuel/pit-window helpers listed in the core tables above.
+- **Debug/validation:** All `Pit.Debug.*`, `Lala.Pit.*`, and `PitLite.*` verbose properties are intended for diagnostics and can be hidden from dashboards unless troubleshooting.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -1,0 +1,35 @@
+# SimHub Log Info Messages
+
+This file documents the Info-level messages emitted via `SimHub.Logging.Current.Info(...)` and what each value in the message represents.
+
+## LalaLaunch.cs
+- **`[SimHubLogInfo][LapCrossing] | pace ... | fuel ...`** — Emitted on each accepted lap to summarize pace and fuel updates. Pace block includes `lap`, `time`, acceptance flag/reason, baseline/delta, stint/last5 averages, confidence, leader lap/average, and sample count; fuel block carries `used`, acceptance flag/reason, `mode` (wet/dry), live burn, wet/dry window counts, session max burn, fuel confidence, overall confidence, and whether a pit trip was active.【F:LalaLaunch.cs†L1060-L1095】
+- **`[LiveFuel] Captured seed from session ... dry=X (n=a), wet=Y (n=b).`** — Written when saving rolling fuel figures to seed the next session; shows car, track key, dry/wet fuel-per-lap values, and sample counts used for each window.【F:LalaLaunch.cs†L640-L678】
+- **`[LiveFuel] Car/track change detected – clearing seeds and confidence`** — Indicates the fuel model was reset because either car or track changed; no variable values beyond the fixed message.【F:LalaLaunch.cs†L822-L836】
+- **`[LiveFuel] HandleSessionChangeForFuelModel error: ...`** and **`CaptureFuelSeedForNextSession error: ...`** — Exception catch logs for session-change fuel handling with the thrown message appended.【F:LalaLaunch.cs†L675-L877】
+- **`[LapDetector] Pending lap confirmation expired ...`** — Warns that a lap increment was not confirmed before the timeout; includes pending lap number and the last observed track percentage when arming.【F:LalaLaunch.cs†L906-L918】
+
+## PitEngine.cs
+- **`[PitEngine] Direct lane travel computed -> lane=Xs, stop=Ys, direct=Zs`** — Live lane timer minus stop duration when a valid direct travel time is measured; shows total lane time, stopped time, and derived direct travel seconds.【F:PitEngine.cs†L100-L236】
+- **`[PitEngine] Pit exit detected – lane=Xs, stop=Ys, direct=Zs. Awaiting pit-lap completion.`** — Fired when leaving pit lane with valid timers, carrying the same trio of values as above and signaling the pit-lap latch is armed.【F:PitEngine.cs†L164-L175】
+- **`[PitEngine] Pit-lap invalid – aborting pit-cycle evaluation.`** — Indicates the pit lap failed validation (e.g., bad data) and the cycle is cleared.【F:PitEngine.cs†L189-L217】
+- **`[PitEngine] Pit-lap captured = Xs – awaiting out-lap completion.`** — Confirms a valid pit lap was latched and reports its seconds before waiting for the out-lap.【F:PitEngine.cs†L189-L207】
+- **`[PitEngine] Out-lap invalid – aborting pit-cycle evaluation.`** — Out-lap failed validation; pit-cycle metrics are discarded.【F:PitEngine.cs†L210-L218】
+- **`[PitEngine] DTL computed (formula): Total=Xs, NetMinusStop=Ys (avg=As, pitLap=Bs, outLap=Cs, stop=Ds)`** — Final pit delta calculation showing total and net (minus stop) losses plus the inputs used: baseline average lap, pit lap, out lap, and stop duration.【F:PitEngine.cs†L225-L239】
+
+## PitCycleLite.cs
+- **`[PitLite] ENTRY edge detected – arming cycle and clearing previous pit figures.`** — Marks pit-entry detection, resets latched timers/values for the new cycle.【F:PitCycleLite.cs†L128-L146】
+- **`[PitLite] EXIT edge detected – latching lane/box timers from PitEngine.`** and **`Exit latched: lane=Xs, box=Ys, direct=Zs, status=Status`** — Signals pit exit, copies timers from PitEngine, computes direct lane time, and records stop vs. drive-through status.【F:PitCycleLite.cs†L147-L163】
+- **`[PitLite] Out-lap complete: Out=Xs, In=Ys, lane=As, box=Bs, chosen=Cs (source).`** — Logged at S/F when the out-lap completes; shows latched in/out laps, lane/box timers, chosen loss, and which source (`dtl`/`direct`) was used.【F:PitCycleLite.cs†L170-L208】
+- **`[PitLite] Latched In-lap = Xs.`** — Captures the in-lap duration when it completes.【F:PitCycleLite.cs†L170-L190】
+- **`[PitLite] Publishing loss (source=dtl): dtl=Xs, direct=Ys, avg=Zs.`** — Publishes pit loss when both laps and baseline pace exist; lists both DTL and direct computations plus the baseline used.【F:PitCycleLite.cs†L197-L208】
+- **`[PitLite] Publishing direct loss (no avg pace): lane=Xs, box=Ys, direct=Zs.`** — Fallback publication when baseline pace is missing; reports the timers used.【F:PitCycleLite.cs†L207-L217】
+
+## Launch trace and profile operations
+- **`[LaunchTrace] ...` messages (open/close/append/discard)** — Lifecycle of launch trace CSV files: opening a new file, discarding unusable traces, writing summaries, or closing files. Each message includes the file path or timestamps involved.【F:LalaLaunch.cs†L4778-L4955】
+- **`[Profiles] ...` messages** — Profile save/ensure logs indicating when car/track profiles are created, updated, rejected, or persisted; messages typically include the profile name, car, track key, or lap time used.【F:LalaLaunch.cs†L447-L2252】【F:ProfilesManagerViewModel.cs†L41-L633】
+- **`[PB] ...` messages** — Personal-best capture or rejection outcomes showing lap milliseconds, car, and track key alongside whether the candidate was accepted.【F:LalaLaunch.cs†L3106-L3148】【F:ProfilesManagerViewModel.cs†L41-L112】
+
+## Launch and pace monitoring
+- **`[LalaLaunch] ...` messages** — High-level lifecycle events such as session snapshots, refuel start/end timing, launch state aborts, on-track detection, or auto-mode switching. Values vary by message (e.g., car/track names, timestamps, or mode/page labels).【F:LalaLaunch.cs†L2887-L3214】
+- **`[Pace] ...` and `[FuelLeader] ...` messages** — Pace filtering decisions (e.g., rejecting outliers or logging fallback pace sources) and leader-lap parsing status; each message lists the lap times, deltas, or raw values considered.【F:LalaLaunch.cs†L1161-L4205】

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -1,189 +1,165 @@
 # SimHub Parameter Inventory
 
-This document maps every custom SimHub-exported parameter defined in `LalaLaunch.cs` (core plus verbose/debug). It captures the internal name, type, units/meaning, update cadence, primary source, and a short description to aid dashboard design. All names below are shown without the implicit `LalaLaunch.` prefix that SimHub adds at runtime. See `Docs/FuelProperties_Spec.md` for the authoritative fuel-property formulas.
+The tables below list every SimHub-exposed property published from `LalaLaunch.cs`. Names omit the implicit `LalaLaunch.` prefix that SimHub adds. Core parameters are always exported; verbose parameters require `SimhubPublish.VERBOSE`.
 
-## SimHub Parameter Inventory
+## Core parameters
 
-### Core parameters (always published)
-| Exported name | Type | Units / meaning | Update mechanism | Primary source | Notes / grouping |
-| --- | --- | --- | --- | --- | --- |
-| Fuel.LiveFuelPerLap | double | L/lap | Recomputed in `UpdateLiveFuelCalcs` (500 ms tick inside `DataUpdate`) | Rolling accepted lap burns (wet/dry aware) | Fuel strategy |
-| Fuel.LiveLapsRemainingInRace | double | Laps | 500 ms fuel update | Projection of laps remaining incl. after-zero drive time | Fuel strategy |
-| Fuel.DeltaLaps | double | Laps | 500 ms fuel update | `LapsRemainingInTank - LiveLapsRemainingInRace` | Fuel strategy |
-| Fuel.TargetFuelPerLap | double | L/lap | 500 ms fuel update | Clamp of `currentFuel / projectedLaps` (≥90% of live rate) when short | Fuel strategy |
-| Fuel.IsPitWindowOpen | bool | Flag | 500 ms fuel update | True when single-stop request fits in tank now | Fuel strategy |
-| Fuel.PitWindowOpeningLap | double | Lap index | 500 ms fuel update | Lap when requested add will fit (current lap if already fits) | Fuel strategy |
-| Fuel.LapsRemainingInTank | double | Laps | 500 ms fuel update | `currentFuel / LiveFuelPerLap` | Fuel strategy |
-| Fuel.Confidence | int | Percent | 500 ms fuel update | Confidence score from live fuel window | Fuel strategy |
-| Fuel.PushFuelPerLap | double | L/lap | 500 ms fuel update | Max burn estimate (session max or +2%) | Fuel strategy |
-| Fuel.FuelSavePerLap | double | L/lap | 500 ms fuel update | Conservative burn (window min or 97% of live) | Fuel strategy |
-| Fuel.DeltaLapsIfPush | double | Laps | 500 ms fuel update | Surplus if driving at push burn | Fuel strategy |
-| Fuel.CanAffordToPush | bool | Flag | 500 ms fuel update | True when `DeltaLapsIfPush >= 0` | Fuel strategy |
-| Fuel.Pit.TotalNeededToEnd | double | Liters | 500 ms fuel update | `LiveLapsRemainingInRace * LiveFuelPerLap` | Pit/fuel |
-| Fuel.Pit.NeedToAdd | double | Liters | 500 ms fuel update | `max(0, TotalNeededToEnd - currentFuel)` | Pit/fuel |
-| Fuel.Pit.TankSpaceAvailable | double | Liters | 500 ms fuel update | `max(0, capacity - currentFuel)` using BoP/override max | Pit/fuel |
-| Fuel.Pit.WillAdd | double | Liters | 500 ms fuel update | Requested add (telemetry) clamped to tank space; 0 if refuel not selected | Pit/fuel |
-| Fuel.Pit.DeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop surplus using live burn | Pit/fuel |
-| Fuel.Pit.FuelSaveDeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop surplus using save burn | Pit/fuel |
-| Fuel.Pit.PushDeltaAfterStop | double | Laps | 500 ms fuel update | Post-stop surplus using push burn | Pit/fuel |
-| Fuel.Pit.FuelOnExit | double | Liters | 500 ms fuel update | `currentFuel + WillAdd` | Pit/fuel |
-| Fuel.Pit.StopsRequiredToEnd | int | Count | 500 ms fuel update | Strategy-required stops or capacity-based ceil | Pit/fuel |
-| Fuel.Live.RefuelRate_Lps | double | Liters/sec | Per-tick | FuelCalcs effective refuel rate (profile/measured) | Fuel strategy |
-| Fuel.Live.TireChangeTime_S | double | Seconds | Per-tick | Tyre change time if any tyre selected, else 0 | Fuel strategy |
-| Fuel.Live.PitLaneLoss_S | double | Seconds | Per-tick | PitEngine lane loss (DTL) used for fuel strategy | Fuel strategy |
-| Fuel.Live.TotalStopLoss | double | Seconds | Per-tick | Lane loss + box time max(fuel, tyres) | Fuel strategy |
-| Fuel.Live.DriveTimeAfterZero | double | Seconds | 500 ms fuel update | Projected drive after timer zero (max of observed/strategy/lap) | Fuel strategy |
-| Fuel.Live.ProjectedDriveSecondsRemaining | double | Seconds | 500 ms fuel update | Remaining wall time including overrun | Fuel strategy |
-| Pace.StintAvgLapTimeSec | double | Seconds | 500 ms update | Rolling stint average from live laps | Pace |
-| Pace.Last5LapAvgSec | double | Seconds | 500 ms update | Rolling 5-lap average | Pace |
-| Pace.PaceConfidence | int | Score | 500 ms update | Internal confidence heuristics | Pace |
-| Pace.OverallConfidence | int | Score | 500 ms update | min(fuel, pace confidence) | Pace |
-| Pit.LastDirectTravelTime | double | Seconds | On valid pit measurement | PitEngine detection of lane travel | Pit timing |
-| Pit.LastTotalPitCycleTimeLoss | double | Seconds | On valid pit measurement | PitEngine | Pit timing |
-| Pit.LastPaceDeltaNetLoss | double | Seconds | On valid pit measurement | PitEngine pace delta | Pit timing |
-| PitLite.Live.TimeOnPitRoadSec | double | Seconds | Per-tick pit monitor | PitEngine elapsed lane time | Pit-lite |
-| PitLite.Live.TimeInBoxSec | double | Seconds | Per-tick pit monitor | PitEngine stationary time | Pit-lite |
-| PitLite.TotalLossSec | double | Seconds | On lap-end candidate latch | PitCycleLite total loss | Pit-lite |
-| PitLite.TotalLossPlusBoxSec | double | Seconds | On lap-end candidate latch | PitCycleLite total loss plus box time | Pit-lite |
-| CurrentDashPage | string | Enum string | Per-tick | ScreenManager.CurrentPage | Dashboard control |
-| DashControlMode | string | Enum string | Per-tick | ScreenManager.Mode | Dashboard control |
-| FalseStartDetected | bool | Flag | Per-tick | Launch state detection | Launch |
-| LastSessionType | string | Session type | Per-tick | Cached from telemetry | Session |
-| Race.LeaderHasFinished | bool | Flag | Per-tick | Checkered flag latch for leader | Session |
-| MsgCxPressed | bool | Flag | Per-tick | Messaging input state | Messaging |
-| PitScreenActive | bool | Flag | Per-tick | Launch/Msg screen selection | Dashboard control |
-| RejoinAlertReasonCode | int | Code | Per-tick | RejoinAssistEngine.CurrentLogicCode | Rejoin assist |
-| RejoinAlertReasonName | string | Name | Per-tick | RejoinAssistEngine.CurrentLogicCode.ToString() | Rejoin assist |
-| RejoinAlertMessage | string | Message | Per-tick | RejoinAssistEngine.CurrentMessage | Rejoin assist |
-| RejoinIsExitingPits | bool | Flag | Per-tick | RejoinAssistEngine.IsExitingPits | Rejoin assist |
-| RejoinCurrentPitPhaseName | string | Enum string | Per-tick | RejoinAssistEngine.CurrentPitPhase | Rejoin assist |
-| RejoinCurrentPitPhase | int | Enum code | Per-tick | RejoinAssistEngine.CurrentPitPhase | Rejoin assist |
-| RejoinThreatLevel | int | Enum code | Per-tick | RejoinAssistEngine.CurrentThreatLevel | Rejoin assist |
-| RejoinThreatLevelName | string | Name | Per-tick | RejoinAssistEngine.CurrentThreatLevel | Rejoin assist |
-| RejoinTimeToThreat | double | Seconds | Per-tick | RejoinAssistEngine.TimeToThreatSeconds | Rejoin assist |
-| LalaDashShowLaunchScreen | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowPitLimiter | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowPitScreen | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowRejoinAssist | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowVerboseMessaging | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowRaceFlags | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowRadioMessages | bool | Flag | Per-tick | Settings | Dash config |
-| LalaDashShowTraffic | bool | Flag | Per-tick | Settings | Dash config |
-| MsgDashShowLaunchScreen | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowPitLimiter | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowPitScreen | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowRejoinAssist | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowVerboseMessaging | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowRaceFlags | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowRadioMessages | bool | Flag | Per-tick | Settings | Msg dash config |
-| MsgDashShowTraffic | bool | Flag | Per-tick | Settings | Msg dash config |
-| ManualTimeoutRemaining | string | Seconds remaining | Per-tick when launch active | Countdown from manual launch arming | Launch |
-| ActualRPMAtClutchRelease | string | RPM | Per launch event | Captured from telemetry at clutch release | Launch |
-| ActualThrottleAtClutchRelease | double | % | Per launch event | Telemetry snapshot | Launch |
-| AntiStallActive | bool | Flag | Per-tick | Telemetry flag | Launch |
-| AntiStallDetectedInLaunch | bool | Flag | Per launch event | Launch detection | Launch |
-| AvgSessionLaunchRPM | string | RPM | Per launch aggregation | Average of session launches | Launch |
-| BitePointInTargetRange | bool | Flag | Per launch event | Derived from clutch telemetry vs. target | Launch |
-| BoggedDown | bool | Flag | Per launch event | Launch performance heuristic | Launch |
-| BogDownFactorPercent | double | % | Per-tick | ActiveProfile setting | Launch |
-| ClutchReleaseDelta | string | ms | Per launch event | Time delta during release | Launch |
-| ClutchReleaseTime | double | Seconds | Per launch event | Telemetry | Launch |
-| LastAvgLaunchRPM | double | RPM | Per launch event | Session aggregate | Launch |
-| LastLaunchRPM | double | RPM | Per launch event | Telemetry snapshot | Launch |
-| LastMinRPM | double | RPM | Per launch event | Telemetry snapshot | Launch |
-| LaunchModeActive | bool | Flag | Per-tick | Launch visibility state | Launch |
-| LaunchStateLabel | string | Enum string | Per-tick | Launch state | Launch |
-| LaunchStateCode | string | Enum code | Per-tick | Launch state | Launch |
-| LaunchRPM | double | RPM | Per-tick | Target/actual launch RPM | Launch |
-| MaxTractionLoss | double | % | Per launch event | Telemetry | Launch |
-| MinRPM | double | RPM | Per launch event | Telemetry | Launch |
-| OptimalBitePoint | double | % | Per-tick | ActiveProfile target | Launch |
-| OptimalBitePointTolerance | double | % | Per-tick | ActiveProfile tolerance | Launch |
-| OptimalRPMTolerance | string | RPM | Per-tick | ActiveProfile tolerance | Launch |
-| OptimalThrottleTolerance | string | % | Per-tick | ActiveProfile tolerance | Launch |
-| ReactionTime | double | ms | Per launch event | Launch detection | Launch |
-| RPMDeviationAtClutchRelease | string | RPM | Per launch event | Telemetry vs. target | Launch |
-| RPMInTargetRange | bool | Flag | Per launch event | Telemetry window check | Launch |
-| TargetLaunchRPM | string | RPM | Per-tick | ActiveProfile target | Launch |
-| TargetLaunchThrottle | string | % | Per-tick | ActiveProfile target | Launch |
-| ThrottleDeviationAtClutchRelease | double | % | Per launch event | Telemetry vs. target | Launch |
-| ThrottleInTargetRange | bool | Flag | Per launch event | Telemetry window check | Launch |
-| ThrottleModulationDelta | double | % | Per launch event | Telemetry modulation | Launch |
-| WheelSpinDetected | bool | Flag | Per launch event | Launch detection | Launch |
-| ZeroTo100Delta | double | km/h difference | Per launch event | Launch performance | Launch |
-| ZeroTo100Time | double | Seconds | Per launch event | Launch performance | Launch |
-| MSG.OvertakeApproachLine | double | meters/seconds (relative line) | Per-tick when enabled | MessagingSystem overtake model | Messaging |
-| MSG.OvertakeWarnSeconds | double | Seconds | Per-tick when enabled | ActiveProfile traffic warning setting | Messaging |
-| MSG.MsgCxTimeMessage | string | Message text | Dash-driven | Placeholder lane for time-silenced alerts (e.g., BOX BOX) | Messaging |
-| MSG.MsgCxTimeVisible | bool | Flag | Dash-driven | True when the time-silenced lane is active/visible | Messaging |
-| MSG.MsgCxTimeSilenceRemaining | double | Seconds | Dash-driven | Remaining silence on the time lane after MsgCx press | Messaging |
-| MSG.MsgCxStateMessage | string | Message text | Dash-driven | Placeholder lane cleared until state/token changes | Messaging |
-| MSG.MsgCxStateVisible | bool | Flag | Dash-driven | True when the state-change lane is active/visible | Messaging |
-| MSG.MsgCxStateToken | string | Token | Dash-driven | Current state token controlling re-appearance | Messaging |
-| MSG.MsgCxActionMessage | string | Message text | Dash-driven | Placeholder lane that fires an action on MsgCx press | Messaging |
-| MSG.MsgCxActionPulse | bool | Flag | Dash-driven | One-shot pulse when the action lane is triggered | Messaging |
+### Fuel model and projection
+| Exported name | Type | Units / meaning | Update cadence | Primary source |
+| --- | --- | --- | --- | --- |
+| Fuel.LiveFuelPerLap | double | L/lap burn used for all projections | 500 ms tick + lap crossing | Rolling accepted laps / fallback SimHub estimate |
+| Fuel.LiveFuelPerLap_Stable | double | Smoothed burn used when the live figure is noisy | 500 ms tick | `LiveFuelPerLap` stability window |
+| Fuel.LiveFuelPerLap_StableSource | string | Provenance for the stable burn (live / profile / sim) | 500 ms tick | Stability selector |
+| Fuel.LiveFuelPerLap_StableConfidence | int | Confidence for the stable burn | 500 ms tick | Stability selector |
+| Fuel.LiveLapsRemainingInRace | double | Laps remaining using current projection | 500 ms tick | `ComputeProjectedLapsRemaining` |
+| Fuel.LiveLapsRemainingInRace_S | string | Formatted laps-remaining string | 500 ms tick | Above calculation |
+| Fuel.LiveLapsRemainingInRace_Stable | double | Laps remaining using stable burn | 500 ms tick | Stable burn projection |
+| Fuel.LiveLapsRemainingInRace_Stable_S | string | Formatted stable projection | 500 ms tick | Stable burn projection |
+| Fuel.DeltaLaps | double | Surplus/deficit to finish at current burn | 500 ms tick | Tank laps − projected race laps |
+| Fuel.TargetFuelPerLap | double | Required burn to finish when short | 500 ms tick | Current fuel ÷ projected laps |
+| Fuel.LapsRemainingInTank | double | Laps possible with current fuel | 500 ms tick | Tank fuel ÷ `LiveFuelPerLap` |
+| Fuel.ProjectionLapTime_Stable | double | Lap time used for race-length projection | 500 ms tick | Pace estimator |
+| Fuel.ProjectionLapTime_StableSource | string | Source label for projection lap time | 500 ms tick | Pace estimator |
+| Fuel.Confidence | int | Fuel-model confidence score | Lap crossing; surfaced each tick | Window quality heuristics |
+| Fuel.PushFuelPerLap | double | Aggressive burn guidance | 500 ms tick | Max observed/session heuristic |
+| Fuel.FuelSavePerLap | double | Conservative burn guidance | 500 ms tick | Window minima |
+| Fuel.DeltaLapsIfPush | double | Surplus/deficit if driving at push burn | 500 ms tick | Push guidance |
+| Fuel.CanAffordToPush | bool | True when push burn still finishes the race | 500 ms tick | Push guidance |
+| Fuel.Live.DriveTimeAfterZero | double | Expected driving after race timer hits 0 | 500 ms tick | Strategy overrun model |
+| Fuel.Live.ProjectedDriveSecondsRemaining | double | Wall-time remaining including overrun | 500 ms tick | Strategy overrun model |
 
-**MsgCx dash actions (button bindings)**
-- `MsgCx` — single-button entry point; automatically targets the active lane in priority order (time → state → action).
-- `MsgCxTimeOnly` / `MsgCxStateOnly` / `MsgCxActionOnly` — optional lane-specific bindings if you want separate buttons.
-| Fuel.LastPitLaneTravelTime | double | Seconds | On valid measurement | PitEngine direct travel time | Pit timing |
+### Fuel deltas and pit needs
+| Exported name | Type | Units / meaning | Update cadence | Primary source |
+| --- | --- | --- | --- | --- |
+| Fuel.Delta.LitresCurrent / LitresPlan / LitresWillAdd | double | Liters needed vs. finish for current fuel, current MFD plan, and planned add | 500 ms tick | FuelCalculator deltas |
+| Fuel.Delta.LitresCurrentPush / LitresPlanPush / LitresWillAddPush | double | Same as above assuming push burn | 500 ms tick | FuelCalculator deltas |
+| Fuel.Delta.LitresCurrentSave / LitresPlanSave / LitresWillAddSave | double | Same as above assuming fuel-save burn | 500 ms tick | FuelCalculator deltas |
+| Fuel.Pit.TotalNeededToEnd / TotalNeededToEnd_S | double/string | Total liters to finish at current burn | 500 ms tick | Live burn × projected laps |
+| Fuel.Pit.NeedToAdd | double | Additional liters required to finish | 500 ms tick | Total needed − tank fuel |
+| Fuel.Pit.TankSpaceAvailable | double | Liters that fit given BoP/override tank | 500 ms tick | Telemetry max fuel / override |
+| Fuel.Pit.WillAdd | double | Liters expected to be added (after clamping to tank space) | 500 ms tick | Telemetry MFD refuel request |
+| Fuel.Pit.FuelOnExit | double | Estimated fuel after completing the stop | 500 ms tick | Current fuel + `WillAdd` |
+| Fuel.Pit.DeltaAfterStop / DeltaAfterStop_S | double/string | Lap surplus after stop at current burn | 500 ms tick | `FuelOnExit` ÷ burn − race laps |
+| Fuel.Pit.FuelSaveDeltaAfterStop / _S | double/string | Lap surplus after stop at save burn | 500 ms tick | Save burn projection |
+| Fuel.Pit.PushDeltaAfterStop / _S | double/string | Lap surplus after stop at push burn | 500 ms tick | Push burn projection |
+| Fuel.PitStopsRequiredByFuel | int | Stops implied by capacity vs. deficit | 500 ms tick | Capacity-based ceiling |
+| Fuel.PitStopsRequiredByPlan | int | Stops from strategy plan | 500 ms tick | FuelCalculator strategy |
+| Fuel.Pit.StopsRequiredToEnd | int | Final stops required (plan or capacity) | 500 ms tick | Strategy + capacity |
+| Fuel.Live.RefuelRate_Lps | double | Effective refuel rate | 500 ms tick | FuelCalcs profile/measured rate |
+| Fuel.Live.TireChangeTime_S | double | Seconds to change tyres if selected | 500 ms tick | FuelCalcs tyre-time estimator |
+| Fuel.Live.PitLaneLoss_S | double | Pit lane loss used by strategy | 500 ms tick | FuelCalcs lane loss |
+| Fuel.Live.TotalStopLoss | double | Pit lane loss + service time | 500 ms tick | FuelCalcs + tyre/refuel time |
 
-### Verbose / debug parameters (published only when `SimhubPublish.VERBOSE` is true)
-| Exported name | Type | Units / meaning | Update mechanism | Primary source | Notes / grouping |
-| --- | --- | --- | --- | --- | --- |
-| Pit.Debug.TimeOnPitRoad | double | Seconds | Per-tick | PitEngine | Pit debug |
-| Pit.Debug.LastPitStopDuration | double | Seconds | Per-tick | PitEngine | Pit debug |
-| Lala.Pit.AvgPaceUsedSec | double | Seconds | Per pit calc | PitEngine baseline pace | Pit debug |
-| Lala.Pit.AvgPaceSource | string | Label | Per pit calc | PitEngine baseline provenance | Pit debug |
-| Lala.Pit.Raw.PitLapSec | double | Seconds | Per pit calc | Raw pit lap delta | Pit debug |
-| Lala.Pit.Raw.DTLFormulaSec | double | Seconds | Per pit calc | Formula delta | Pit debug |
-| Lala.Pit.InLapSec | double | Seconds | Per pit calc | In-lap delta vs. baseline | Pit debug |
-| Lala.Pit.OutLapSec | double | Seconds | Per pit calc | Out-lap delta vs. baseline | Pit debug |
-| Lala.Pit.DeltaInSec | double | Seconds | Per pit calc | In-lap loss | Pit debug |
-| Lala.Pit.DeltaOutSec | double | Seconds | Per pit calc | Out-lap loss | Pit debug |
-| Lala.Pit.DriveThroughLossSec | double | Seconds | Per pit calc | Drive-through loss | Pit debug |
-| Lala.Pit.DirectTravelSec | double | Seconds | Per pit calc | Lane direct travel | Pit debug |
-| Lala.Pit.StopSeconds | double | Seconds | Per pit calc | Stationary time | Pit debug |
-| Lala.Pit.ServiceStopLossSec | double | Seconds | Per pit calc | Total service loss (travel + stop) | Pit debug |
-| Lala.Pit.Profile.PitLaneLossSec | double | Seconds | Per pit calc | Profile pit lane loss | Pit debug |
-| Lala.Pit.CandidateSavedSec | double | Seconds | On save | PitLite saved loss | Pit debug |
-| Lala.Pit.CandidateSource | string | Label | On save | PitLite saved source | Pit debug |
-| PitLite.InLapSec | double | Seconds | Per-tick | PitCycleLite in-lap | Pit-lite debug |
-| PitLite.OutLapSec | double | Seconds | Per-tick | PitCycleLite out-lap | Pit-lite debug |
-| PitLite.DeltaInSec | double | Seconds | Per-tick | PitCycleLite delta | Pit-lite debug |
-| PitLite.DeltaOutSec | double | Seconds | Per-tick | PitCycleLite delta | Pit-lite debug |
-| PitLite.TimePitLaneSec | double | Seconds | Per-tick | PitCycleLite lane time | Pit-lite debug |
-| PitLite.TimePitBoxSec | double | Seconds | Per-tick | PitCycleLite box time | Pit-lite debug |
-| PitLite.DirectSec | double | Seconds | Per-tick | PitCycleLite direct time | Pit-lite debug |
-| PitLite.DTLSec | double | Seconds | Per-tick | PitCycleLite drive-through loss | Pit-lite debug |
-| PitLite.Status | string | Enum string | Per-tick | PitCycleLite status | Pit-lite debug |
-| PitLite.CurrentLapType | string | Enum string | Per-tick | PitCycleLite current lap type | Pit-lite debug |
-| PitLite.LastLapType | string | Enum string | Per-tick | PitCycleLite last lap type | Pit-lite debug |
-| PitLite.LossSource | string | Label | On save | PitCycleLite saved source | Pit-lite debug |
-| PitLite.LastSaved.Sec | double | Seconds | On save | PitCycleLite saved loss | Pit-lite debug |
-| PitLite.LastSaved.Source | string | Label | On save | PitCycleLite saved source | Pit-lite debug |
-| PitLite.Live.SeenEntryThisLap | bool | Flag | Per-tick | PitCycleLite | Pit-lite debug |
-| PitLite.Live.SeenExitThisLap | bool | Flag | Per-tick | PitCycleLite | Pit-lite debug |
+### Pace and race state
+| Exported name | Type | Units / meaning | Update cadence | Primary source |
+| --- | --- | --- | --- | --- |
+| Pace.StintAvgLapTimeSec | double | Rolling stint-average lap | Lap crossing surfaced each tick | Pace estimator |
+| Pace.Last5LapAvgSec | double | Average of last up-to-five clean laps | Lap crossing surfaced each tick | Pace estimator |
+| Pace.LeaderAvgLapTimeSec | double | Rolling leader pace | Lap crossing surfaced each tick | Leader telemetry candidate read |
+| Pace.LeaderDeltaToPlayerSec | double | Leader pace − player pace | Lap crossing surfaced each tick | Derived from above |
+| Pace.PaceConfidence | int | Pace model confidence | Lap crossing surfaced each tick | Heuristics on lap quality |
+| Pace.OverallConfidence | int | Min of pace/fuel confidence | Lap crossing surfaced each tick | Derived |
+| Race.OverallLeaderHasFinished / Race.ClassLeaderHasFinished / Race.LeaderHasFinished | bool | Checkered flag latches | Per-tick | Session flags |
+| Race.OverallLeaderHasFinishedValid / Race.ClassLeaderHasFinishedValid | bool | Validity flags for leader-finished values | Per-tick | Session flags |
 
-## Driver-Facing Dashboard Parameters
+### Pit timing and PitLite
+| Exported name | Type | Units / meaning | Update cadence | Primary source |
+| --- | --- | --- | --- | --- |
+| Pit.LastDirectTravelTime | double | Limiter-to-limiter lane time | On valid pit measurement | PitEngine direct travel |
+| Pit.LastTotalPitCycleTimeLoss | double | Pit delta vs. baseline pace | On valid pit measurement | PitEngine DTL | 
+| Pit.LastPaceDeltaNetLoss | double | Pit loss minus stopped time | On valid pit measurement | PitEngine |
+| PitLite.Live.TimeOnPitRoadSec | double | Running lane timer | Per-tick during pit | PitEngine |
+| PitLite.Live.TimeInBoxSec | double | Running stationary timer | Per-tick during pit | PitEngine |
+| PitLite.TotalLossSec | double | Preferred pit loss output (DTL/direct) | Latched on out-lap | PitCycleLite |
+| PitLite.TotalLossPlusBoxSec | double | Pit loss plus stationary time | Latched on out-lap | PitCycleLite |
 
-The most driver-relevant signals (intended for dashboards rather than engineering screens) are:
+### Dashboard overlays and rejoin assist
+| Exported name | Type | Meaning |
+| --- | --- | --- |
+| CurrentDashPage | string | Active dash page |
+| DashControlMode | string | Dash auto/manual mode |
+| PitScreenActive | bool | Whether pit screen is being shown |
+| FalseStartDetected | bool | Launch false-start latch |
+| LastSessionType | string | Most recent session type token |
+| MsgCxPressed | bool | Whether MsgCx button was pressed this tick |
+| RejoinAlertReasonCode / Name | int/string | Active rejoin logic code |
+| RejoinAlertMessage | string | Human-readable rejoin instruction |
+| RejoinIsExitingPits | bool | Pit phase flag |
+| RejoinCurrentPitPhase / Name | int/string | Current pit phase enum |
+| RejoinThreatLevel / Name | int/string | Current traffic threat level |
+| RejoinTimeToThreat | double | Seconds to nearest threat |
 
-- **Fuel strategy:** `Fuel.LiveFuelPerLap`, `Fuel.LiveLapsRemainingInRace`, `Fuel.LapsRemainingInTank`, `Fuel.Pit.TotalNeededToEnd`, `Fuel.Pit.NeedToAdd`, `Fuel.PushFuelPerLap`, `Fuel.DeltaLapsIfPush`, `Fuel.IsPitWindowOpen`, `Fuel.PitWindowOpeningLap`, `Fuel.Pit.StopsRequiredToEnd`, `Fuel.LastPitLaneTravelTime`.
-- **Pace awareness:** `Pace.StintAvgLapTimeSec`, `Pace.Last5LapAvgSec`, `Pace.PaceConfidence`, `Pace.OverallConfidence`.
-- **Pit/penalty context:** `Pit.LastDirectTravelTime`, `Pit.LastTotalPitCycleTimeLoss`, `Pit.LastPaceDeltaNetLoss`, `PitLite.TotalLossSec`.
-- **Rejoin assist:** `RejoinAlertReasonCode`, `RejoinAlertReasonName`, `RejoinAlertMessage`, `RejoinIsExitingPits`, `RejoinCurrentPitPhase`, `RejoinThreatLevel`, `RejoinTimeToThreat`.
-- **Launch / start aids:** `LaunchModeActive`, `LaunchStateLabel`, `LaunchRPM`, `TargetLaunchRPM`, `TargetLaunchThrottle`, `ActualRPMAtClutchRelease`, `ActualThrottleAtClutchRelease`, `ManualTimeoutRemaining`.
+### Dash visibility settings
+| Exported name | Type | Dash |
+| --- | --- | --- |
+| LalaDashShowLaunchScreen, LalaDashShowPitLimiter, LalaDashShowPitScreen, LalaDashShowRejoinAssist, LalaDashShowVerboseMessaging, LalaDashShowRaceFlags, LalaDashShowRadioMessages, LalaDashShowTraffic | bool | Lala dash toggles |
+| MsgDashShowLaunchScreen, MsgDashShowPitLimiter, MsgDashShowPitScreen, MsgDashShowRejoinAssist, MsgDashShowVerboseMessaging, MsgDashShowRaceFlags, MsgDashShowRadioMessages, MsgDashShowTraffic | bool | Messaging dash toggles |
 
-Reliability/caveats:
-- Fuel and pace fields are refreshed in the 500 ms loop and rely on continuous live telemetry; confidence scores indicate stability. They are trustworthy only while the session is running and clean laps are being logged.
-- Pit loss metrics latch when PitEngine/PitCycleLite detect valid pit cycles; between stops they retain the last saved values.
-- Rejoin assist outputs are only meaningful when the RejoinAssistEngine is enabled and actively tracking incidents.
-- Launch parameters update during the launch routine; outside of start procedures, many retain the last run values.
+### Launch control & manual timer
+| Exported name | Type | Units / meaning |
+| --- | --- | --- |
+| ManualTimeoutRemaining | string | Seconds remaining on manual launch arm |
+| ActualRPMAtClutchRelease | string | RPM snapshot at clutch release |
+| ActualThrottleAtClutchRelease | double | % throttle at clutch release |
+| AntiStallActive / AntiStallDetectedInLaunch | bool | Anti-stall flags |
+| AvgSessionLaunchRPM / LastAvgLaunchRPM | string/double | Session average launch RPM |
+| BitePointInTargetRange | bool | Whether clutch bite was within tolerance |
+| BoggedDown / BogDownFactorPercent | bool/double | Bog-down detection and profile factor |
+| ClutchReleaseDelta | string | ms delta during release |
+| ClutchReleaseTime | double | Seconds for clutch release |
+| LastLaunchRPM / LastMinRPM / MinRPM | double | Telemetry snapshots |
+| LaunchModeActive | bool | Whether launch UI is visible |
+| LaunchStateLabel / LaunchStateCode | string | Current launch state |
+| LaunchRPM / TargetLaunchRPM | double | Live and target launch RPM |
+| MaxTractionLoss | double | % slip observed |
+| OptimalBitePoint / OptimalBitePointTolerance | double | Target bite point and tolerance |
+| OptimalRPMTolerance / OptimalThrottleTolerance | string | Tolerances for RPM and throttle |
+| ReactionTime | double | ms to release |
+| RPMDeviationAtClutchRelease | string | Delta vs. target RPM |
+| RPMInTargetRange | bool | RPM window flag |
+| TargetLaunchThrottle | string | Target throttle % |
+| ThrottleDeviationAtClutchRelease | double | Delta vs. target throttle |
+| ThrottleInTargetRange | bool | Throttle window flag |
+| ThrottleModulationDelta | double | % modulation measurement |
+| WheelSpinDetected | bool | Wheel spin flag |
+| ZeroTo100Delta | double | km/h delta vs. baseline |
+| ZeroTo100Time | double | 0–100 km/h time for last launch |
 
-## Observations / Potential Issues
+### Messaging system
+| Exported name | Type | Meaning |
+| --- | --- | --- |
+| MSG.OvertakeApproachLine | double | Relative line metric for approaching traffic |
+| MSG.OvertakeWarnSeconds | double | Seconds of approach buffer to warn |
+| MSG.MsgCxTimeMessage / MsgCxStateMessage / MsgCxActionMessage | string | Message text per lane |
+| MSG.MsgCxTimeVisible / MsgCxStateVisible | bool | Visibility for time/state lanes |
+| MSG.MsgCxTimeSilenceRemaining | double | Remaining silence window for time lane |
+| MSG.MsgCxStateToken | string | Token controlling state lane reappearance |
+| MSG.MsgCxActionPulse | bool | One-shot trigger when action lane fires |
 
-- Verbose properties are gated behind `SimhubPublish.VERBOSE`; dashboards relying on them must enable that flag explicitly.
-- Several launch-related properties are formatted as strings (e.g., RPM values with `ToString("F0")`) while others are numeric, which may confuse dashboards expecting consistent types.
-- `ManualTimeoutRemaining` returns an empty string when not armed instead of `0`, so widgets should handle blank output.
-- Pace and fuel confidence are separate but `Pace.OverallConfidence` simply takes the minimum; consumers should pick the most relevant metric rather than assume it is independently computed.
+## Verbose / debug parameters
+| Exported name | Type | Units / meaning | Update cadence | Source |
+| --- | --- | --- | --- | --- |
+| Pit.Debug.TimeOnPitRoad | double | Seconds on pit road (live timer) | Per-tick | PitEngine |
+| Pit.Debug.LastPitStopDuration | double | Stationary box timer | Per-tick | PitEngine |
+| Lala.Pit.AvgPaceUsedSec | double | Baseline pace fed into DTL | Per calc | PitEngine |
+| Lala.Pit.AvgPaceSource | string | Source label for baseline pace | Per calc | PitEngine |
+| Lala.Pit.Raw.PitLapSec | double | Pit lap including stop | Per calc | PitEngine |
+| Lala.Pit.Raw.DTLFormulaSec | double | Raw DTL computation | Per calc | PitEngine |
+| Lala.Pit.InLapSec / OutLapSec | double | In/out lap deltas vs. baseline | Per calc | PitEngine |
+| Lala.Pit.DeltaInSec / DeltaOutSec | double | In/out loss contributions | Per calc | PitEngine |
+| Lala.Pit.DriveThroughLossSec | double | Drive-through-style loss | Per calc | PitEngine |
+| Lala.Pit.DirectTravelSec | double | Direct lane travel time | Per calc | PitEngine |
+| Lala.Pit.StopSeconds | double | Stationary stop duration | Per calc | PitEngine |
+| Lala.Pit.ServiceStopLossSec | double | DTL + stop time (floored) | Per calc | PitEngine |
+| Lala.Pit.Profile.PitLaneLossSec | double | Saved profile pit-lane loss | Per calc | Active profile track |
+| Lala.Pit.CandidateSavedSec / CandidateSource | double/string | Last saved pit-loss candidate and provenance | On save | PitEngine |
+| PitLite.InLapSec / OutLapSec | double | Latched pit-lite lap deltas | Per-tick | PitCycleLite |
+| PitLite.DeltaInSec / DeltaOutSec | double | Pit-lite deltas vs. pace | Per-tick | PitCycleLite |
+| PitLite.TimePitLaneSec / TimePitBoxSec | double | Latched timers from PitEngine | Per-tick | PitCycleLite |
+| PitLite.DirectSec | double | Lane time minus box | Per-tick | PitCycleLite |
+| PitLite.DTLSec | double | Pit-lite DTL (floored) | Per-tick | PitCycleLite |
+| PitLite.Status | string | Pit-lite status enum | Per-tick | PitCycleLite |
+| PitLite.CurrentLapType / LastLapType | string | Current/previous lap classification | Per-tick | PitCycleLite |
+| PitLite.LossSource | string | Whether DTL or direct loss was published | Per-tick | PitCycleLite |
+| PitLite.LastSaved.Sec / LastSaved.Source | double/string | Last saved pit-lite candidate and source | On save | PitCycleLite |
+| PitLite.Live.SeenEntryThisLap / SeenExitThisLap | bool | Pit-edge flags for current lap | Per-tick | PitCycleLite |


### PR DESCRIPTION
## Summary
- refresh SimHub parameter inventory and pit property docs to match current exports
- update fuel property spec to reflect current calculations and projections
- add catalog of SimHub log info messages and remove obsolete branch documents

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69410e4435d8832fa3d2713738aea0b4)