### PR TITLE
Align pace warm-up acceptance with fuel model

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1453,7 +1453,7 @@ namespace LaunchPlugin
                     }
 
                     // 1) Global race warm-up: ignore very early race laps (same as fuel)
-                    if (completedLapsNow <= 2)
+                    if (completedLapsNow <= 1)
                     {
                         paceReject = true;
                         paceReason = "race-warmup";


### PR DESCRIPTION
## Summary
- align pace/lap-time warm-up gating with fuel-per-lap to reject only laps with CompletedLaps <= 1
- keep existing incident/pit/outlier filters and confidence gates unchanged

## Testing
- dotnet build LaunchPlugin.sln *(fails: `dotnet` not available in container environment; Windows/SimHub dependencies required)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e2f2fcb0832f8a3cd1b3e152979f)