### PR TITLE
Gate fuel readiness for messaging and snapshot

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1249,7 +1249,8 @@ namespace LaunchPlugin
 
         if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
             && !IsFuelPerLapManual
-            && value > 0)
+            && value > 0
+            && (_plugin?.IsFuelReady ?? false))
         {
             ApplyPlanningSourceToAutoFields(applyLapTime: false, applyFuel: true);
         }
@@ -2642,6 +2643,8 @@ namespace LaunchPlugin
 
         try
         {
+            bool fuelReady = _plugin?.IsFuelReady ?? false;
+
             if (applyLapTime && !IsEstimatedLapTimeManual)
             {
                 TimeSpan? lap = null;
@@ -2654,8 +2657,11 @@ namespace LaunchPlugin
                 }
                 else if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
                 {
-                    lap = GetLiveAverageLapTimeSnapshot();
-                    lapSource = "Live avg";
+                    if (fuelReady)
+                    {
+                        lap = GetLiveAverageLapTimeSnapshot();
+                        lapSource = "Live avg";
+                    }
                 }
 
                 if (lap.HasValue)
@@ -2683,7 +2689,10 @@ namespace LaunchPlugin
                 }
                 else if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
                 {
-                    fuel = GetLiveAverageFuelPerLapForCurrentCondition();
+                    if (fuelReady)
+                    {
+                        fuel = GetLiveAverageFuelPerLapForCurrentCondition();
+                    }
                 }
 
                 if (fuel.HasValue)

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -434,6 +434,14 @@ namespace LaunchPlugin
             }
         }
 
+        public bool IsFuelReady
+        {
+            get
+            {
+                return LiveFuelPerLap_StableConfidence >= GetFuelReadyConfidenceThreshold();
+            }
+        }
+
         private PitCycleLite _pitLite; // simple, deterministic pit-cycle surface for the test dash
 
         // Freeze latched pit debug values after we finalize at the end of OUT LAP.

--- a/Messaging/MessageEvaluators.cs
+++ b/Messaging/MessageEvaluators.cs
@@ -84,6 +84,8 @@ namespace LaunchPlugin.Messaging
             if (_latchedThisSession) return false;
 
             if (!TryGet(signals, "PitStopsRequiredByFuel", out int stopsRequired)) return false;
+            if (!TryGet(signals, "FuelIsReady", out bool fuelReady)) return false;
+            if (!fuelReady) return false;
             if (stopsRequired != 0) return false;
 
             _latchedThisSession = true;

--- a/Messaging/SignalProvider.cs
+++ b/Messaging/SignalProvider.cs
@@ -66,6 +66,7 @@ namespace LaunchPlugin.Messaging
                 { "FuelLapsRemaining", () => _plugin?.LiveLapsRemainingInRace },
                 { "FuelDeltaLaps", () => _plugin?.DeltaLaps },
                 { "FuelCanPush", () => _plugin?.CanAffordToPush },
+                { "FuelIsReady", () => _plugin?.IsFuelReady },
                 { "PitStopsRequiredByFuel", () => _plugin?.PitStopsRequiredByFuel },
                 { "PitWindowOpen", () => _plugin?.IsPitWindowOpen },
 


### PR DESCRIPTION
## Summary
- expose a shared IsFuelReady flag using the FuelReadyConfidence threshold and surface it to messaging
- block fuel.push_ok until fuel readiness is met to avoid fallback-triggered push messaging
- gate LiveSnapshot auto-apply for fuel and pace on readiness so low-confidence values don’t overwrite plans

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499cbf6ec0832fbad86048b61f936c)