### PR TITLE
Handle missing MSGV1 evaluator placeholders

### DIFF
--- a/Messaging/MessageDefinitionStore.cs
+++ b/Messaging/MessageDefinitionStore.cs
@@ -8,6 +8,11 @@ namespace LaunchPlugin.Messaging
     public static class MessageDefinitionStore
     {
         private const string FileName = "LalaLaunch.Messages.json";
+        private static readonly HashSet<string> ExcludedMsgIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "rejoin.threat_high",
+            "rejoin.threat_med"
+        };
 
         public static string GetFolderPath()
         {
@@ -40,6 +45,7 @@ namespace LaunchPlugin.Messaging
                 {
                     ApplyDefaults(def);
                 }
+                RemoveExcludedMessages(list);
                 if (list.Count == 0)
                 {
                     list = BuildDefaultDefinitions();
@@ -579,7 +585,14 @@ namespace LaunchPlugin.Messaging
                 ApplyDefaults(def);
             }
 
+            RemoveExcludedMessages(list);
             return list;
+        }
+
+        private static void RemoveExcludedMessages(List<MessageDefinition> list)
+        {
+            if (list == null || list.Count == 0) return;
+            list.RemoveAll(def => def != null && ExcludedMsgIds.Contains(def.MsgId ?? string.Empty));
         }
     }
 }

--- a/Messaging/MessageEngine.cs
+++ b/Messaging/MessageEngine.cs
@@ -503,6 +503,14 @@ namespace LaunchPlugin.Messaging
                 var msgs = referenced.TryGetValue(id, out var list) ? string.Join(",", list) : "";
                 return $"{id}|{msgs}";
             }));
+
+            var summary = string.Join("; ", missing.Select(id =>
+            {
+                var msgs = referenced.TryGetValue(id, out var list) ? string.Join(",", list) : "";
+                return $"{id} -> {msgs}";
+            }));
+
+            LogInfo($"Registered placeholder evaluators for missing IDs: {summary}");
         }
     }
 
@@ -556,24 +564,15 @@ namespace LaunchPlugin.Messaging
 
     internal class MissingEvaluator : IMessageEvaluator
     {
-        private readonly string _id;
-        private readonly List<string> _msgIds;
-        private bool _logged;
-
         public MissingEvaluator(string id, List<string> msgIds)
         {
-            _id = id ?? "unknown";
-            _msgIds = msgIds ?? new List<string>();
+            _ = id;
+            _ = msgIds;
         }
 
         public bool Evaluate(MessageDefinition definition, ISignalProvider signals, DateTime utcNow, out MessageEvaluationResult result)
         {
             result = null;
-            if (!_logged)
-            {
-                _logged = true;
-                SimHub.Logging.Current.Warn($"[LalaPlugin:MSGV1] Missing evaluator '{_id}' used by: {string.Join(",", _msgIds)}");
-            }
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- exclude the rejoin threat messages from MSGV1 defaults and ignore any persisted copies on load
- treat missing evaluators as placeholders with a single startup summary instead of runtime warnings

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dd5dd25c832fbe780735abae5545)