### PR TITLE
Docs refresh: canonical index, inventories, and subsystem framework

### DIFF
--- a/Docs/FuelTab_SourceFlowNotes.md
+++ b/Docs/FuelTab_SourceFlowNotes.md
@@ -1,25 +1,45 @@
-# Fuel Tab data source flow (current implementation)
+# Fuel Tab Data Source Flow (CANONICAL)
 
-## Where values come from
-- **Car & track selection**
-  - The Fuel tab binds its combo boxes to `AvailableCarProfiles` and `AvailableTrackStats` in `FuelCalcs`. Selecting a car or track updates `SelectedCarProfile` / `SelectedTrackStats`, which in turn calls `LoadProfileData()` to hydrate planner defaults. 【F:FuelCalcs.cs†L510-L623】
-  - Live sessions call `SetLiveSession(car, track)` from `LalaLaunch`, which selects the matching profile entry (or the first available track), updates the snapshot labels, and triggers the same `LoadProfileData()` path. 【F:FuelCalcs.cs†L1958-L2100】【F:LalaLaunch.cs†L579-L704】
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
 
-- **Lap time sources**
-  - Manual entry goes through the `EstimatedLapTime` property; typing sets `LapTimeSourceInfo` to `"source: manual"` and recalculates. 【F:FuelCalcs.cs†L676-L716】
-  - The **PB** button invokes `LoadPersonalBestAsRacePace()`, which uses the stored PB plus race pace delta, updates `LapTimeSourceInfo` to `"source: PB"`, and recalculates. It also refreshes if the PB changes while PB is already selected. 【F:FuelCalcs.cs†L750-L778】【F:FuelCalcs.cs†L2319-L2332】
-  - The **LIVE** button calls `UseLiveLapPace()`, which applies the rolling live average from `_liveAvgLapSeconds`, sets `LapTimeSourceInfo` to `"source: live average"`, and recalculates. Live telemetry populates `_liveAvgLapSeconds` through `SetLiveLapPaceEstimate(...)` when pace samples arrive. 【F:FuelCalcs.cs†L173-L216】【F:FuelCalcs.cs†L1693-L1758】
-  - The **PROFILE** button calls `LoadProfileLapTime()`, pulling the saved dry/wet average for the selected track and marking `LapTimeSourceInfo` as `"source: profile"`. `LoadProfileData()` also defaults to the profile dry average (or PB/manual fallback) on load. 【F:FuelCalcs.cs†L108-L150】【F:FuelCalcs.cs†L1085-L1161】【F:FuelCalcs.cs†L2142-L2218】
+Scope: technical flow of lap time and fuel-per-lap sources for the Fuel planner tab. See `Docs/SimHubParameterInventory.md` for exported properties and `Docs/FuelProperties_Spec.md` for fuel-model rules.
 
-- **Fuel per lap sources**
-  - Manual typing goes through `FuelPerLapText`, which marks `FuelPerLapSourceInfo` as `"source: manual"` and updates `FuelPerLap` when parsable. 【F:FuelCalcs.cs†L500-L546】
-  - The **MAX** button calls `UseMaxFuelPerLap()`, pulling the session maximum tracked by the plugin and tagging `FuelPerLapSourceInfo` as `"source: max"`. 【F:FuelCalcs.cs†L770-L783】
-  - The **LIVE** button runs `UseLiveFuelPerLap()`, which applies the rolling live average from telemetry and sets `FuelPerLapSourceInfo` to `"source: live average"`. Live telemetry populates the cached averages via `SetLiveFuelPerLap(...)`. 【F:FuelCalcs.cs†L306-L341】【F:FuelCalcs.cs†L785-L806】【F:LalaLaunch.cs†L820-L1093】
-  - The **PROFILE** button calls `UseProfileFuelPerLap()`, loading the track’s dry average and marking `FuelPerLapSourceInfo` as `"source: profile"`. Profile loading also sets fuel per lap defaults and availability flags. 【F:FuelCalcs.cs†L1188-L1249】【F:FuelCalcs.cs†L2142-L2226】
+## Source precedence and automatic application
+Evidence: `FuelCalcs.cs` — planning source handling and auto-apply paths.【F:FuelCalcs.cs†L298-L339】【F:FuelCalcs.cs†L2635-L2706】
 
-## UI indicators and flags
-- `LapTimeSourceInfo`, `FuelPerLapSourceInfo`, and the live/PB/profile helper labels are bound in XAML under the lap time and fuel per lap controls so users can see which source is active. 【F:FuelCalculatorView.xaml†L230-L301】【F:FuelCalculatorView.xaml†L371-L423】
-- Live availability and suggestion flags come from `FuelCalcs`:
-  - `IsLiveLapPaceAvailable` controls the **LIVE** lap time button; `IsLiveFuelPerLapAvailable` controls the fuel **LIVE** button.
-  - `ApplyLiveFuelSuggestion` and `ApplyLiveMaxFuelSuggestion` are user-facing toggles; availability is tracked separately via `IsLiveFuelPerLapAvailable` and `HasLiveMaxFuelSuggestion` so telemetry can publish suggestions without overwriting the user’s choice. 【F:FuelCalcs.cs†L280-L343】【F:FuelCalcs.cs†L785-L834】【F:FuelCalcs.cs†L2298-L2316】
-- Live session metadata (car, track, best/average laps, fuel tank detection, confidence summaries) is pushed from `LalaLaunch` into `FuelCalcs` through `SetLiveLapPaceEstimate`, `SetLiveFuelPerLap`, `SetMaxFuelPerLap`, and `UpdateLiveDisplay`, which in turn update the snapshot at the top of the Fuel tab. 【F:LalaLaunch.cs†L820-L1093】【F:FuelCalcs.cs†L1729-L1918】【F:FuelCalcs.cs†L2298-L2316】
+- **Planning source selector:** `SelectedPlanningSourceMode` toggles between **Profile** and **LiveSnapshot**. Switching resets manual lap time/fuel flags and re-applies sources to auto fields.
+- **Auto-apply rules:** When planning source = Profile, profile averages (lap and fuel) are pushed automatically unless the corresponding manual flag is set. When planning source = LiveSnapshot and `IsFuelReady` is true, live averages are auto-applied (lap and fuel) only if the user has not marked them manual.
+- **Manual override:** Typing lap time or fuel sets `IsEstimatedLapTimeManual` / `IsFuelPerLapManual`, blocking further auto-applies until the planning source is changed (which clears the manual flags).
+- **Buttons override source info:** PB/LIVE/PROFILE/MAX buttons set both the value and `SourceInfo` labels; the latest button press wins even if the planning source differs.
+
+## Lap time sources
+- **Manual entry:** `EstimatedLapTime` textbox; sets `LapTimeSourceInfo` = `"source: manual"` and flips the manual flag.【F:FuelCalcs.cs†L676-L716】
+- **PB button:** `LoadPersonalBestAsRacePace()` loads stored PB + delta, sets `LapTimeSourceInfo` = `"source: PB"`, and refreshes when PB changes while PB mode is active.【F:FuelCalcs.cs†L750-L778】【F:FuelCalcs.cs†L2319-L2332】
+- **LIVE button:** `UseLiveLapPace()` applies `_liveAvgLapSeconds`, sets `LapTimeSourceInfo` = `"source: live average"`. Live average maintained via `SetLiveLapPaceEstimate(...)` from `LalaLaunch`.【F:FuelCalcs.cs†L173-L216】【F:FuelCalcs.cs†L1693-L1758】【F:LalaLaunch.cs†L1895-L2143】
+- **PROFILE button:** `LoadProfileLapTime()` uses profile dry/wet average and marks `LapTimeSourceInfo` = `"source: profile"`. Profile loading defaults to dry average (PB/manual fallback) on load.【F:FuelCalcs.cs†L108-L150】【F:FuelCalcs.cs†L1085-L1161】【F:FuelCalcs.cs†L2142-L2226】
+- **Auto-apply:** When planning source LiveSnapshot and fuel is ready, live avg is auto-applied unless manually overridden; Profile mode auto-applies profile average similarly.【F:FuelCalcs.cs†L2635-L2706】
+
+## Fuel per lap sources
+- **Manual entry:** `FuelPerLapText` setter parses text, sets `FuelPerLapSourceInfo` = `"source: manual"`, and marks fuel manual.【F:FuelCalcs.cs†L500-L546】
+- **LIVE button:** `UseLiveFuelPerLap()` applies rolling live average and sets `FuelPerLapSourceInfo` = `"source: live average"`. Live values arrive via `SetLiveFuelPerLap(...)` from `LalaLaunch`.【F:FuelCalcs.cs†L306-L341】【F:FuelCalcs.cs†L785-L806】【F:LalaLaunch.cs†L1895-L2143】
+- **MAX button:** `UseMaxFuelPerLap()` uses session max (`_liveMaxFuel` per condition) or plugin max display; sets `FuelPerLapSourceInfo` accordingly.【F:FuelCalcs.cs†L1188-L1220】
+- **PROFILE button:** `UseProfileFuelPerLap()` loads profile dry average and marks `FuelPerLapSourceInfo` = `"source: profile"`. Profile data also seeds availability flags on load.【F:FuelCalcs.cs†L1188-L1249】【F:FuelCalcs.cs†L2142-L2226】
+- **Save/eco helpers:** `UseLiveFuelSave()` pulls live min burn when available; `FuelPerLapSourceInfo` notes `"Live save"`.【F:FuelCalcs.cs†L1195-L1205】
+- **Auto-apply:** When planning source LiveSnapshot and fuel is ready, `ApplySetLiveFuelPerLap` auto-applies live fuel to planner if fuel is not manual; Profile mode auto-applies profile fuel similarly.【F:FuelCalcs.cs†L1250-L1257】【F:FuelCalcs.cs†L2635-L2706】
+
+## Live snapshot integration
+- `LalaLaunch` pushes identity and live stats via `SetLiveSession`, `SetLiveLapPaceEstimate`, `SetLiveFuelPerLap`, `SetMaxFuelPerLap`, and `UpdateLiveDisplay`. These update the snapshot header, availability flags, and strategy displays in `FuelCalcs`.【F:LalaLaunch.cs†L3200-L3233】【F:LalaLaunch.cs†L1895-L2143】【F:FuelCalcs.cs†L1729-L1918】【F:FuelCalcs.cs†L2298-L2316】
+- Live lap pace availability gate: `IsLiveLapPaceAvailable` drives the LIVE button enablement and helper hints.【F:FuelCalcs.cs†L353-L365】【F:FuelCalcs.cs†L1693-L1758】
+- Live fuel readiness gate: auto-apply from live snapshot requires `IsFuelReady` (stable confidence) from the plugin.【F:FuelCalcs.cs†L2635-L2706】【F:LalaLaunch.cs†L468-L506】
+
+## Max fuel suggestion vs. override
+- `HasLiveMaxFuelSuggestion` surfaces when live max fuel is known; `SetLiveMaxFuelOverrideCommand` calls `ApplyLiveMaxFuelSuggestion()` to copy it into `MaxFuelOverride`. No auto-apply occurs without user command.【F:FuelCalcs.cs†L588-L605】【F:FuelCalcs.cs†L1222-L1227】【F:FuelCalcs.cs†L2575-L2595】
+
+## UI indicators and bindings
+- `LapTimeSourceInfo`, `FuelPerLapSourceInfo`, and helper labels are bound in XAML to show active source selections under each control.【F:FuelCalculatorView.xaml†L230-L301】【F:FuelCalculatorView.xaml†L371-L423】
+- Live availability flags (`IsLiveLapPaceAvailable`, `IsLiveFuelPerLapAvailable`, `HasLiveMaxFuelSuggestion`) control button enablement; manual flags block automatic reapplication until the planning source changes.【F:FuelCalcs.cs†L298-L365】【F:FuelCalcs.cs†L2142-L2226】
+
+## TODO/VERIFY
+- TODO/VERIFY: Confirm whether any UI flow surfaces wet/dry profile eco choices beyond min fuel; current code auto-applies only average values (`TryGetProfileFuelForCondition`).【F:FuelCalcs.cs†L2635-L2706】

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,0 +1,61 @@
+# Project Index
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## What this repo is
+LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control instrumentation, fuel strategy calculations, pit-cycle timing, rejoin assistance, messaging outputs, and dash/screen coordination across the Fuel, Pit, Launch, and Messaging tabs. Runtime behaviour lives in C# (e.g., `LalaLaunch.cs`, `FuelCalcs.cs`, `PitEngine.cs`) with SimHub exports documented below.
+
+## Start here
+- [SimHubParameterInventory.md](SimHubParameterInventory.md) — canonical export list.
+- [SimHubLogMessages.md](SimHubLogMessages.md) — canonical log catalogue.
+- [FuelProperties_Spec.md](FuelProperties_Spec.md) — canonical fuel model behaviour.
+- [FuelTab_SourceFlowNotes.md](FuelTab_SourceFlowNotes.md) — canonical Fuel tab source flow.
+- [Reset_And_Session_Identity.md](Reset_And_Session_Identity.md) — canonical reset/session rules.
+- [BranchWorkflow.md](BranchWorkflow.md) — branching policy.
+- [ConflictResolution.md](ConflictResolution.md) — merge/conflict process.
+
+## Doc inventory & canonicalisation
+- **Truth docs:** `SimHubParameterInventory.md`, `SimHubLogMessages.md`, `FuelProperties_Spec.md`, `FuelTab_SourceFlowNotes.md`, `Reset_And_Session_Identity.md`, `TimerZeroBehavior.md`.
+- **Subsystem notes:** `Message_Catalog_v5_Signal_Mapping_Report.md`, `FuelTab_LeaderPaceFlow.md`, `FuelTabActionPlanOptions.md`, `FuelTabAnalysis.md`, `LALA-036-extra-time-sanity.md`, `LalaLaunch_Handover_Summary-20251130.docx`.
+- **Workflow/process:** `BranchWorkflow.md`, `ConflictResolution.md`, `RepoStatus.md`.
+- **Legacy / reference-only:** `SimHub_Parameter_Inventory.xlsx`, `FuelProperties_Spec.xlsx`, `FuelProperties_Spec (version 1).xlsx`, `Message_Catalog_v5.xlsx`, `Message_Catalog_v5_MessageToSignal_Map.csv`, `Message_Catalog_v5_Signals.csv`, `CarInfo_AllCars.xlsx`, `Codex_Task_Backlog-20251215.xlsx`, `Dahl Design → Lala Launch Mapping (lala Dash).docx`, `Dahl Design → Lala Launch Message Properties Mapping.docx`, `Dash Design.pptx`, `Dual Clutch Logic.docx`, `Phase 1 and 2 Test Script-20251202.docx`, `SessionResetIssues.docx`, `SimHub_DualClutch_Paddle_Guide.docx`, `TestingData.djson`, `UI Work.pptx`. Keep for reference; they are superseded by the canonical files above unless explicitly cited.
+- **Archived:** leave everything under `/Docs/Archived` untouched.
+
+## Subsystem map
+| Subsystem | Purpose | Documentation link |
+| --- | --- | --- |
+| Fuel model | Live burn capture, stability selection, projection inputs, pit window state machine | [Subsystems/Fuel_Model.md](Subsystems/Fuel_Model.md) |
+| Fuel planner tab | UI-facing planner sources, suggestions, and profile integration | [Subsystems/Fuel_Planner_Tab.md](Subsystems/Fuel_Planner_Tab.md) |
+| Pit timing & pit-loss | PitEngine DTL/direct capture, pit-lite surface exports | [Subsystems/Pit_Timing_And_PitLoss.md](Subsystems/Pit_Timing_And_PitLoss.md) |
+| Pace & projection | Pace windows, projection lap selection, after-zero handling | [Subsystems/Pace_And_Projection.md](Subsystems/Pace_And_Projection.md) |
+| Launch mode | Launch state machine, trace logging, anti-stall/bog detection | [Subsystems/Launch_Mode.md](Subsystems/Launch_Mode.md) |
+| Message system v1 | Evaluator-driven stack, outputs, and signal registry | [Subsystems/Message_System_V1.md](Subsystems/Message_System_V1.md) |
+| Profiles & PB | Profile resolution, PB updates, and identity snapshots | [Subsystems/Profiles_And_PB.md](Subsystems/Profiles_And_PB.md) |
+| Trace logging | Telemetry trace lifecycle and launch trace handling | [Subsystems/Trace_Logging.md](Subsystems/Trace_Logging.md) |
+| Dash integration | Screen manager modes, pit screen, and dash visibility toggles | [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
+
+## Canonical docs map
+| Topic | Canonical file | Notes |
+| --- | --- | --- |
+| SimHub exports | [SimHubParameterInventory.md](SimHubParameterInventory.md) | `SimHub_Parameter_Inventory.xlsx` is **LEGACY/REFERENCE ONLY**. |
+| SimHub log catalogue | [SimHubLogMessages.md](SimHubLogMessages.md) | Use this list; no parallel copies. |
+| Fuel model & pit rules | [FuelProperties_Spec.md](FuelProperties_Spec.md) | `FuelProperties_Spec.xlsx` and `FuelProperties_Spec (version 1).xlsx` are **LEGACY/REFERENCE ONLY**. |
+| Fuel tab data flow | [FuelTab_SourceFlowNotes.md](FuelTab_SourceFlowNotes.md) | Earlier analysis docs remain for context only. |
+| Reset & session identity | [Reset_And_Session_Identity.md](Reset_And_Session_Identity.md) | Central reset rules. |
+| Timer zero behaviour | [TimerZeroBehavior.md](TimerZeroBehavior.md) | Cross-linked from reset/finish logic. |
+| Message catalog signals | [Message_Catalog_v5_Signal_Mapping_Report.md](Message_Catalog_v5_Signal_Mapping_Report.md) | CSV/XLSX variants are **REFERENCE ONLY**. |
+| Branching/merges | [BranchWorkflow.md](BranchWorkflow.md) / [ConflictResolution.md](ConflictResolution.md) | Canonical workflow/process guidance. |
+
+## Change-control rules
+- Export changes → update `SimHubParameterInventory.md`.
+- Log changes → update `SimHubLogMessages.md`.
+- Fuel logic changes → update `FuelProperties_Spec.md`.
+- Reset / identity changes → update `Reset_And_Session_Identity.md`.
+- Fuel tab/UI source or planner changes → update `FuelTab_SourceFlowNotes.md`.
+
+## Freshness
+- Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+- Date: 2025-12-28  
+- Branch: docs/refresh-index-subsystems

--- a/Docs/Reset_And_Session_Identity.md
+++ b/Docs/Reset_And_Session_Identity.md
@@ -1,0 +1,36 @@
+# Reset & Session Identity (CANONICAL)
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Definitions
+- **Session identity/token:** `SessionID:SubSessionID` string derived from `WeekendInfo.SessionID/SubSessionID`, exported as `Reset.ThisSession`; prior value exported as `Reset.LastSession`.【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L2737-L2740】
+- **Session type:** SimHub `SessionTypeName` (e.g., Practice, Qualifying, Race), exported as `Reset.ThisSessionType` and tracked separately from token for fuel-model handling.【F:LalaLaunch.cs†L3235-L3335】【F:LalaLaunch.cs†L2737-L2740】
+- **New session (plugin perspective):** either the session token changes or the session type changes compared to `_lastFuelSessionType`.
+
+## What constitutes a reset
+- **Session token change** (identity) triggers: fuel/pit/rejoin resets, finish-timing reset, smoothing reset, profile snapshot clear, and a `[LalaPlugin:Session] token change ...` log entry.【F:LalaLaunch.cs†L3308-L3365】
+- **Session type change** triggers fuel-model reset/seed logic and MSGV1 session reset even if the token is unchanged.【F:LalaLaunch.cs†L3649-L3676】
+- **Car/track change** (while identity stable) triggers confidence/fuel model reset and clears stored seeds.【F:LalaLaunch.cs†L968-L1003】
+
+## Reset matrix
+| Subsystem | Reset triggers | State cleared | State preserved | Evidence logs |
+| --- | --- | --- | --- | --- |
+| Fuel model & pace | Session type change; session token change; car/track change; explicit call from `HandleSessionChangeForFuelModel`. | Fuel windows (dry/wet), confidence, stable burn/pace, lap detector, pit window state, live max fuel, pace windows, smoothing, finish timing readiness; seeds cleared on car/track change. | Seeds applied when entering Race with matching car/track; profile fuel averages updated only when valid dry laps exist. | `[LalaPlugin:Fuel Burn] Car/track change detected...`【F:LalaLaunch.cs†L968-L983】; session token log【F:LalaLaunch.cs†L3308-L3365】; per-lap logs restart after reset. |
+| PitEngine & PitLite | Session token change; session type change indirectly via fuel reset; session token change finalizes pending PitLite candidate before reset. | Pit phase state, latched timers, pit-lite cycle, freeze flags. | Persisted pit-lane loss saved to profile before reset if available. | `[LalaPlugin:Pit Cycle] Saved PitLaneLoss ...`【F:LalaLaunch.cs†L2950-L3004】; token-change block consumes candidate and resets pit state.【F:LalaLaunch.cs†L3308-L3365】 |
+| Finish timing / after-zero | Session token change; session type change; after session end when checkered processed. | Leader finished latches, timer-zero latch, observed extra-time state, cached class metadata. | Observed extra-time result logged once per session end. | `[LalaPlugin:Finish] ...` logs for flag/derived/driver checkered; after-zero result log.【F:LalaLaunch.cs†L4566-L4790】【F:LalaLaunch.cs†L4534-L4560】 |
+| Messaging (MSGV1) | Session type change; session token change. | Message stack, active outputs, missing-evaluator state. | None (definitions stay loaded). | Implicit via `ResetSession()`; no dedicated log (use MSGV1 stack logs for evidence).【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3649-L3676】 |
+| Rejoin assist | Session token change. | Logic code, threat state, pit-phase detection. | None. | Reset invoked in session-token change block (no direct log).【F:LalaLaunch.cs†L3308-L3365】 |
+| Dash/pit screen | Session token change resets snapshot car/track and pits dismissed flag; auto-dash re-armed on session-type change for ignition transitions. | Live snapshot car/track labels, pit screen dismissed flag, auto-dash arming tokens. | User visibility toggles (settings) persist. | `[LalaPlugin:Profile] Session start snapshot...`【F:LalaLaunch.cs†L3308-L3365】; auto-dash logs on ignition events.【F:LalaLaunch.cs†L3690-L3730】 |
+
+## Timer-zero considerations
+- **Contract:** Timed races should follow the leader-white-flag after timer zero; see `Docs/TimerZeroBehavior.md` for expected iRacing rules.
+- **Observed behaviour in code:** `_timerZeroSeen` latches when `SessionTimeRemain` crosses to ≤0.5 s after at least one completed lap. Finish detection uses session flags plus heuristics comparing leader lap distance; after-zero projections log source switches (`planner` vs `live`) and final observed after-zero at session end.【F:LalaLaunch.cs†L1895-L1993】【F:LalaLaunch.cs†L4566-L4790】
+- **Reset rules:** Finish-timing state resets on session token/type change and after `MaybeLogAfterZeroResult` runs.
+- TODO/VERIFY: Confirm if lap-limited (non-timed) races require additional finish derivation beyond leader lap pct heuristic (currently heuristic only when timed).【F:LalaLaunch.cs†L4566-L4715】
+
+## Cross-links
+- Exported reset/session fields: `Reset.*`, `Race.*` flags in `Docs/SimHubParameterInventory.md`.
+- Timer-zero modelling details: `Docs/TimerZeroBehavior.md`.
+- Pit/fuel projection impacts: `Docs/FuelProperties_Spec.md`.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -1,58 +1,123 @@
-# SimHub Log Info Messages
+# SimHub Log Messages (CANONICAL)
 
-This file documents the Info-level messages emitted via `SimHub.Logging.Current.Info(...)` and what each value in the message represents.
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
 
-## LalaLaunch.cs (fuel, laps, and projections)
-- **`[LalaPlugin:Fuel Burn] Captured seed from session ... dry=X (n=a), wet=Y (n=b).`** — Saves rolling fuel figures to seed the next session, logging car, track key, dry/wet fuel-per-lap, and sample counts.【F:LalaLaunch.cs†L663-L691】
-- **`[LalaPlugin:Fuel Burn] Seeded race model from previous session ...`** — Confirms dry/wet seed values were applied when starting a new session, including confidence.【F:LalaLaunch.cs†L807-L823】
-- **`[LalaPlugin:Fuel Burn] Car/track change detected – clearing seeds and confidence`** — Indicates the fuel model was reset because car or track changed.【F:LalaLaunch.cs†L835-L849】
-- **`[LalaPlugin:Lap Detector] ...` (low-speed ignore, pending armed/rejected, atypical crossing)** — Lap detection debug logs covering rejected laps (e.g., too slow), armed pending confirmations with track % and speed, rejected pendings, and atypical crossings that still advance the lap.【F:LalaLaunch.cs†L980-L1054】
-- **`[LalaPlugin:PACE] Lap N: ...`**, **`[LalaPlugin:FUEL PER LAP] Lap N: ...`**, **`[LalaPlugin:FUEL DELTA] Lap N: ...`**, **`[LalaPlugin:RACE PROJECTION] Lap N: ...`** — Per-lap summaries at S/F with acceptance flags/reasons plus pace deltas, stint/last5, leader pace, fuel mode and window counts, delta-to-finish liters, stable laps remaining, projection lap source, after-zero handling, and projected laps/time remaining.【F:LalaLaunch.cs†L1119-L1148】
-- **`[LalaPlugin:Leader Lap] clearing leader pace (feed dropped), lastAvg=...`** — Clears stored leader pace when the feed disappears after a lap cross.【F:LalaLaunch.cs†L1203-L1223】
-- **`[LalaPlugin:Drive Time Projection] ...`** — Race-only per-lap projection log showing session time remaining, after-zero source/value, projected laps, reference lap time/source, and observed after-zero drive time.【F:LalaLaunch.cs†L2085-L2098】
-## LalaLaunch.cs (profiles, pit cycle, launch/dash state)
-- **`[LalaPlugin:Profiles] Changes to '<profile>' saved.`** — Confirmation when the active profile is saved from the UI command.【F:LalaLaunch.cs†L449-L461】
-- **`[LalaPlugin:Profiles] Applied profile to live and refreshed Fuel.`** — Fired when a profile is applied via the Profiles view callback during plugin init.【F:LalaLaunch.cs†L2359-L2372】
-- **`[LalaPlugin:Pit Cycle] Saved PitLaneLoss = Xs (src).`** — Records persistence of pit-lane loss (DTL or direct) after calculation and pushes it to the fuel tab snapshot.【F:LalaLaunch.cs†L2695-L2711】
-- **`[LalaPlugin:Pit Cycle] Pit Lite Data used for DTL.`** — Notes that a finished out-lap from `PitCycleLite` was consumed to compute pit loss.【F:LalaLaunch.cs†L2713-L2728】
-- **`[LalaPlugin:Launch Trace] ...`** — Lifecycle of launch trace CSVs: discards, aborts when off track/in pits, manual timeout, PB announcements, and session snapshots include car/track names and reasons.【F:LalaLaunch.cs†L3010-L4557】
-- **`[LalaPlugin:Dash] ...`** — Dash auto-mode/on-track detection logs showing resets or mode/page switches.【F:LalaLaunch.cs†L3323-L3343】
-- **`[LalaPlugin:Leader Lap] no valid leader lap time from any candidate – returning 0`** — Emitted when leader lap parsing yields no usable candidates.【F:LalaLaunch.cs†L4414-L4433】
+Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
 
-## Lap detector timeout
-- **`[LalaPlugin:Lap Detector] Pending lap confirmation expired ...`** — Warns that an armed lap increment was not confirmed before timeout, including pending lap, last observed track %, and speed context.【F:LalaLaunch.cs†L980-L1009】
+## How to read logs for debugging
+- **Filter by tag prefix** (e.g., `[LalaPlugin:Fuel Burn]`, `[LalaPlugin:Pit Cycle]`, `[LalaPlugin:Finish]`) to isolate subsystems.
+- **Lap-coupled logs** (PACE/FUEL/RACE PROJECTION) appear once per completed lap and include acceptance reasons; correlate them with lap numbers.
+- **Pit-cycle logs** appear on pit entry/exit/out-lap completion. Use them with PitLite status exports.
+- **Session/identity logs** (`[LalaPlugin:Session]`, `[LalaPlugin:Finish]`) mark resets and finish detection; pair with `Reset.*` SimHub exports.
+- **Message system logs** (`MSGV1`) surface missing evaluators and active stack debug—check when adding new messages.
 
-## PitEngine.cs
-- **`[LalaPlugin:Pit Cycle] Direct lane travel computed -> lane=Xs, stop=Ys, direct=Zs`** — Lane timer minus stop duration when a valid direct travel time is measured; shows lane time, stopped time, and derived direct seconds.【F:PitEngine.cs†L90-L236】
-- **`[LalaPlugin:Pit Cycle] Pit exit detected – lane=Xs, stop=Ys, direct=Zs. Awaiting pit-lap completion.`** — Triggered on pit-lane exit with valid timers; arms pit-lap latch.【F:PitEngine.cs†L89-L175】
-- **`[LalaPlugin:Pit Cycle] Pit-lap invalid – aborting pit-cycle evaluation.`** — Pit lap failed validation; cycle cleared.【F:PitEngine.cs†L189-L217】
-- **`[LalaPlugin:Pit Cycle] Pit-lap captured = Xs – awaiting out-lap completion.`** — Valid pit lap latched with its duration logged.【F:PitEngine.cs†L192-L207】
-- **`[LalaPlugin:Pit Cycle] Out-lap invalid – aborting pit-cycle evaluation.`** — Out-lap failed validation; cycle discarded.【F:PitEngine.cs†L210-L218】
-- **`[LalaPlugin:Pit Cycle] DTL computed (formula): Total=Xs, NetMinusStop=Ys (avg=As, pitLap=Bs, outLap=Cs, stop=Ds)`** — Final pit delta computation with all inputs echoed.【F:PitEngine.cs†L223-L239】
+## Action, dash, and launch controls
+- **`[LalaPlugin:Dash] PrimaryDashMode action fired (placeholder).`** — Action binding confirmed; no behaviour implemented yet.【F:LalaLaunch.cs†L10-L36】
+- **`[LalaPlugin:Dash] SecondaryDashMode action fired (placeholder).`** — Same as above for secondary dash action.【F:LalaLaunch.cs†L10-L36】
+- **`[LalaPlugin:Launch] LaunchMode pressed -> re-enabled launch mode.`** — User pressed Launch while feature was user-disabled; flag cleared.【F:LalaLaunch.cs†L17-L45】
+- **`[LalaPlugin:Launch] LaunchMode blocked (inPits=..., seriousRejoin=...).`** — Launch button ignored due to pit/rejoin guard.【F:LalaLaunch.cs†L17-L45】
+- **`[LalaPlugin:Launch] LaunchMode pressed -> ManualPrimed.`** — Launch primed manually after passing guards.【F:LalaLaunch.cs†L17-L45】
+- **`[LalaPlugin:Launch] LaunchMode pressed -> aborting (state=...).`** — Launch button used as cancel; state reset and user-disabled latched.【F:LalaLaunch.cs†L17-L45】
+- **`[LalaPlugin:PitScreen] Toggle pressed IN PITS -> dismissed=..., manual=...`** — Pit screen dismiss toggle used while on pit road.【F:LalaLaunch.cs†L47-L87】
+- **`[LalaPlugin:PitScreen] Toggle pressed ON TRACK -> manual=...`** — Pit screen manual force toggle used on track.【F:LalaLaunch.cs†L47-L87】
+- **`[LalaPlugin:MsgCx] MsgCx action fired (pressed latched + engines notified).`** — MsgCx action invoked; message engines receive cancel signal.【F:LalaLaunch.cs†L87-L118】
+- **`[LalaPlugin:Launch] State change: <old> -> <new>.`** — Launch state machine transition (e.g., primed → logging).【F:LalaLaunch.cs†L2470-L2494】
+- **`[LalaPlugin:Launch Trace] <reason> – cancelling to Idle.`** — Launch trace aborted to idle with the provided reason (debounced).【F:LalaLaunch.cs†L3048-L3074】
+- **`[LalaPlugin:Launch] ManualPrimed timeout fired ...`** — Manual prime exceeded 30 s; launch cancelled and user-disabled latched.【F:LalaLaunch.cs†L4993-L5004】
 
-## PitCycleLite.cs
-- **`[LalaPlugin:Pit Lite] Entry detected. Arming cycle and clearing previous pit figures.`** — Pit entry edge; resets latched timers and state.【F:PitCycleLite.cs†L122-L147】
-- **`[LalaPlugin:Pit Lite] Exit detected. Latching lane and box timers from PitEngine.`** and **`Exit latched. Lane=Xs, Box=Ys, Direct=Zs, Status=Status.`** — Pit exit edge and immediate latch of lane/box/direct timers with stop vs. drive-through status.【F:PitCycleLite.cs†L147-L163】
-- **`[LalaPlugin:Pit Lite] Out-lap complete. Out=..., In=..., Lane=..., Box=..., Saved=... (source=...).`** — At S/F after out-lap completion, listing lap times, timers, chosen loss, and source (`dtl`/`direct`).【F:PitCycleLite.cs†L170-L208】
-- **`[LalaPlugin:Pit Lite] Latched In-lap. In=...`** — Logs in-lap duration when it finishes.【F:PitCycleLite.cs†L183-L190】
-- **`[LalaPlugin:Pit Lite] Publishing loss. Source=..., DTL=..., Direct=..., Avg=...`** — Publishes pit loss when baseline pace exists.【F:PitCycleLite.cs†L194-L208】
-- **`[LalaPlugin:Pit Lite] Publishing direct loss (avg pace missing). Lane=..., Box=..., Direct=...`** — Fallback publication when baseline pace is missing.【F:PitCycleLite.cs†L207-L217】
+## Fuel seeds, session change, and identity
+- **`[LalaPlugin:Fuel Burn] Captured seed from session ... dry=X (n=a), wet=Y (n=b).`** — Saves rolling dry/wet fuel figures before session change for seeding Race.【F:LalaLaunch.cs†L790-L830】
+- **`[LalaPlugin:Fuel Burn] Seeded race model from previous session ... conf=Z%.`** — Applies saved seeds on entering Race with matching car/track.【F:LalaLaunch.cs†L934-L956】
+- **`[LalaPlugin:Fuel Burn] Car/track change detected – clearing seeds and confidence`** — Fuel model reset because car or track identity changed.【F:LalaLaunch.cs†L968-L983】
+- **`[LalaPlugin:Session] token change old=... new=... type=...`** — Session identity changed (SessionID/SubSessionID); triggers subsystem resets and pit-save finalization.【F:LalaLaunch.cs†L3308-L3365】
 
-## FuelCalcs.cs
-- **`[LalaPlugin:Fuel Burn] Strategy reset – defaults applied.`** — Strategy inputs reset to defaults; throttled to once per second.【F:FuelCalcs.cs†L2037-L2057】
-- **`[LalaPlugin:Leader Lap] ResetSnapshotDisplays: cleared live snapshot including leader delta.`** — Logs when live strategy snapshot rows are cleared after session end/reset.【F:FuelCalcs.cs†L2995-L3013】
-- **`[LalaPlugin:Leader Lap] CalculateStrategy: estLap=..., leaderDelta=..., leaderLap=...`** — Strategy tab leader-pace computation with estimated lap, delta, and derived leader lap when values change meaningfully.【F:FuelCalcs.cs†L3842-L3869】
+## Lap detection and per-lap summaries
+- **`[LalaPlugin:Lap Detector] Pending expired ...`** — Armed lap increment expired without confirmation; includes target lap and pct.【F:LalaLaunch.cs†L1058-L1068】
+- **`[LalaPlugin:Lap Detector] Pending rejected ...`** — Armed lap rejected at expiry with pct/speed context.【F:LalaLaunch.cs†L1118-L1127】
+- **`[LalaPlugin:Lap Detector] Ignored reason=low speed ...`** — Lap increment ignored because speed <8 km/h at crossing.【F:LalaLaunch.cs†L1134-L1149】
+- **`[LalaPlugin:Lap Detector] Pending armed ...`** — Lap increment armed due to atypical pct; includes track pct and speed context.【F:LalaLaunch.cs†L1150-L1168】
+- **`[LalaPlugin:Lap Detector] lap_crossed source=CompletedLaps ...`** — Atypical crossing still accepted; pct and speed included.【F:LalaLaunch.cs†L1169-L1185】
+- **`[LalaPlugin:PACE] Lap N: ...`** — Per-lap pace summary with acceptance reason, lap time, stint/last5, leader lap/avg, sample count.【F:LalaLaunch.cs†L1238-L1259】
+- **`[LalaPlugin:FUEL PER LAP] Lap N: ...`** — Fuel acceptance/rejection, mode, window counts, confidence, pit involvement.【F:LalaLaunch.cs†L1259-L1267】
+- **`[LalaPlugin:FUEL DELTA] Lap N: ...`** — Current fuel, required liters, delta, stable burn/laps remaining.【F:LalaLaunch.cs†L1268-L1272】
+- **`[LalaPlugin:RACE PROJECTION] Lap N: ...`** — After-zero source/value, timer0, session remain, projected laps, projection lap seconds, projected remaining seconds.【F:LalaLaunch.cs†L1273-L1281】
+- **`[LalaPlugin:Leader Lap] clearing leader pace (feed dropped), lastAvg=...`** — Leader pace cache cleared when feed disappears.【F:LalaLaunch.cs†L1336-L1355】
 
-## ProfilesManagerViewModel.cs
-- **`[LalaPlugin:Pace] PB Updated: car @ track -> lap`** — Personal-best update with car, track display, and lap time text.【F:ProfilesManagerViewModel.cs†L66-L78】
-- **`[LalaPlugin:Profiles] Track resolved: key='...'`** — Logs resolved track key/display during profile operations.【F:ProfilesManagerViewModel.cs†L160-L182】
-- **`[LalaPlugin:Profiles] Default Settings profile not found, creating baseline profile.`** — Indicates creation of the default profile when missing.【F:ProfilesManagerViewModel.cs†L551-L570】
+## Projection, after-zero, and pit window
+- **`[LalaPlugin:Drive Time Projection] After 0 Source Change from=... to=...`** — Switches between planner and live after-zero once timer zero is seen and live estimate is valid.【F:LalaLaunch.cs†L2005-L2019】
+- **`[LalaPlugin:Pit Window] state=... label=... reqAdd=... tankSpace=... lap=... confStable=... reqStops=... closeLap=...`** — Pit window state transitions with context (requested add, tank space, confidence).【F:LalaLaunch.cs†L2145-L2335】
+- **`[LalaPlugin:Drive Time Projection] tRemain=... after0Used=... lapsProj=... simLaps=... lapRef=... lapRefSrc=... after0Observed=...`** — Per-lap race-only projection snapshot showing after-zero, lap reference, and simulation comparison.【F:LalaLaunch.cs†L2337-L2347】
+- **`[LalaPlugin:Pace] source=... lap=... stint=... last5=... profile=...`** — Projection lap source change (stint/last5/profile/fallback) with lap seconds.【F:LalaLaunch.cs†L4378-L4391】
+- **`[LalaPlugin:Drive Time Projection] projection=drive_time ...`** — Logged when projected laps differ notably from sim laps; shows delta laps, lap ref, after-zero source, remaining seconds.【F:LalaLaunch.cs†L4498-L4516】
+- **`[LalaPlugin:After0Result] driver=... leader=... pred=... lapsPred=...`** — After-zero outcome logged once when session ends or checkered seen.【F:LalaLaunch.cs†L4534-L4560】
 
-## CarProfiles.cs
-- **`[LalaPlugin:Profiles] ...` (ensure, add, save)** — Various profile-ensure/save operations log the profile name, track key, or lap stats when creating or updating entries.【F:CarProfiles.cs†L230-L754】
+## Pit, refuel, and PitLite
+- **`[LalaPlugin:Pit Cycle] Saved PitLaneLoss = Xs (src).`** — Persisted pit lane loss from PitLite/DTL (debounced).【F:LalaLaunch.cs†L2950-L3004】
+- **`[LalaPlugin:Pit Cycle] Pit Lite Data used for DTL.`** — Consumed PitLite out-lap candidate to save pit loss.【F:LalaLaunch.cs†L3004-L3035】
+- **`[LalaPlugin:Refuel Rate] Learned refuel rate ... Cooldown until ...`** — Refuel EMA learning completed from detected fuel added/time. 【F:LalaLaunch.cs†L3488-L3507】
+- **`[LalaPlugin:Pit Lite] ...`** — See PitCycleLite section below for entry/exit/out-lap/publish logs.
+- **`[LalaPlugin:Pit Cycle] ...`** — See PitEngine section below for DTL/direct computations and pit-lap captures.
 
-## LaunchAnalysisControl.xaml.cs
-- **`[LaunchTrace] Deleted trace file: <path>`** — UI-driven deletion of a recorded launch trace file, logging the full path.【F:LaunchAnalysisControl.xaml.cs†L55-L70】
+## Profiles, PBs, and fuel seeds
+- **`[LalaPlugin:Profiles] Changes to '<profile>' saved.`** — Save action from Profiles tab command.【F:LalaLaunch.cs†L560-L580】
+- **`[LalaPlugin:Profiles] Applied profile to live and refreshed Fuel.`** — Profile applied via view-model callback during init.【F:LalaLaunch.cs†L2585-L2633】
+- **`[LalaPlugin:Profile] Session start snapshot: Car='...'  Track='...'`** — Live snapshot cleared and session identity pushed to Fuel tab on session change.【F:LalaLaunch.cs†L3308-L3365】
+- **`[LalaPlugin:Profile] New live combo detected. Auto-selecting profile for Car='...' Track='...'`** — Auto-selection fired once per new car/track combo in DataUpdate.【F:LalaLaunch.cs†L3598-L3625】
+- **`[LalaPlugin:Pace] PB Updated: car @ track -> lap`** — PB update accepted via ProfilesManagerViewModel.【F:ProfilesManagerViewModel.cs†L66-L88】
+- **`[LalaPlugin:Profiles] Track resolved: key='...'`** — Track resolution during profile operations.【F:ProfilesManagerViewModel.cs†L160-L182】
+- **`[LalaPlugin:Profiles] Default Settings profile not found, creating baseline profile.`** — Baseline profile auto-created on load miss.【F:ProfilesManagerViewModel.cs†L551-L570】
+- **`[LalaPlugin:Profile/Pace] PB updated for track '...' (...) ...`** — CarProfiles PB change (live or manual).【F:CarProfiles.cs†L230-L251】
+- **`[LalaPlugin:Profile/Pace] AvgDry updated ...`** — Dry average lap time edited for a track.【F:CarProfiles.cs†L526-L547】
+- **`[LalaPlugin:Profile / Pace] AvgWet updated ...`** — Wet average lap time edited for a track.【F:CarProfiles.cs†L718-L740】
 
-## RejoinAssistEngine.cs
-- **`[LalaPlugin:Rejoin Assist] MsgCx override triggered.`** — Indicates message context override activation within rejoin assist logic.【F:RejoinAssistEngine.cs†L601-L622】
+## Dashboard and pit screen automation
+- **`[LalaPlugin:Dash] Ignition off detected – auto dash re-armed.`** — Auto dash will re-run on next ignition-on/engine-start.【F:LalaLaunch.cs†L3690-L3710】
+- **`[LalaPlugin:Dash] Auto dash executed for session '...' – mode=auto, page='...'`** — Auto dash switched page on ignition-on/engine-start.【F:LalaLaunch.cs†L3711-L3724】
+- **`[LalaPlugin:Dash] Auto dash timer expired – mode set to 'manual'.`** — Auto dash reverted to manual after delay.【F:LalaLaunch.cs†L3718-L3729】
+- **`[LalaPlugin:PitScreen] Active -> <bool> (onPitRoad=..., dismissed=..., manual=...)`** — Pit screen visibility changed due to pit state or manual toggle.【F:LalaLaunch.cs†L3734-L3763】
+
+## Finish timing and after-zero observation
+- **`[LalaPlugin:Finish] checkered_flag trigger=flag ...`** — Finish detection driven by session flag data; includes leader/class validity and multiclass flag.【F:LalaLaunch.cs†L4566-L4715】
+- **`[LalaPlugin:Finish] leader_finish trigger=derived source=...`** — Derived leader finish (class/overall) once timer zero seen and heuristics trip.【F:LalaLaunch.cs†L4716-L4740】
+- **`[LalaPlugin:Finish] finish_latch trigger=driver_checkered ...`** — Driver checkered lap detected; logs timer0, leader/driver checkered times, after-zero measurements.【F:LalaLaunch.cs†L4729-L4780】
+
+## Leader lap selection
+- **`[LalaPlugin:Leader Lap] reject source=... reason=...`** — Candidate leader lap rejected (too small, below floor); may fall back to previous avg.【F:LalaLaunch.cs†L4845-L4862】
+- **`[LalaPlugin:Leader Lap] using leader lap from <source> = Xs`** — Accepted leader lap source (telemetry fallback ordering).【F:LalaLaunch.cs†L4852-L4867】
+- **`[LalaPlugin:Leader Lap] no valid leader lap time from any candidate – returning 0`** — All candidates invalid; leader lap cleared.【F:LalaLaunch.cs†L4869-L4872】
+- **`[LalaPlugin:Leader Lap] ResetSnapshotDisplays: cleared live snapshot including leader delta.`** — Live strategy snapshot cleared on session end/reset from FuelCalcs.【F:FuelCalcs.cs†L2985-L3023】
+- **`[LalaPlugin:Leader Lap] CalculateStrategy: estLap=..., leaderDelta=..., leaderLap=...`** — Strategy lap calculation when leader delta or estimate changes meaningfully.【F:FuelCalcs.cs†L3839-L3879】
+
+## PitEngine (DTL/direct lane timing)
+- **`[LalaPlugin:Pit Cycle] Direct lane travel computed -> lane=Xs, stop=Ys, direct=Zs`** — Valid direct lane time captured; includes lane and stop timing.【F:PitEngine.cs†L90-L175】
+- **`[LalaPlugin:Pit Cycle] Pit exit detected – lane=Xs, stop=Ys, direct=Zs. Awaiting pit-lap completion.`** — Pit exit edge latched with timers; arms pit lap/out-lap tracking.【F:PitEngine.cs†L122-L175】
+- **`[LalaPlugin:Pit Cycle] Pit-lap invalid – aborting pit-cycle evaluation.`** — Pit lap failed validation; cycle cleared.【F:PitEngine.cs†L175-L218】
+- **`[LalaPlugin:Pit Cycle] Pit-lap captured = Xs – awaiting out-lap completion.`** — Valid pit lap latched; waiting for out-lap.【F:PitEngine.cs†L189-L207】
+- **`[LalaPlugin:Pit Cycle] Out-lap invalid – aborting pit-cycle evaluation.`** — Out-lap rejected; clears state.【F:PitEngine.cs†L207-L218】
+- **`[LalaPlugin:Pit Cycle] DTL computed (formula): Total=Xs, NetMinusStop=Ys (avg=As, pitLap=Bs, outLap=Cs, stop=Ds)`** — Final DTL computation with contributing terms.【F:PitEngine.cs†L218-L239】
+
+## PitCycleLite (pit-lite surface)
+- **`[LalaPlugin:Pit Lite] Entry detected. Arming cycle and clearing previous pit figures.`** — Pit entry edge; resets latched values.【F:PitCycleLite.cs†L122-L147】
+- **`[LalaPlugin:Pit Lite] Exit detected. Latching lane and box timers from PitEngine.`** — Pit exit edge seen; pulls timers from PitEngine.【F:PitCycleLite.cs†L147-L163】
+- **`[LalaPlugin:Pit Lite] Exit latched. Lane=..., Box=..., Direct=..., Status=Status.`** — Immediate exit latch with timers and status (drive-through vs stop).【F:PitCycleLite.cs†L147-L163】
+- **`[LalaPlugin:Pit Lite] Out-lap complete. Out=..., In=..., Lane=..., Box=..., Saved=... (source=...).`** — Out-lap completed; publishes loss candidate and lap stats.【F:PitCycleLite.cs†L170-L208】
+- **`[LalaPlugin:Pit Lite] In-lap latched. In=...`** — In-lap duration latched when validated.【F:PitCycleLite.cs†L183-L190】
+- **`[LalaPlugin:Pit Lite] Publishing loss. Source=..., DTL=..., Direct=..., Avg=...`** — Publishes preferred loss with baseline pace.【F:PitCycleLite.cs†L194-L208】
+- **`[LalaPlugin:Pit Lite] Publishing direct loss (avg pace missing). Lane=..., Box=..., Direct=...`** — Fallback publication when pace unavailable.【F:PitCycleLite.cs†L205-L213】
+
+## FuelCalcs (planner and strategy)
+- **`[LalaPlugin:Fuel Burn] Strategy reset – defaults applied.`** — Planner reset to defaults (throttled to 1 s).【F:FuelCalcs.cs†L2038-L2057】
+- **`[LalaPlugin:Leader Lap] ResetSnapshotDisplays: cleared live snapshot including leader delta.`** — Live snapshot cleared after session end/reset (mirrors leader delta wipe).【F:FuelCalcs.cs†L2985-L3023】
+- **`[LalaPlugin:Leader Lap] CalculateStrategy: estLap=..., leaderDelta=..., leaderLap=...`** — Strategy leader lap calculation log (only when values change meaningfully).【F:FuelCalcs.cs†L3839-L3879】
+
+## Message system v1
+- **`[LalaPlugin:MSGV1] <message>`** — General MSGV1 engine logs (e.g., stack outputs).【F:Messaging/MessageEngine.cs†L478-L560】
+- **`[LalaPlugin:MSGV1] Registered placeholder evaluators: ...`** — Fired when message definitions reference missing evaluators; lists evaluator→message mapping.【F:Messaging/MessageEngine.cs†L499-L560】
+
+## File and trace housekeeping
+- **`[LaunchTrace] Deleted trace file: <path>`** — Launch trace file deletion via UI command.【F:LaunchAnalysisControl.xaml.cs†L55-L70】
+
+## Rejoin assist
+- **`[LalaPlugin:Rejoin Assist] MsgCx override triggered.`** — Message context override fired inside rejoin assist engine.【F:RejoinAssistEngine.cs†L601-L622】

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -1,165 +1,146 @@
-# SimHub Parameter Inventory
+# SimHub Parameter Inventory (CANONICAL)
 
-The tables below list every SimHub-exposed property published from `LalaLaunch.cs`. Names omit the implicit `LalaLaunch.` prefix that SimHub adds. Core parameters are always exported; verbose parameters require `SimhubPublish.VERBOSE`.
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
 
-## Core parameters
+- All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2606-L2955】【F:LalaLaunch.cs†L3235-L3585】
+- Legacy spreadsheet `SimHub_Parameter_Inventory.xlsx` is reference-only; this file is canonical.
+- “Defined in” lists the class/method that computes the value before `AttachCore/AttachVerbose` publishes it.
 
-### Fuel model and projection
-| Exported name | Type | Units / meaning | Update cadence | Primary source |
+## Fuel
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Fuel.LiveFuelPerLap | double | L/lap burn used for all projections | 500 ms tick + lap crossing | Rolling accepted laps / fallback SimHub estimate |
-| Fuel.LiveFuelPerLap_Stable | double | Smoothed burn used when the live figure is noisy | 500 ms tick | `LiveFuelPerLap` stability window |
-| Fuel.LiveFuelPerLap_StableSource | string | Provenance for the stable burn (live / profile / sim) | 500 ms tick | Stability selector |
-| Fuel.LiveFuelPerLap_StableConfidence | int | Confidence for the stable burn | 500 ms tick | Stability selector |
-| Fuel.LiveLapsRemainingInRace | double | Laps remaining using current projection | 500 ms tick | `ComputeProjectedLapsRemaining` |
-| Fuel.LiveLapsRemainingInRace_S | string | Formatted laps-remaining string | 500 ms tick | Above calculation |
-| Fuel.LiveLapsRemainingInRace_Stable | double | Laps remaining using stable burn | 500 ms tick | Stable burn projection |
-| Fuel.LiveLapsRemainingInRace_Stable_S | string | Formatted stable projection | 500 ms tick | Stable burn projection |
-| Fuel.DeltaLaps | double | Surplus/deficit to finish at current burn | 500 ms tick | Tank laps − projected race laps |
-| Fuel.TargetFuelPerLap | double | Required burn to finish when short | 500 ms tick | Current fuel ÷ projected laps |
-| Fuel.LapsRemainingInTank | double | Laps possible with current fuel | 500 ms tick | Tank fuel ÷ `LiveFuelPerLap` |
-| Fuel.ProjectionLapTime_Stable | double | Lap time used for race-length projection | 500 ms tick | Pace estimator |
-| Fuel.ProjectionLapTime_StableSource | string | Source label for projection lap time | 500 ms tick | Pace estimator |
-| Fuel.Confidence | int | Fuel-model confidence score | Lap crossing; surfaced each tick | Window quality heuristics |
-| Fuel.PushFuelPerLap | double | Aggressive burn guidance | 500 ms tick | Max observed/session heuristic |
-| Fuel.FuelSavePerLap | double | Conservative burn guidance | 500 ms tick | Window minima |
-| Fuel.DeltaLapsIfPush | double | Surplus/deficit if driving at push burn | 500 ms tick | Push guidance |
-| Fuel.CanAffordToPush | bool | True when push burn still finishes the race | 500 ms tick | Push guidance |
-| Fuel.Live.DriveTimeAfterZero | double | Expected driving after race timer hits 0 | 500 ms tick | Strategy overrun model |
-| Fuel.Live.ProjectedDriveSecondsRemaining | double | Wall-time remaining including overrun | 500 ms tick | Strategy overrun model |
+| Fuel.LiveFuelPerLap | double | Rolling average burn per accepted lap (wet/dry windows, rejects pit/warmup/off-track/outliers). | 500 ms poll (`UpdateLiveFuelCalcs`). | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2672-L2955】 |
+| Fuel.LiveFuelPerLap_Stable / StableSource / StableConfidence | double/string/double | Smoothed burn chosen from live/profile (deadband hold; confidence aligned to source). | 500 ms poll. | `LalaLaunch.cs` — `UpdateStableFuelPerLap` + `AttachCore`【F:LalaLaunch.cs†L4180-L4254】【F:LalaLaunch.cs†L2672-L2955】 |
+| Fuel.FuelReadyConfidenceThreshold | double | Confidence threshold gating fuel readiness and pit window. | 500 ms poll. | `LalaLaunch.cs` — `GetFuelReadyConfidenceThreshold` + `AttachCore`【F:LalaLaunch.cs†L2672-L2955】 |
+| Fuel.LiveLapsRemainingInRace / _S | double | Projected laps remaining using stable burn & lap time with EMA-smoothed string variant. | 500 ms poll. | `LalaLaunch.cs` — `ComputeProjectedLapsRemaining`, `UpdateSmoothedFuelOutputs`, `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L4243-L4306】【F:LalaLaunch.cs†L2676-L2690】 |
+| Fuel.LiveLapsRemainingInRace_Stable / _Stable_S | double | Explicit stable mirror of the projection (for dash/debug). | 500 ms poll. | `LalaLaunch.cs` — `UpdateSmoothedFuelOutputs` + `AttachCore`【F:LalaLaunch.cs†L4243-L4306】【F:LalaLaunch.cs†L2676-L2690】 |
+| Fuel.DeltaLaps | double | Lap surplus/deficit vs. projected distance at stable burn. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2676-L2690】 |
+| Fuel.TargetFuelPerLap | double | Required burn to finish when short (floored to 10% saving). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1995-L2054】【F:LalaLaunch.cs†L2681-L2684】 |
+| Fuel.LapsRemainingInTank | double | Tank fuel ÷ stable (or live) burn. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L1967】【F:LalaLaunch.cs†L2687-L2690】 |
+| Fuel.Confidence | int | Fuel-model confidence from accepted window size/quality. | 500 ms poll. | `LalaLaunch.cs` — `ComputeFuelModelConfidence` + `AttachCore`【F:LalaLaunch.cs†L1830-L1890】【F:LalaLaunch.cs†L2688-L2691】 |
+| Fuel.PushFuelPerLap / Fuel.FuelSavePerLap | double | Push = max session burn or +2%; Save = min window burn or 97% fallback. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L2005-L2143】【F:LalaLaunch.cs†L2690-L2694】 |
+| Fuel.DeltaLapsIfPush / Fuel.CanAffordToPush | double/bool | Surplus/deficit if driving at push burn and affordability flag. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L2005-L2143】【F:LalaLaunch.cs†L2690-L2694】 |
+| Fuel.Delta.LitresCurrent / Plan / WillAdd | double | Liter delta to finish for current fuel, MFD request, and clamped add at stable burn. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L2145-L2195】【F:LalaLaunch.cs†L2694-L2702】 |
+| Fuel.Delta.LitresCurrentPush / PlanPush / WillAddPush | double | Same deltas assuming push burn. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L2145-L2210】【F:LalaLaunch.cs†L2697-L2702】 |
+| Fuel.Delta.LitresCurrentSave / PlanSave / WillAddSave | double | Same deltas assuming fuel-save burn. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L2145-L2210】【F:LalaLaunch.cs†L2699-L2702】 |
+| Fuel.Pit.TotalNeededToEnd / _S | double | Liters required to finish at stable burn (smoothed `_S` via EMA). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs`, `UpdateSmoothedFuelOutputs`, `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L4243-L4306】【F:LalaLaunch.cs†L2703-L2710】 |
+| Fuel.Pit.NeedToAdd | double | Shortfall vs. required liters. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2704-L2706】 |
+| Fuel.Pit.TankSpaceAvailable | double | Remaining capacity after BoP/override clamp. | 500 ms poll. | `LalaLaunch.cs` — `ResolveMaxTankCapacity`, `UpdateLiveFuelCalcs`, `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2705-L2708】 |
+| Fuel.Pit.WillAdd | double | Requested add clamped to tank space. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2706-L2708】 |
+| Fuel.Pit.FuelOnExit | double | Current fuel + clamped add. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2712-L2716】 |
+| Fuel.Pit.DeltaAfterStop / _S | double | Lap surplus after the planned stop at stable burn (`_S` smoothed). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs`, `UpdateSmoothedFuelOutputs`, `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2711-L2714】【F:LalaLaunch.cs†L4243-L4306】 |
+| Fuel.Pit.FuelSaveDeltaAfterStop / _S | double | Surplus after stop using fuel-save burn (`_S` smoothed). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs`, `UpdateSmoothedFuelOutputs`, `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2710-L2712】【F:LalaLaunch.cs†L4243-L4306】 |
+| Fuel.Pit.PushDeltaAfterStop / _S | double | Surplus after stop assuming push burn (`_S` smoothed). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs`, `UpdateSmoothedFuelOutputs`, `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2711-L2713】【F:LalaLaunch.cs†L4243-L4306】 |
+| Fuel.PitStopsRequiredByFuel / Fuel.PitStopsRequiredByPlan / Fuel.Pit.StopsRequiredToEnd | int | Capacity-based stop count, strategy-required stops, and published stop requirement (plan-first). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2714-L2718】 |
+| Fuel.Live.RefuelRate_Lps | double | Learned refuel rate EMA for current profile. | 500 ms poll. | `LalaLaunch.cs` — refuel learning in `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L3489-L3510】【F:LalaLaunch.cs†L2717-L2720】 |
+| Fuel.Live.TireChangeTime_S | double | Estimated tyre change seconds for current selection. | 500 ms poll. | `LalaLaunch.cs` — `GetEffectiveTireChangeTimeSeconds` + `AttachCore`【F:LalaLaunch.cs†L1911-L1950】【F:LalaLaunch.cs†L2717-L2720】 |
+| Fuel.Live.PitLaneLoss_S | double | Pit lane loss from profile/learned value used by strategy. | 500 ms poll. | `LalaLaunch.cs` — `_pit.LastTotalPitCycleTimeLoss` persistence + `AttachCore`【F:LalaLaunch.cs†L1408-L1462】【F:LalaLaunch.cs†L2717-L2721】 |
+| Fuel.Live.TotalStopLoss | double | Pit lane loss + service time composite for strategy displays. | 500 ms poll. | `LalaLaunch.cs` — `CalculateTotalStopLossSeconds` + `AttachCore`【F:LalaLaunch.cs†L1911-L1950】【F:LalaLaunch.cs†L2719-L2722】 |
+| Fuel.Live.DriveTimeAfterZero | double | Extra drive seconds after timer zero (planner/live observed). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` after-zero model + `AttachCore`【F:LalaLaunch.cs†L1911-L1993】【F:LalaLaunch.cs†L2721-L2724】 |
+| Fuel.After0.PlannerSeconds / Fuel.After0.LiveEstimateSeconds / Fuel.After0.Source | double/double/string | Planner-configured after-zero allowance, live observed estimate, and source label (“planner”/“live”). | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1911-L1993】【F:LalaLaunch.cs†L2722-L2726】 |
+| Fuel.Live.ProjectedDriveSecondsRemaining | double | Projected wall-time remaining (includes after-zero). | 500 ms poll. | `LalaLaunch.cs` — `ComputeProjectedLapsRemaining` + `AttachCore`【F:LalaLaunch.cs†L4396-L4404】【F:LalaLaunch.cs†L2726-L2729】 |
+| Fuel.ProjectionLapTime_Stable / _StableSource | double/string | Selected projection lap time and provenance (stint/last5/profile/fallback). | 500 ms poll. | `LalaLaunch.cs` — `GetProjectionLapSeconds` + `AttachCore`【F:LalaLaunch.cs†L4306-L4394】【F:LalaLaunch.cs†L2725-L2727】 |
+| Fuel.Live.IsFuelReady | bool | True when stable confidence meets the readiness threshold. | 500 ms poll. | `LalaLaunch.cs` — `IsFuelReady` property + `AttachCore`【F:LalaLaunch.cs†L500-L506】【F:LalaLaunch.cs†L2727-L2729】 |
+| Fuel.PitWindowState / Fuel.PitWindowLabel / Fuel.IsPitWindowOpen / Fuel.PitWindowOpeningLap / Fuel.PitWindowClosingLap | int/string/bool/int/int | Pit window state machine (open ECO/STD/PUSH, SET FUEL, NO DATA YET, N/A, TANK SPACE/ERROR). Opening/closing lap markers mirror the state machine. | 500 ms poll. | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` pit window block + `AttachCore`【F:LalaLaunch.cs†L2145-L2335】【F:LalaLaunch.cs†L2682-L2687】 |
+| Fuel.LastPitLaneTravelTime | double | Last direct pit-lane travel time saved from pit cycle. | On save; surfaced each poll. | `LalaLaunch.cs` — `Pit_OnValidPitStopTimeLossCalculated` + `AttachCore`【F:LalaLaunch.cs†L2950-L3004】【F:LalaLaunch.cs†L2672-L2955】 |
 
-### Fuel deltas and pit needs
-| Exported name | Type | Units / meaning | Update cadence | Primary source |
+## Pace / Projection
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Fuel.Delta.LitresCurrent / LitresPlan / LitresWillAdd | double | Liters needed vs. finish for current fuel, current MFD plan, and planned add | 500 ms tick | FuelCalculator deltas |
-| Fuel.Delta.LitresCurrentPush / LitresPlanPush / LitresWillAddPush | double | Same as above assuming push burn | 500 ms tick | FuelCalculator deltas |
-| Fuel.Delta.LitresCurrentSave / LitresPlanSave / LitresWillAddSave | double | Same as above assuming fuel-save burn | 500 ms tick | FuelCalculator deltas |
-| Fuel.Pit.TotalNeededToEnd / TotalNeededToEnd_S | double/string | Total liters to finish at current burn | 500 ms tick | Live burn × projected laps |
-| Fuel.Pit.NeedToAdd | double | Additional liters required to finish | 500 ms tick | Total needed − tank fuel |
-| Fuel.Pit.TankSpaceAvailable | double | Liters that fit given BoP/override tank | 500 ms tick | Telemetry max fuel / override |
-| Fuel.Pit.WillAdd | double | Liters expected to be added (after clamping to tank space) | 500 ms tick | Telemetry MFD refuel request |
-| Fuel.Pit.FuelOnExit | double | Estimated fuel after completing the stop | 500 ms tick | Current fuel + `WillAdd` |
-| Fuel.Pit.DeltaAfterStop / DeltaAfterStop_S | double/string | Lap surplus after stop at current burn | 500 ms tick | `FuelOnExit` ÷ burn − race laps |
-| Fuel.Pit.FuelSaveDeltaAfterStop / _S | double/string | Lap surplus after stop at save burn | 500 ms tick | Save burn projection |
-| Fuel.Pit.PushDeltaAfterStop / _S | double/string | Lap surplus after stop at push burn | 500 ms tick | Push burn projection |
-| Fuel.PitStopsRequiredByFuel | int | Stops implied by capacity vs. deficit | 500 ms tick | Capacity-based ceiling |
-| Fuel.PitStopsRequiredByPlan | int | Stops from strategy plan | 500 ms tick | FuelCalculator strategy |
-| Fuel.Pit.StopsRequiredToEnd | int | Final stops required (plan or capacity) | 500 ms tick | Strategy + capacity |
-| Fuel.Live.RefuelRate_Lps | double | Effective refuel rate | 500 ms tick | FuelCalcs profile/measured rate |
-| Fuel.Live.TireChangeTime_S | double | Seconds to change tyres if selected | 500 ms tick | FuelCalcs tyre-time estimator |
-| Fuel.Live.PitLaneLoss_S | double | Pit lane loss used by strategy | 500 ms tick | FuelCalcs lane loss |
-| Fuel.Live.TotalStopLoss | double | Pit lane loss + service time | 500 ms tick | FuelCalcs + tyre/refuel time |
+| Pace.StintAvgLapTimeSec | double | Rolling average of accepted clean laps. | Per lap (on crossing). | `LalaLaunch.cs` — `DetectLapCrossing` & pace acceptance + `AttachCore`【F:LalaLaunch.cs†L1080-L1405】【F:LalaLaunch.cs†L2732-L2737】 |
+| Pace.Last5LapAvgSec | double | Average of last up-to-five clean laps. | Per lap. | `LalaLaunch.cs` — pace window update + `AttachCore`【F:LalaLaunch.cs†L1080-L1405】【F:LalaLaunch.cs†L2732-L2737】 |
+| Pace.LeaderAvgLapTimeSec | double | Rolling leader pace (cleared when feed drops). | Per lap. | `LalaLaunch.cs` — leader lap processing + `AttachCore`【F:LalaLaunch.cs†L1336-L1375】【F:LalaLaunch.cs†L2733-L2736】 |
+| Pace.LeaderDeltaToPlayerSec | double | Leader pace minus player pace. | Per lap. | `LalaLaunch.cs` — `UpdateLeaderDelta` + `AttachCore`【F:LalaLaunch.cs†L1080-L1405】【F:LalaLaunch.cs†L2734-L2737】 |
+| Pace.PaceConfidence | int | Confidence derived from clean pace window size/outlier rejection. | Per lap. | `LalaLaunch.cs` — `ComputePaceConfidence` + `AttachCore`【F:LalaLaunch.cs†L1080-L1405】【F:LalaLaunch.cs†L2735-L2737】 |
+| Pace.OverallConfidence | int | Combined fuel/pace confidence (probabilistic product). | Per lap / poll. | `LalaLaunch.cs` — `OverallConfidence` getter + `AttachCore`【F:LalaLaunch.cs†L468-L491】【F:LalaLaunch.cs†L2736-L2737】 |
 
-### Pace and race state
-| Exported name | Type | Units / meaning | Update cadence | Primary source |
+## Pit timing and PitLite
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Pace.StintAvgLapTimeSec | double | Rolling stint-average lap | Lap crossing surfaced each tick | Pace estimator |
-| Pace.Last5LapAvgSec | double | Average of last up-to-five clean laps | Lap crossing surfaced each tick | Pace estimator |
-| Pace.LeaderAvgLapTimeSec | double | Rolling leader pace | Lap crossing surfaced each tick | Leader telemetry candidate read |
-| Pace.LeaderDeltaToPlayerSec | double | Leader pace − player pace | Lap crossing surfaced each tick | Derived from above |
-| Pace.PaceConfidence | int | Pace model confidence | Lap crossing surfaced each tick | Heuristics on lap quality |
-| Pace.OverallConfidence | int | Min of pace/fuel confidence | Lap crossing surfaced each tick | Derived |
-| Race.OverallLeaderHasFinished / Race.ClassLeaderHasFinished / Race.LeaderHasFinished | bool | Checkered flag latches | Per-tick | Session flags |
-| Race.OverallLeaderHasFinishedValid / Race.ClassLeaderHasFinishedValid | bool | Validity flags for leader-finished values | Per-tick | Session flags |
+| Pit.LastDirectTravelTime / Pit.LastTotalPitCycleTimeLoss / Pit.LastPaceDeltaNetLoss | double | Latest pit lane direct time, total DTL, and pace-delta net loss from PitEngine. | On pit cycle completion (latched) and surfaced each poll. | `LalaLaunch.cs` — pit finalization + `AttachCore`【F:LalaLaunch.cs†L1408-L1469】【F:LalaLaunch.cs†L2743-L2746】 |
+| PitLite.Live.TimeOnPitRoadSec / TimeInBoxSec | double | Live timers during a pit stop (lane and box). | Per tick while pitting. | `LalaLaunch.cs` — PitEngine timers + `AttachCore`【F:LalaLaunch.cs†L1408-L1469】【F:LalaLaunch.cs†L2791-L2795】 |
+| PitLite.TotalLossSec / TotalLossPlusBoxSec | double | PitLite preferred loss (DTL/direct) and loss+box composite latched on out-lap. | On pit-lite publication, surfaced each poll. | `PitCycleLite.cs` publish + `AttachCore`【F:PitCycleLite.cs†L170-L208】【F:LalaLaunch.cs†L2796-L2800】 |
+| PitLite.Status | string | PitLite status enum (AwaitingPitLap/OutLapComplete/etc.). | Per tick; **verbose**. | `PitCycleLite.cs` state + `AttachVerbose`【F:PitCycleLite.cs†L122-L217】【F:LalaLaunch.cs†L2790-L2793】 |
+| PitLite.CurrentLapType / LastLapType | string | PitLite lap classification (Normal/Pit/Out/etc.). | Per tick; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L122-L217】【F:LalaLaunch.cs†L2793-L2797】 |
+| PitLite.LossSource | string | Whether DTL or direct loss was published. | Per publication; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L170-L217】【F:LalaLaunch.cs†L2796-L2799】 |
+| PitLite.LastSaved.Sec / LastSaved.Source | double/string | Most recent saved pit-lite candidate and provenance. | On save; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L170-L217】【F:LalaLaunch.cs†L2797-L2799】 |
+| PitLite.Live.SeenEntryThisLap / SeenExitThisLap | bool | Entry/exit edges observed this lap. | Per tick; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L122-L163】【F:LalaLaunch.cs†L2801-L2805】 |
 
-### Pit timing and PitLite
-| Exported name | Type | Units / meaning | Update cadence | Primary source |
+## Launch
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Pit.LastDirectTravelTime | double | Limiter-to-limiter lane time | On valid pit measurement | PitEngine direct travel |
-| Pit.LastTotalPitCycleTimeLoss | double | Pit delta vs. baseline pace | On valid pit measurement | PitEngine DTL | 
-| Pit.LastPaceDeltaNetLoss | double | Pit loss minus stopped time | On valid pit measurement | PitEngine |
-| PitLite.Live.TimeOnPitRoadSec | double | Running lane timer | Per-tick during pit | PitEngine |
-| PitLite.Live.TimeInBoxSec | double | Running stationary timer | Per-tick during pit | PitEngine |
-| PitLite.TotalLossSec | double | Preferred pit loss output (DTL/direct) | Latched on out-lap | PitCycleLite |
-| PitLite.TotalLossPlusBoxSec | double | Pit loss plus stationary time | Latched on out-lap | PitCycleLite |
+| ManualTimeoutRemaining | string | Seconds remaining on 30 s manual prime timeout (empty when inactive). | Per tick during launch states. | `LalaLaunch.cs` — `AttachCore` timeout block【F:LalaLaunch.cs†L2845-L2860】 |
+| LaunchModeActive | bool | Whether launch UI is visible (primed/in-progress/logging/completed). | Per tick. | `LalaLaunch.cs` — launch state machine + `AttachCore`【F:LalaLaunch.cs†L2470-L2510】【F:LalaLaunch.cs†L2869-L2878】 |
+| LaunchStateLabel / LaunchStateCode | string/string | Human-readable and numeric launch state tokens. | Per tick. | `LalaLaunch.cs` — launch state machine + `AttachCore`【F:LalaLaunch.cs†L2470-L2510】【F:LalaLaunch.cs†L2872-L2878】 |
+| LaunchRPM / TargetLaunchRPM | double | Live and target RPMs for launch. | Per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| ActualRPMAtClutchRelease / RPMDeviationAtClutchRelease | string/string | RPM at clutch release and deviation vs. target. | Per launch event; surfaced per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| ActualThrottleAtClutchRelease / ThrottleDeviationAtClutchRelease | double/double | Throttle at release and deviation vs. target. | Per launch event; surfaced per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| TargetLaunchThrottle / OptimalThrottleTolerance | string/string | Target throttle % and tolerance from profile. | Per tick. | `LalaLaunch.cs` — profile-backed metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| OptimalBitePoint / OptimalBitePointTolerance | double/double | Profile bite point target/tolerance. | Per tick. | `LalaLaunch.cs` — profile metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| AvgSessionLaunchRPM / LastAvgLaunchRPM / LastLaunchRPM / LastMinRPM / MinRPM | string/double/double/double/double | Session launch RPM aggregates and last-run snapshots. | Per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| MaxTractionLoss | double | Max % traction loss during launch. | Per launch run; surfaced per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| ReactionTime / ClutchReleaseTime / ClutchReleaseDelta | double/string/string | Launch reaction/phase timing measurements. | Per launch run; surfaced per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| BitePointInTargetRange / RPMInTargetRange / ThrottleInTargetRange | bool | True when the respective control stayed within tolerance during launch. | Per launch run; surfaced per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| WheelSpinDetected / BoggedDown / BogDownFactorPercent | bool/bool/double | Spin/bog detection flags and profile bog factor. | Per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| AntiStallActive / AntiStallDetectedInLaunch | bool | Anti-stall detection live flag and launch-run latch. | Per tick. | `LalaLaunch.cs` — anti-stall logic + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| TargetLaunchThrottle | string | Target throttle % from profile. | Per tick. | `LalaLaunch.cs` — profile metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| ThrottleModulationDelta | double | % modulation measurement during launch. | Per launch run; surfaced per tick. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| ZeroTo100Time / ZeroTo100Delta | double | 0–100 km/h time and delta vs. baseline. | Per launch run. | `LalaLaunch.cs` — launch metrics + `AttachCore`【F:LalaLaunch.cs†L2845-L2895】 |
+| FalseStartDetected | bool | Flag set when car moves before green while clutch released. | Per tick. | `LalaLaunch.cs` — false start detection + `AttachCore`【F:LalaLaunch.cs†L4989-L5015】【F:LalaLaunch.cs†L2807-L2811】 |
 
-### Dashboard overlays and rejoin assist
-| Exported name | Type | Meaning |
-| --- | --- | --- |
-| CurrentDashPage | string | Active dash page |
-| DashControlMode | string | Dash auto/manual mode |
-| PitScreenActive | bool | Whether pit screen is being shown |
-| FalseStartDetected | bool | Launch false-start latch |
-| LastSessionType | string | Most recent session type token |
-| MsgCxPressed | bool | Whether MsgCx button was pressed this tick |
-| RejoinAlertReasonCode / Name | int/string | Active rejoin logic code |
-| RejoinAlertMessage | string | Human-readable rejoin instruction |
-| RejoinIsExitingPits | bool | Pit phase flag |
-| RejoinCurrentPitPhase / Name | int/string | Current pit phase enum |
-| RejoinThreatLevel / Name | int/string | Current traffic threat level |
-| RejoinTimeToThreat | double | Seconds to nearest threat |
-
-### Dash visibility settings
-| Exported name | Type | Dash |
-| --- | --- | --- |
-| LalaDashShowLaunchScreen, LalaDashShowPitLimiter, LalaDashShowPitScreen, LalaDashShowRejoinAssist, LalaDashShowVerboseMessaging, LalaDashShowRaceFlags, LalaDashShowRadioMessages, LalaDashShowTraffic | bool | Lala dash toggles |
-| MsgDashShowLaunchScreen, MsgDashShowPitLimiter, MsgDashShowPitScreen, MsgDashShowRejoinAssist, MsgDashShowVerboseMessaging, MsgDashShowRaceFlags, MsgDashShowRadioMessages, MsgDashShowTraffic | bool | Messaging dash toggles |
-
-### Launch control & manual timer
-| Exported name | Type | Units / meaning |
-| --- | --- | --- |
-| ManualTimeoutRemaining | string | Seconds remaining on manual launch arm |
-| ActualRPMAtClutchRelease | string | RPM snapshot at clutch release |
-| ActualThrottleAtClutchRelease | double | % throttle at clutch release |
-| AntiStallActive / AntiStallDetectedInLaunch | bool | Anti-stall flags |
-| AvgSessionLaunchRPM / LastAvgLaunchRPM | string/double | Session average launch RPM |
-| BitePointInTargetRange | bool | Whether clutch bite was within tolerance |
-| BoggedDown / BogDownFactorPercent | bool/double | Bog-down detection and profile factor |
-| ClutchReleaseDelta | string | ms delta during release |
-| ClutchReleaseTime | double | Seconds for clutch release |
-| LastLaunchRPM / LastMinRPM / MinRPM | double | Telemetry snapshots |
-| LaunchModeActive | bool | Whether launch UI is visible |
-| LaunchStateLabel / LaunchStateCode | string | Current launch state |
-| LaunchRPM / TargetLaunchRPM | double | Live and target launch RPM |
-| MaxTractionLoss | double | % slip observed |
-| OptimalBitePoint / OptimalBitePointTolerance | double | Target bite point and tolerance |
-| OptimalRPMTolerance / OptimalThrottleTolerance | string | Tolerances for RPM and throttle |
-| ReactionTime | double | ms to release |
-| RPMDeviationAtClutchRelease | string | Delta vs. target RPM |
-| RPMInTargetRange | bool | RPM window flag |
-| TargetLaunchThrottle | string | Target throttle % |
-| ThrottleDeviationAtClutchRelease | double | Delta vs. target throttle |
-| ThrottleInTargetRange | bool | Throttle window flag |
-| ThrottleModulationDelta | double | % modulation measurement |
-| WheelSpinDetected | bool | Wheel spin flag |
-| ZeroTo100Delta | double | km/h delta vs. baseline |
-| ZeroTo100Time | double | 0–100 km/h time for last launch |
-
-### Messaging system
-| Exported name | Type | Meaning |
-| --- | --- | --- |
-| MSG.OvertakeApproachLine | double | Relative line metric for approaching traffic |
-| MSG.OvertakeWarnSeconds | double | Seconds of approach buffer to warn |
-| MSG.MsgCxTimeMessage / MsgCxStateMessage / MsgCxActionMessage | string | Message text per lane |
-| MSG.MsgCxTimeVisible / MsgCxStateVisible | bool | Visibility for time/state lanes |
-| MSG.MsgCxTimeSilenceRemaining | double | Remaining silence window for time lane |
-| MSG.MsgCxStateToken | string | Token controlling state lane reappearance |
-| MSG.MsgCxActionPulse | bool | One-shot trigger when action lane fires |
-
-## Verbose / debug parameters
-| Exported name | Type | Units / meaning | Update cadence | Source |
+## Messages & Rejoin
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Pit.Debug.TimeOnPitRoad | double | Seconds on pit road (live timer) | Per-tick | PitEngine |
-| Pit.Debug.LastPitStopDuration | double | Stationary box timer | Per-tick | PitEngine |
-| Lala.Pit.AvgPaceUsedSec | double | Baseline pace fed into DTL | Per calc | PitEngine |
-| Lala.Pit.AvgPaceSource | string | Source label for baseline pace | Per calc | PitEngine |
-| Lala.Pit.Raw.PitLapSec | double | Pit lap including stop | Per calc | PitEngine |
-| Lala.Pit.Raw.DTLFormulaSec | double | Raw DTL computation | Per calc | PitEngine |
-| Lala.Pit.InLapSec / OutLapSec | double | In/out lap deltas vs. baseline | Per calc | PitEngine |
-| Lala.Pit.DeltaInSec / DeltaOutSec | double | In/out loss contributions | Per calc | PitEngine |
-| Lala.Pit.DriveThroughLossSec | double | Drive-through-style loss | Per calc | PitEngine |
-| Lala.Pit.DirectTravelSec | double | Direct lane travel time | Per calc | PitEngine |
-| Lala.Pit.StopSeconds | double | Stationary stop duration | Per calc | PitEngine |
-| Lala.Pit.ServiceStopLossSec | double | DTL + stop time (floored) | Per calc | PitEngine |
-| Lala.Pit.Profile.PitLaneLossSec | double | Saved profile pit-lane loss | Per calc | Active profile track |
-| Lala.Pit.CandidateSavedSec / CandidateSource | double/string | Last saved pit-loss candidate and provenance | On save | PitEngine |
-| PitLite.InLapSec / OutLapSec | double | Latched pit-lite lap deltas | Per-tick | PitCycleLite |
-| PitLite.DeltaInSec / DeltaOutSec | double | Pit-lite deltas vs. pace | Per-tick | PitCycleLite |
-| PitLite.TimePitLaneSec / TimePitBoxSec | double | Latched timers from PitEngine | Per-tick | PitCycleLite |
-| PitLite.DirectSec | double | Lane time minus box | Per-tick | PitCycleLite |
-| PitLite.DTLSec | double | Pit-lite DTL (floored) | Per-tick | PitCycleLite |
-| PitLite.Status | string | Pit-lite status enum | Per-tick | PitCycleLite |
-| PitLite.CurrentLapType / LastLapType | string | Current/previous lap classification | Per-tick | PitCycleLite |
-| PitLite.LossSource | string | Whether DTL or direct loss was published | Per-tick | PitCycleLite |
-| PitLite.LastSaved.Sec / LastSaved.Source | double/string | Last saved pit-lite candidate and source | On save | PitCycleLite |
-| PitLite.Live.SeenEntryThisLap / SeenExitThisLap | bool | Pit-edge flags for current lap | Per-tick | PitCycleLite |
+| MSG.OvertakeApproachLine | double | Relative line metric for approaching traffic. | Per tick. | `LalaLaunch.cs` — `_msgSystem` outputs + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSG.OvertakeWarnSeconds | double | Approach buffer seconds to warn (from profile). | Per tick. | `LalaLaunch.cs` — profile read + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSG.MsgCxTimeMessage / MsgCxStateMessage / MsgCxActionMessage | string | Message text for time/state/action lanes. | Per tick. | `LalaLaunch.cs` — `_msgSystem` outputs + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSG.MsgCxTimeVisible / MsgCxStateVisible | bool | Visibility flags for respective lanes. | Per tick. | `LalaLaunch.cs` — `_msgSystem` outputs + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSG.MsgCxTimeSilenceRemaining | double | Remaining silence window for time lane. | Per tick. | `LalaLaunch.cs` — `_msgSystem` outputs + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSG.MsgCxStateToken | string | Token controlling state lane reappearance. | Per tick. | `LalaLaunch.cs` — `_msgSystem` outputs + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSG.MsgCxActionPulse | bool | One-shot trigger when action lane fires. | Per tick. | `LalaLaunch.cs` — `_msgSystem` outputs + `AttachCore`【F:LalaLaunch.cs†L2899-L2940】 |
+| MSGV1.ActiveText_Lala / ActivePriority_Lala / ActiveMsgId_Lala / ActiveText_Msg / ActivePriority_Msg / ActiveMsgId_Msg | string | Active message payloads for Lala and Msg lanes. | Per tick while MSGV1 engine active. | `LalaLaunch.cs` — `_msgV1Engine.Outputs` + `AttachCore`【F:LalaLaunch.cs†L2919-L2940】【F:Messaging/MessageEngine.cs†L478-L560】 |
+| MSGV1.ActiveTextColor_* / ActiveBgColor_* / ActiveOutlineColor_* / ActiveFontSize_* | string/int | Visual styling for active messages. | Per tick. | `Messaging/MessageEngine.cs` outputs + `AttachCore`【F:Messaging/MessageEngine.cs†L478-L560】【F:LalaLaunch.cs†L2919-L2940】 |
+| MSGV1.ActiveCount | int | Count of active queued messages. | Per tick. | `Messaging/MessageEngine.cs` outputs + `AttachCore`【F:Messaging/MessageEngine.cs†L478-L560】【F:LalaLaunch.cs†L2919-L2940】 |
+| MSGV1.LastCancelMsgId | string | ID of last cancelled message. | Per tick. | `Messaging/MessageEngine.cs` outputs + `AttachCore`【F:Messaging/MessageEngine.cs†L478-L560】【F:LalaLaunch.cs†L2919-L2940】 |
+| MSGV1.ClearAllPulse | bool | One-shot clear-all pulse. | Per tick. | `Messaging/MessageEngine.cs` outputs + `AttachCore`【F:Messaging/MessageEngine.cs†L478-L560】【F:LalaLaunch.cs†L2919-L2940】 |
+| MSGV1.StackCsv | string | CSV of active message IDs/priorities for debugging. | Per tick. | `Messaging/MessageEngine.cs` outputs + `AttachCore`【F:Messaging/MessageEngine.cs†L478-L560】【F:LalaLaunch.cs†L2919-L2940】 |
+| MSGV1.MissingEvaluatorsCsv | string | CSV of evaluator IDs missing definitions. | On detection; surfaced per tick. | `Messaging/MessageEngine.cs` — `RegisterMissingEvaluators` + `AttachCore`【F:Messaging/MessageEngine.cs†L478-L560】 |
+| RejoinAlertReasonCode / RejoinAlertReasonName / RejoinAlertMessage | int/string/string | Active rejoin logic code/name/message. | Per tick. | `LalaLaunch.cs` — `_rejoinEngine` outputs + `AttachCore`【F:LalaLaunch.cs†L2818-L2824】 |
+| RejoinIsExitingPits | bool | Whether rejoin assist thinks you are exiting pits. | Per tick. | `RejoinAssistEngine` state + `AttachCore`【F:LalaLaunch.cs†L2819-L2823】【F:RejoinAssistEngine.cs†L90-L160】 |
+| RejoinCurrentPitPhase / RejoinCurrentPitPhaseName | int/string | Current pit phase enum and label. | Per tick. | `RejoinAssistEngine` state + `AttachCore`【F:LalaLaunch.cs†L2819-L2825】【F:RejoinAssistEngine.cs†L90-L160】 |
+| RejoinThreatLevel / RejoinThreatLevelName / RejoinTimeToThreat | int/string/double | Threat scoring and time-to-threat for rejoin assist. | Per tick. | `RejoinAssistEngine` outputs + `AttachCore`【F:LalaLaunch.cs†L2826-L2831】【F:RejoinAssistEngine.cs†L540-L640】 |
+| MsgCxPressed | bool | Latched true for 500 ms after MsgCx action. | Per tick. | `LalaLaunch.cs` — `RegisterMsgCxPress` + `AttachCore`【F:LalaLaunch.cs†L2475-L2479】【F:LalaLaunch.cs†L2815-L2820】 |
+
+## Session / Identity
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
+| --- | --- | --- | --- | --- |
+| Reset.LastSession / Reset.ThisSession | string | Last and current session tokens (`SessionID:SubSessionID`). | On session change; surfaced each poll. | `LalaLaunch.cs` — session token handling + `AttachCore`【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L2737-L2740】 |
+| Reset.ThisSessionType | string | Cached session type used for finish timing. | On session change. | `LalaLaunch.cs` — finish timing reset + `AttachCore`【F:LalaLaunch.cs†L4566-L4715】【F:LalaLaunch.cs†L2737-L2740】 |
+| LastSessionType | string | Last observed session type token (raw). | Per tick. | `LalaLaunch.cs` — DataUpdate session probe + `AttachCore`【F:LalaLaunch.cs†L3201-L3274】【F:LalaLaunch.cs†L2808-L2811】 |
+| Race.OverallLeaderHasFinished / Race.ClassLeaderHasFinished / Race.LeaderHasFinished | bool | Leader-finished latches (overall/class plus derived). | Per tick; updated when flags/heuristics trip. | `LalaLaunch.cs` — `UpdateFinishTiming` + `AttachCore`【F:LalaLaunch.cs†L4566-L4790】【F:LalaLaunch.cs†L2809-L2816】 |
+| Race.OverallLeaderHasFinishedValid / Race.ClassLeaderHasFinishedValid | bool | Validity flags for leader-finished values. | Per tick. | `LalaLaunch.cs` — `UpdateFinishTiming` + `AttachCore`【F:LalaLaunch.cs†L4566-L4790】【F:LalaLaunch.cs†L2809-L2816】 |
+
+## Dash control & visibility
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
+| --- | --- | --- | --- | --- |
+| CurrentDashPage | string | Current dash page set by `ScreenManager`. | Per tick. | `LalaLaunch.cs` — `Screens` state + `AttachCore`【F:LalaLaunch.cs†L2805-L2810】【F:LalaLaunch.cs†L3688-L3730】 |
+| DashControlMode | string | Dash control mode (“manual”/“auto”). | Per tick. | `LalaLaunch.cs` — `Screens.Mode` + `AttachCore`【F:LalaLaunch.cs†L2805-L2810】【F:LalaLaunch.cs†L3688-L3730】 |
+| PitScreenActive | bool | Whether pit screen is currently shown. | Per tick. | `LalaLaunch.cs` — pit screen state + `AttachCore`【F:LalaLaunch.cs†L3732-L3763】【F:LalaLaunch.cs†L2815-L2818】 |
+| LalaDashShowLaunchScreen / LalaDashShowPitLimiter / LalaDashShowPitScreen / LalaDashShowRejoinAssist / LalaDashShowVerboseMessaging / LalaDashShowRaceFlags / LalaDashShowRadioMessages / LalaDashShowTraffic | bool | User visibility toggles for Lala dash. | Per tick. | `LaunchPluginSettings` persisted values + `AttachCore`【F:LalaLaunch.cs†L2832-L2841】 |
+| MsgDashShowLaunchScreen / MsgDashShowPitLimiter / MsgDashShowPitScreen / MsgDashShowRejoinAssist / MsgDashShowVerboseMessaging / MsgDashShowRaceFlags / MsgDashShowRadioMessages / MsgDashShowTraffic | bool | User visibility toggles for messaging dash. | Per tick. | `LaunchPluginSettings` persisted values + `AttachCore`【F:LalaLaunch.cs†L2842-L2849】 |
+
+## Debug (verbose-only)
+| Exported name | Type | Units / meaning | Update cadence | Defined in |
+| --- | --- | --- | --- | --- |
+| Pit.Debug.TimeOnPitRoad / Pit.Debug.LastPitStopDuration | double | Live lane timer and last stationary duration. | Per tick (pits); **verbose**. | `PitEngine` timers + `AttachVerbose`【F:PitEngine.cs†L80-L239】【F:LalaLaunch.cs†L2745-L2749】 |
+| Lala.Pit.AvgPaceUsedSec / AvgPaceSource | double/string | Baseline pace fed into pit delta and its source. | Per pit delta calc; **verbose**. | `PitEngine` pace selection + `AttachVerbose`【F:LalaLaunch.cs†L1336-L1415】【F:LalaLaunch.cs†L2751-L2755】 |
+| Lala.Pit.Raw.PitLapSec / Raw.DTLFormulaSec | double | Reconstructed pit lap and formula DTL components. | On pit delta publish; **verbose**. | `LalaLaunch.cs` pit finalize + `AttachVerbose`【F:LalaLaunch.cs†L1336-L1415】【F:LalaLaunch.cs†L2753-L2756】 |
+| Lala.Pit.InLapSec / OutLapSec / DeltaInSec / DeltaOutSec | double | Latched in/out lap times and deltas vs. baseline. | On pit lap/out-lap; **verbose**. | `PitEngine` finalize + `AttachVerbose`【F:LalaLaunch.cs†L1336-L1415】【F:LalaLaunch.cs†L2755-L2759】 |
+| Lala.Pit.DriveThroughLossSec / DirectTravelSec / StopSeconds / ServiceStopLossSec | double | Drive-through loss, direct lane time, stop duration, and floored service loss. | On pit delta calc; **verbose**. | `PitEngine` + `AttachVerbose`【F:PitEngine.cs†L80-L239】【F:LalaLaunch.cs†L2759-L2766】 |
+| Lala.Pit.Profile.PitLaneLossSec | double | Saved profile pit-lane loss. | On save; **verbose**. | `LalaLaunch.cs` pit save + `AttachVerbose`【F:LalaLaunch.cs†L2950-L3028】【F:LalaLaunch.cs†L2765-L2775】 |
+| Lala.Pit.CandidateSavedSec / CandidateSource | double/string | Last candidate pit loss and its provenance. | On save; **verbose**. | `LalaLaunch.cs` pit save + `AttachVerbose`【F:LalaLaunch.cs†L1336-L1415】【F:LalaLaunch.cs†L2777-L2780】 |
+| PitLite.InLapSec / OutLapSec / DeltaInSec / DeltaOutSec / TimePitLaneSec / TimePitBoxSec / DirectSec / DTLSec | double | PitLite lap/timer breakdowns. | Per tick/out-lap; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L122-L217】【F:LalaLaunch.cs†L2781-L2790】 |
+| PitLite.LossSource | string | Whether DTL or direct was published. | Per publish; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L170-L217】【F:LalaLaunch.cs†L2796-L2799】 |
+| PitLite.LastSaved.Sec / LastSaved.Source | double/string | Last saved pit-lite candidate/time source. | On save; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L170-L217】【F:LalaLaunch.cs†L2797-L2799】 |

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -1,0 +1,44 @@
+# Dash Integration
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Coordinate dash pages/modes, pit screen visibility, and dash visibility toggles for Lala and Messaging dashes.
+
+## Inputs (source + cadence)
+- User actions: MsgCx, TogglePitScreen, PrimaryDashMode, SecondaryDashMode, LaunchMode (actions registered at init).【F:LalaLaunch.cs†L2585-L2633】
+- Telemetry flags: ignition on/off, engine started, pit lane status, session type (per tick in `DataUpdate`).【F:LalaLaunch.cs†L3688-L3735】
+- Settings: dash visibility toggles and auto-dash enable flag from `LaunchPluginSettings`.【F:LalaLaunch.cs†L2832-L2849】
+
+## Internal state
+- `ScreenManager` with `Mode` (`manual`/`auto`) and `CurrentPage`; `_dashPendingSwitch`, `_dashExecutedForCurrentArm`, `_dashDesiredPage`, `_dashSwitchToken` manage auto-switch debounce.【F:LalaLaunch.cs†L3688-L3735】
+- Pit screen flags: `_pitScreenDismissed`, `_pitScreenManualEnabled`, `_pitScreenActive`, `_pittingTimer` for entry debounce.【F:LalaLaunch.cs†L47-L87】【F:LalaLaunch.cs†L3734-L3763】
+- Last session type `_dashLastSessionType` to re-arm auto-dash per session change.【F:LalaLaunch.cs†L3680-L3685】
+
+## Calculation blocks (high level)
+1. **Action handling:** Primary/Secondary dash actions currently placeholders (log only). PitScreen toggle differentiates in-pits vs on-track behaviour; MsgCx action latched for 500 ms for messaging engines.【F:LalaLaunch.cs†L10-L118】
+2. **Auto-dash arming:** Session-type change sets desired page (practice/timing/racing) and arms auto switch; ignition off re-arms for next start.【F:LalaLaunch.cs†L3688-L3735】
+3. **Auto-dash execution:** On ignition-on/engine-start, sets mode=auto, page=desired, then reverts to manual after delay if token unchanged; logs both actions.【F:LalaLaunch.cs†L3688-L3730】
+4. **Pit screen visibility:** In pits, shows screen after 200 ms unless dismissed; on track, mirrors manual enable; state changes logged.【F:LalaLaunch.cs†L47-L87】【F:LalaLaunch.cs†L3734-L3763】
+
+## Outputs (exports + logs)
+- Exports: `CurrentDashPage`, `DashControlMode`, `PitScreenActive`, `MsgCxPressed`, visibility toggles (`LalaDashShow*`, `MsgDashShow*`). See inventory.
+- Logs: dash action placeholders, auto-dash arming/execution, pit screen toggle/active changes.【F:LalaLaunch.cs†L10-L118】【F:LalaLaunch.cs†L3688-L3735】
+
+## Dependencies / ordering assumptions
+- Auto-dash uses session type from telemetry; requires settings to enable switching.
+- Pit screen relies on SimHub pit lane flag `IsOnPitRoad`.
+
+## Reset rules
+- Session token change clears pit screen dismissed flag and snapshot labels; auto-dash re-armed on session-type change.【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3680-L3730】
+
+## Failure modes
+- Placeholder dash actions provide no functional change yet; only log.
+- Pit lane flag glitches could flicker pit screen; entry debounce helps mitigate.
+
+## Test checklist
+- Toggle pit screen in pits vs on track to confirm log and `PitScreenActive` behaviour.
+- Enable auto-dash, change session type, cycle ignition to observe auto page switch and manual reversion.
+- Verify visibility toggle exports change when settings flipped in UI.

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -1,0 +1,50 @@
+# Fuel Model
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Captures live fuel burn, selects a stable burn, projects race distance (including after-zero), and drives pit window exports consumed by the Fuel tab and dashes. Canonical exports: see `Docs/SimHubParameterInventory.md` (Fuel section).
+
+## Inputs (source + cadence)
+- Telemetry fuel level, lap count, session time/remain, pit refuel request (`DataUpdate` 500 ms poll).【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L3572-L3578】
+- Profile fuel baselines (dry/wet) from active profile (per access).【F:LalaLaunch.cs†L810-L1040】
+- SimHub fallback `DataCorePlugin.Computed.Fuel_LitersPerLap` when no laps accepted.【F:LalaLaunch.cs†L1895-L1967】
+- Session type and identity for reset/seeding; car/track identity for seeds.【F:LalaLaunch.cs†L830-L1003】【F:LalaLaunch.cs†L3308-L3365】
+
+## Internal state
+- Rolling windows for dry/wet burn (size 5), min/max, sample freshness counters, active seeds, mode flag (`_isWetMode`).【F:LalaLaunch.cs†L340-L420】【F:LalaLaunch.cs†L810-L1040】
+- Stable burn triple (`_stableFuelPerLap`, source, confidence) with deadband hold.【F:LalaLaunch.cs†L4180-L4254】
+- After-zero planner/live estimates and last projection values for logging thresholds.【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L4498-L4516】
+- Pit window state cache to throttle logging (`_lastPitWindowState`, label, timestamp).【F:LalaLaunch.cs†L2145-L2335】
+
+## Calculation blocks (high level)
+1. **Lap acceptance** — Apply warm-up/pit/incident/telemetry/profile-bracket rejection before window insert.【F:LalaLaunch.cs†L1080-L1415】
+2. **Window update** — Maintain dry/wet lists, mins/maxes, session max, and send live stats to FuelCalcs.【F:LalaLaunch.cs†L1714-L1868】
+3. **Stable selection** — Choose live vs. profile candidate with deadband; assign confidence.【F:LalaLaunch.cs†L4180-L4254】
+4. **Projection** — Compute projection lap time (pace-driven) and projected laps; apply after-zero source (planner vs live).【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L4306-L4391】
+5. **Pit math** — Tank laps, deltas, push/save guidance, required stops, and pit window state machine.【F:LalaLaunch.cs†L1895-L2335】
+6. **Smoothing** — EMA smoothing for laps-remaining and pit deltas for `_S` exports.【F:LalaLaunch.cs†L4243-L4306】
+
+## Outputs (exports + logs)
+- Exports under `Fuel.*`, `Pace.*`, pit window fields; see inventory. Logs: lap summaries (`PACE/FUEL/RACE PROJECTION`), pit window state changes, projection source changes, after-zero results.【F:LalaLaunch.cs†L1238-L1281】【F:LalaLaunch.cs†L2145-L2347】【F:LalaLaunch.cs†L4378-L4516】
+
+## Dependencies / ordering assumptions
+- Requires `FuelCalculator` instance for live display updates and strategy integration; `UpdateLiveFuelCalcs` called after leader delta refresh and pit updates in the 500 ms loop.【F:LalaLaunch.cs†L3572-L3578】【F:LalaLaunch.cs†L1336-L1415】
+- Pit window uses stable burn and tank capacity from pit systems (`EffectiveLiveMaxTank`).【F:LalaLaunch.cs†L1895-L2143】
+
+## Reset rules
+- `HandleSessionChangeForFuelModel` (session type change) and session-token change both call `ResetLiveFuelModelForNewSession` (clears windows, stable, confidence, pit window, pace windows) with optional seeding on Race entry.【F:LalaLaunch.cs†L830-L1040】【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3649-L3676】
+- Car/track change clears seeds/confidence.【F:LalaLaunch.cs†L968-L1003】
+
+## Failure modes
+- Telemetry zeros or implausible fuel deltas → rejection; may leave model unready (confidence 0, pit window **NO DATA YET**).
+- Missing profile baselines → profile fallback skipped; stable holds prior or resets to fallback.
+- TODO/VERIFY: Incident latch (`_latchedIncidentReason`) is a placeholder; confirm wiring to actual incident telemetry.
+
+## Test checklist
+- Start new session, observe `[LalaPlugin:Fuel Burn] ... captured seed` and seeding on Race entry with matching combo.
+- Drive clean laps to see lap summary logs and stable burn rise above readiness; pit window transitions out of **NO DATA YET**.
+- Trigger pit lap and pit-warmup laps to confirm rejection reasons and stable burn hold.
+- Switch session type (e.g., Practice→Race) and verify resets + optional seed application.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -1,0 +1,50 @@
+# Fuel Planner Tab
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Planner UI for lap time and fuel-per-lap selection, mixing live snapshots with profile data and manual overrides. Drives strategy inputs and displays live/session snapshots.
+
+## Inputs (source + cadence)
+- Live snapshots from `LalaLaunch` (`SetLiveSession`, `SetLiveLapPaceEstimate`, `SetLiveFuelPerLap`, `SetMaxFuelPerLap`, `UpdateLiveDisplay`) pushed every 500 ms poll.【F:LalaLaunch.cs†L3200-L3233】【F:LalaLaunch.cs†L1895-L2143】【F:FuelCalcs.cs†L1729-L1918】
+- Profile data from `ProfilesViewModel` and active profile selection (on load and car/track change).【F:FuelCalcs.cs†L510-L623】
+- User interactions: planning source toggle, manual text edits, LIVE/PB/PROFILE/MAX buttons (on demand).【F:FuelCalcs.cs†L298-L365】【F:FuelCalcs.cs†L676-L806】
+
+## Internal state
+- `SelectedPlanningSourceMode` (Profile vs LiveSnapshot) with manual flags for lap time and fuel to block auto-apply.【F:FuelCalcs.cs†L298-L339】【F:FuelCalcs.cs†L2635-L2706】
+- Live caches: `_liveAvgLapSeconds`, `_liveMaxFuel`, live min/max burn per condition, `IsFuelReady` gating from plugin.【F:FuelCalcs.cs†L108-L216】【F:FuelCalcs.cs†L1188-L1257】
+- Snapshot identity (live car/track) for header and suggestion availability.【F:FuelCalcs.cs†L1729-L1918】
+
+## Calculation blocks (high level)
+1. **Source selection:** Planning source change clears manual flags and applies profile/live averages to lap time/fuel when allowed.【F:FuelCalcs.cs†L298-L339】【F:FuelCalcs.cs†L2635-L2706】
+2. **Manual overrides:** Text edits set manual flags and `SourceInfo` labels (`source: manual`).【F:FuelCalcs.cs†L500-L716】
+3. **Button actions:** PB/LIVE/PROFILE/MAX call specific loaders and update `SourceInfo` strings; LIVE/PB guard on availability flags.【F:FuelCalcs.cs†L676-L806】【F:FuelCalcs.cs†L1188-L1249】
+4. **Live suggestion handling:** Live fuel auto-applied only when planning source = LiveSnapshot, `IsFuelReady` true, and fuel not manual; max-fuel suggestion requires explicit command (`ApplyLiveMaxFuelSuggestion`).【F:FuelCalcs.cs†L1250-L1257】【F:FuelCalcs.cs†L1222-L1227】
+5. **Snapshot updates:** Live session identity changes refresh header labels and live availability flags.【F:FuelCalcs.cs†L1729-L1918】
+
+## Outputs (exports + logs)
+- UI bindings in `FuelCalculatorView.xaml` for source info labels, availability states, and helper text.【F:FuelCalculatorView.xaml†L230-L301】【F:FuelCalculatorView.xaml†L371-L423】
+- Strategy values consumed inside `FuelCalcs` for pit/lap projections; no direct SimHub exports beyond those set by `LalaLaunch`.
+- Logs: PB update acceptance/rejection, track resolution, strategy reset, leader lap calc (see `Docs/SimHubLogMessages.md`).【F:FuelCalcs.cs†L2038-L2057】【F:FuelCalcs.cs†L3839-L3879】【F:ProfilesManagerViewModel.cs†L66-L182】
+
+## Dependencies / ordering assumptions
+- Requires active `LalaLaunch` to push live data; planning source LiveSnapshot depends on `IsFuelReady` from plugin.
+- Car/track selection uses `FuelCalcs.SetLiveSession` inputs; must align with profile management flow.
+
+## Reset rules
+- Planning source change clears manual lap/fuel flags and reapplies source values.【F:FuelCalcs.cs†L298-L339】
+- `ResetStrategyInputs` and `ResetSnapshotDisplays` clear planner values when strategy reset is triggered (e.g., via settings reset).【F:FuelCalcs.cs†L2038-L2057】【F:FuelCalcs.cs†L2985-L3023】
+- Session identity change from plugin updates live snapshot identity; planner state otherwise persists unless reset invoked.
+
+## Failure modes
+- Live snapshot unavailable or fuel not ready → LiveSnapshot planning source auto-apply no-ops, leaving prior values.
+- Profile entries missing -> profile loads may fall back to defaults; check `TryGetProfileFuelForCondition` return before applying.
+- TODO/VERIFY: Determine UX for wet/dry toggles when live condition flips mid-session; auto-apply currently gated on `IsFuelReady`.
+
+## Test checklist
+- Toggle planning source and confirm manual flags clear and sources reapply.
+- Enter manual lap/fuel then change planning source to ensure auto-apply resumes.
+- Press LIVE/PB/PROFILE/MAX buttons with/without live availability to verify `SourceInfo` labels and blocking.
+- With `IsFuelReady` false, ensure LiveSnapshot auto-apply does not overwrite manual values; once ready, confirm it applies.

--- a/Docs/Subsystems/Launch_Mode.md
+++ b/Docs/Subsystems/Launch_Mode.md
@@ -1,0 +1,43 @@
+# Launch Mode
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+State machine and telemetry capture for launch control: priming, logging, metrics (reaction, RPM/throttle windows), anti-stall/bog detection, and manual timeout.
+
+## Inputs (source + cadence)
+- User actions: `LaunchMode` toggle (SimHub action), MsgCx, dashboard primary/secondary actions (placeholders).【F:LalaLaunch.cs†L10-L45】【F:LalaLaunch.cs†L87-L118】
+- Telemetry per tick: clutch, throttle, speed, start flags, anti-stall threshold from profile, time since prime (manual timeout).【F:LalaLaunch.cs†L3572-L3664】【F:LalaLaunch.cs†L4989-L5015】
+- Profile targets: target RPM/throttle, bite point/tolerances, bog factor, anti-stall threshold.【F:LalaLaunch.cs†L2845-L2895】
+
+## Internal state
+- Launch state enum (Idle, ManualPrimed, AutoPrimed, InProgress, Logging, Completed, Cancelled) and user-disabled latch for toggle behaviour.【F:LalaLaunch.cs†L2470-L2510】
+- Timers: manual prime 30 s timeout, reaction/clutch timing, trace logger lifecycle flags.【F:LalaLaunch.cs†L3045-L3074】【F:LalaLaunch.cs†L4989-L5015】
+- Metrics: RPM/throttle at clutch release, deviations, zero-to-100 time/delta, traction loss, anti-stall detection, wheel spin, bog detection flags.【F:LalaLaunch.cs†L2845-L2895】
+
+## Calculation blocks (high level)
+1. **Action handling:** LaunchMode toggles between primed and aborted states with pit/rejoin guards; state changes logged.【F:LalaLaunch.cs†L10-L45】【F:LalaLaunch.cs†L2470-L2494】
+2. **Launch start detection:** When primed and clutch/throttle move past thresholds, enter Logging; trace logger updates each tick during launch.【F:LalaLaunch.cs†L3572-L3664】
+3. **Metric capture:** Record RPM/throttle snapshots, timing deltas, anti-stall, wheel spin, bog factor during launch run; surface via SimHub exports.【F:LalaLaunch.cs†L2845-L2895】
+4. **Timeout/abort:** Manual prime timeout cancels launch and logs; CancelLaunchToIdle logs reason once.【F:LalaLaunch.cs†L3045-L3074】【F:LalaLaunch.cs†L4989-L5015】
+
+## Outputs (exports + logs)
+- Exports: launch metrics, manual timeout remaining, state labels/codes, zero-to-100 metrics (see inventory). Logs: launch mode button events, state changes, trace cancel reasons, timeout log.【F:LalaLaunch.cs†L10-L45】【F:LalaLaunch.cs†L2470-L2510】【F:LalaLaunch.cs†L3045-L3074】【F:LalaLaunch.cs†L4989-L5015】
+
+## Dependencies / ordering assumptions
+- Trace logger (`TelemetryTraceLogger`) must exist; start/stop handled inside launch code (see `Trace_Logging` stub). Launch metrics depend on active profile thresholds.
+
+## Reset rules
+- `ResetAllValues` clears last-run metrics and abort latch; called during init and when leaving sessions via broader resets.【F:LalaLaunch.cs†L3045-L3094】
+- Session token/type changes do not directly alter launch state but pits/rejoin guards can block priming.
+
+## Failure modes
+- Placeholder dash actions currently log only; no functional switch.
+- TODO/VERIFY: Confirm integration point for auto-primed state (currently manual toggle dominates).【F:LalaLaunch.cs†L2470-L2510】
+
+## Test checklist
+- Trigger LaunchMode in pits and on track to see block vs. primed logs.
+- Perform a launch to capture metrics and verify exports update; ensure manual timeout cancels after 30 s.
+- Abort launch (LaunchMode again) and confirm trace cancel log fires once.

--- a/Docs/Subsystems/Message_System_V1.md
+++ b/Docs/Subsystems/Message_System_V1.md
@@ -1,0 +1,45 @@
+# Message System V1
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Evaluate message definitions against telemetry and plugin signals, maintain active stack, and publish styled SimHub exports for Lala/Msg dashes.
+
+## Inputs (source + cadence)
+- Message definitions from `MessageEngine` (evaluators + registry) loaded at init. Evaluators consume SimHub properties (flags, pace mode, gaps) and plugin exports (pit window, fuel deltas, rejoin threat, pace averages).【F:Messaging/MessageEngine.cs†L430-L560】【F:Docs/Message_Catalog_v5_Signal_Mapping_Report.md†L7-L80】
+- MsgCx action pulses for cancel/override (per action press).【F:LalaLaunch.cs†L87-L118】
+- Planning source and profile changes indirectly affect signals (e.g., fuel deltas).
+
+## Internal state
+- Evaluator dictionary with placeholder evaluators for missing IDs (logged).
+- Outputs struct (`MessageEngineOutputs`) containing active text, priorities, colors, font sizes, stack CSV, and missing-evaluator CSV.【F:Messaging/MessageEngine.cs†L478-L560】
+- Session reset hook to clear stack when session type/token changes.【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3649-L3676】
+
+## Calculation blocks (high level)
+1. **Evaluator registration:** Build evaluator map; missing evaluators replaced with placeholders and logged.【F:Messaging/MessageEngine.cs†L430-L520】
+2. **Signal ingestion:** Signals pulled from SimHub/plugin exports each evaluation tick (cadence controlled by host—TODO/VERIFY cadence in runtime loop).【F:Messaging/MessageEngine.cs†L430-L520】
+3. **Message activation:** Evaluators set active messages, priorities, styles; outputs written to exports.
+4. **Cancel handling:** MsgCx triggers `_msgV1Engine.OnMsgCxPressed()` to clear/cancel messages per engine rules.【F:LalaLaunch.cs†L87-L118】
+
+## Outputs (exports + logs)
+- Exports: `MSGV1.ActiveText_*`, priority, IDs, colors, font sizes, `ActiveCount`, `LastCancelMsgId`, `ClearAllPulse`, `StackCsv`, `MissingEvaluatorsCsv` (see inventory).【F:LalaLaunch.cs†L2919-L2940】
+- Logs: `[LalaPlugin:MSGV1] Registered placeholder evaluators: ...` and other engine-level messages.【F:Messaging/MessageEngine.cs†L499-L560】
+- Signal mappings: see `Docs/Message_Catalog_v5_Signal_Mapping_Report.md`.
+
+## Dependencies / ordering assumptions
+- Requires plugin exports (fuel deltas, pit window, pace) to be up-to-date; relies on `LalaLaunch` 500 ms loop feeding those exports.
+- Session reset must call `ResetSession` to avoid stale stack; triggered on session type/token change in `LalaLaunch`.
+
+## Reset rules
+- `ResetSession()` invoked on session type change and session token change; clears outputs/stack and missing-evaluator CSV.【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3649-L3676】
+
+## Failure modes
+- Missing evaluator IDs -> placeholders; logged with evaluator→message mapping.
+- Signals marked TBD in catalog (e.g., incident-ahead) have no evaluator yet; messages will never fire until implemented.
+
+## Test checklist
+- Load plugin and check log for missing evaluators; verify `MissingEvaluatorsCsv` export matches log.
+- Trigger MsgCx action and confirm `ClearAllPulse` or cancel IDs update, stack clears.
+- Simulate pit window open, fuel deficit, or flag changes to see message activations per catalog.

--- a/Docs/Subsystems/Pace_And_Projection.md
+++ b/Docs/Subsystems/Pace_And_Projection.md
@@ -1,0 +1,43 @@
+# Pace & Projection
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Maintain clean-lap pace metrics, choose projection lap times, and integrate leader pace for strategy and fuel projection.
+
+## Inputs (source + cadence)
+- Telemetry lap times, leader lap time candidates, session type/state (per lap via `DetectLapCrossing`).【F:LalaLaunch.cs†L1080-L1415】
+- Profile pace averages for fallback; live leader lap times from SimHub telemetry (`SessionBestLapTime`, etc.).【F:LalaLaunch.cs†L1336-L1375】【F:LalaLaunch.cs†L4306-L4391】
+
+## Internal state
+- Recent player lap list (size 6) for stint/last5, median pace for pit baseline, leader lap history list with last value and cleared flag.【F:LalaLaunch.cs†L1080-L1415】【F:LalaLaunch.cs†L1336-L1375】
+- Projection lap stable value/source cache with last logged source and debounce timestamp.【F:LalaLaunch.cs†L4306-L4391】
+- Pace confidence based on window size/outlier rejection; overall confidence combines with fuel confidence.【F:LalaLaunch.cs†L1080-L1415】【F:LalaLaunch.cs†L468-L491】
+
+## Calculation blocks (high level)
+1. **Lap acceptance:** Reject laps for warm-up, pit involvement, incidents, bad lap times, and pace outliers (gross >20 s, slow >6 s above baseline).【F:LalaLaunch.cs†L1080-L1415】
+2. **Pace windows:** Update stint avg, last5 avg, leader avg, leader delta; push live lap pace to FuelCalcs when valid.【F:LalaLaunch.cs†L1080-L1415】【F:LalaLaunch.cs†L1336-L1375】
+3. **Projection lap selection:** Prefer stint average when pace confidence high; else last5; else profile avg; fallback estimator. Logs source changes every ≥5 s when value/source changes.【F:LalaLaunch.cs†L4306-L4391】
+4. **Integration with fuel:** Projection lap and pace confidence feed race-distance projection and pit window calculations in fuel model.【F:LalaLaunch.cs†L1895-L2143】
+
+## Outputs (exports + logs)
+- Exports: `Pace.StintAvgLapTimeSec`, `Pace.Last5LapAvgSec`, `Pace.LeaderAvgLapTimeSec`, `Pace.LeaderDeltaToPlayerSec`, `Pace.PaceConfidence`, `Pace.OverallConfidence`, `Fuel.ProjectionLapTime_Stable`, `Fuel.ProjectionLapTime_StableSource`. See inventory.
+- Logs: per-lap `[LalaPlugin:PACE] ...`, leader pace clear, projection source change, leader-lap acceptance/rejection logs.【F:LalaLaunch.cs†L1238-L1281】【F:LalaLaunch.cs†L1336-L1375】【F:LalaLaunch.cs†L4378-L4391】【F:LalaLaunch.cs†L4845-L4872】
+
+## Dependencies / ordering assumptions
+- Leader pace depends on telemetry candidates; uses player pace as fallback for rejection floor.
+- Fuel projection relies on stable burn readiness; if fuel not ready, projection laps may fall back to SimHub laps remaining.
+
+## Reset rules
+- Fuel-model reset and session-token change clear pace windows and leader pace history; confidence reset to 0.【F:LalaLaunch.cs†L830-L1040】【F:LalaLaunch.cs†L3308-L3365】
+
+## Failure modes
+- Missing leader data → leader avg cleared and logged; projection still runs using player pace.
+- Outlier filtering may reject valid laps in chaotic sessions; monitor lap reason logs.
+
+## Test checklist
+- Drive clean laps to see pace/leader logs and exports rise.
+- Simulate leader feed drop to confirm clear log and zeroed leader delta.
+- Change session type to verify pace reset and projection source log refresh.

--- a/Docs/Subsystems/Pit_Timing_And_PitLoss.md
+++ b/Docs/Subsystems/Pit_Timing_And_PitLoss.md
@@ -1,0 +1,49 @@
+# Pit Timing & Pit Loss
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Capture pit-lane travel, compute DTL/direct losses, and publish pit-lite surfaces for dashboards and strategy. Canonical exports: `Pit.*` and `PitLite.*` in `Docs/SimHubParameterInventory.md`.
+
+## Inputs (source + cadence)
+- Telemetry lap times, pit lane flags, stop duration from SimHub telemetry (per tick in `DataUpdate`).【F:LalaLaunch.cs†L1336-L1415】【F:PitEngine.cs†L80-L239】
+- Baseline pace from fuel/pace estimator (stint/median) and profile averages for pit delta comparisons.【F:LalaLaunch.cs†L1336-L1415】
+- Pit service selections (refuel on/off) influence tank-space and stop-loss calculations in fuel model.【F:LalaLaunch.cs†L1895-L2143】
+
+## Internal state
+- `PitEngine` state machine (AwaitingPitLap, AwaitingOutLap) with latched lane/box timers and stop duration.【F:PitEngine.cs†L80-L239】
+- Debug fields `_pitDbg_*` latched on out-lap completion (raw pit lap, DTL formula terms).【F:LalaLaunch.cs†L1336-L1415】
+- `PitCycleLite` entry/exit latches and candidate loss source (`dtl` vs `direct`).【F:PitCycleLite.cs†L122-L217】
+- Freeze flag `_pitFreezeUntilNextCycle` to hold debug values until next pit entry.【F:LalaLaunch.cs†L1336-L1415】
+
+## Calculation blocks (high level)
+1. **Pit entry/exit detection:** `PitCycleLite` arms cycle on entry, latches timers on exit from `PitEngine`.【F:PitCycleLite.cs†L122-L163】
+2. **Pit lap/out-lap validation:** `PitEngine` validates pit lap and out-lap before computing DTL; invalid laps abort cycle.【F:PitEngine.cs†L175-L218】
+3. **DTL/direct selection:** On out-lap completion, chooses DTL if available else direct lane time; publishes totals and debug fields.【F:LalaLaunch.cs†L1336-L1415】【F:PitEngine.cs†L218-L239】
+4. **Persistence:** `Pit_OnValidPitStopTimeLossCalculated` saves pit-lane loss to profile (debounced) and updates Fuel tab snapshot.【F:LalaLaunch.cs†L2950-L3004】
+5. **Fuel integration:** `UpdateLiveFuelCalcs` consumes last direct time and total loss for stop-loss estimates and pit window tank capacity.【F:LalaLaunch.cs†L1895-L2143】
+
+## Outputs (exports + logs)
+- Exports: `Pit.LastDirectTravelTime`, `Pit.LastTotalPitCycleTimeLoss`, `PitLite.*` live timers, debug verbose fields (`Lala.Pit.*`). See inventory for cadence.
+- Logs: `[LalaPlugin:Pit Cycle] ...` from `PitEngine`, `[LalaPlugin:Pit Lite] ...` from `PitCycleLite`, profile save logs, pit window logs (fuel model).【F:PitEngine.cs†L90-L239】【F:PitCycleLite.cs†L122-L217】【F:LalaLaunch.cs†L2145-L2335】
+
+## Dependencies / ordering assumptions
+- `PitEngine.Update` must run before `PitCycleLite.Update` each tick (`DataUpdate` order) so pit-lite sees fresh timers.【F:LalaLaunch.cs†L3308-L3415】
+- Baseline pace provided by fuel/pace estimator; if missing, PitCycleLite can fall back to direct loss publish.
+- Profile persistence depends on `ActiveProfile` and track key/name; missing profile aborts save with warning log.【F:LalaLaunch.cs†L2950-L3004】
+
+## Reset rules
+- Session token change resets PitEngine/PitLite state and may finalize pending candidate once before clearing.【F:LalaLaunch.cs†L3308-L3365】
+- Fuel-model session-type reset indirectly clears pit freeze and debug latches via `ResetLiveFuelModelForNewSession`.【F:LalaLaunch.cs†L830-L1040】
+
+## Failure modes
+- Missing baseline pace → PitLite publishes direct loss instead of DTL.
+- Repeated identical pit loss within debounce window ignored to prevent thrash.
+- TODO/VERIFY: Validate lane/box timers when SimHub pit flags glitch (current code trusts timers if available).
+
+## Test checklist
+- Run pit entry/exit to see PitLite entry/exit logs and live timers.
+- Complete pit + out-lap with valid baseline to log DTL formula and profile save; verify `Pit.LastTotalPitCycleTimeLoss` updates.
+- Trigger invalid pit/out-lap (e.g., off-track) to confirm abort logs and no save.

--- a/Docs/Subsystems/Profiles_And_PB.md
+++ b/Docs/Subsystems/Profiles_And_PB.md
@@ -1,0 +1,46 @@
+# Profiles & PB Management
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Manage car/track profiles, personal bests (PB), and track identity resolution for planner defaults and live snapshot labeling.
+
+## Inputs (source + cadence)
+- Live car/track detection from `LalaLaunch` (`SetLiveSession`) every 500 ms poll; session token changes clear snapshots.【F:LalaLaunch.cs†L3200-L3233】【F:LalaLaunch.cs†L3308-L3365】
+- User actions: save profile, apply profile to live, PB manual edits, profile selection in UI.【F:LalaLaunch.cs†L2585-L2633】【F:ProfilesManagerViewModel.cs†L50-L200】
+- Telemetry PB updates from SimHub best lap (`DataUpdate` per tick).【F:LalaLaunch.cs†L3578-L3591】
+
+## Internal state
+- `ProfilesManagerViewModel` list of `CarProfile` objects with nested track stats (avg lap, fuel averages, pit lane loss, PB).【F:ProfilesManagerViewModel.cs†L28-L200】
+- Snapshot caches `_lastSnapshotCar/_lastSnapshotTrack` to avoid redundant pushes to FuelCalcs.【F:LalaLaunch.cs†L3200-L3233】
+- Auto-select trackers `_lastSeenCar/_lastSeenTrack` to avoid repeated auto profile selection within session.【F:LalaLaunch.cs†L3596-L3625】
+
+## Calculation blocks (high level)
+1. **Identity probe:** Read car model/track key/display; normalize "unknown"; push to FuelCalcs if changed.【F:LalaLaunch.cs†L3200-L3233】
+2. **Auto profile application:** On new car/track combo, auto-select profile and refresh smoothing/strategy; logged once per combo.【F:LalaLaunch.cs†L3596-L3625】
+3. **PB handling:** PB updates from telemetry forwarded to FuelCalcs and Profiles VM; acceptance logged; CarProfile PB property logs changes (manual edits included).【F:LalaLaunch.cs†L3578-L3591】【F:CarProfiles.cs†L230-L251】
+4. **Profile save/apply:** UI commands save active profile and apply profile to live on init callback; profile persistence handled in VM.【F:LalaLaunch.cs†L2585-L2633】【F:ProfilesManagerViewModel.cs†L551-L570】
+5. **Track resolution:** VM resolves track keys/display names and logs resolution; creates default profile if missing.【F:ProfilesManagerViewModel.cs†L160-L182】【F:ProfilesManagerViewModel.cs†L551-L570】
+
+## Outputs (exports + logs)
+- Exports: `Reset.*` session tokens, `CurrentTrackName/Key` (internal), live snapshot labels in Fuel tab; PB/lap/fuel averages feed planner defaults.
+- Logs: profile save/apply, auto-select, PB updates, track resolution, default-profile creation (see `Docs/SimHubLogMessages.md`).【F:LalaLaunch.cs†L560-L580】【F:LalaLaunch.cs†L3596-L3625】【F:ProfilesManagerViewModel.cs†L66-L182】【F:CarProfiles.cs†L230-L251】
+
+## Dependencies / ordering assumptions
+- `ProfilesManagerViewModel` instantiated during plugin `Init`; `FuelCalcs` constructed afterward but receives profile handle.
+- Active profile must exist for pit-lane loss persistence and fuel baselines; auto-created default used otherwise.
+
+## Reset rules
+- Session token change clears snapshot identity and resets profile-related smoothing; auto-select may re-run when new live combo detected.【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3596-L3625】
+- Fuel-model reset does not alter stored profiles but may update track stats when new stable dry fuel is available.
+
+## Failure modes
+- Unknown car/track prevents seed application and profile lookup; logged as errors/warnings.
+- TODO/VERIFY: Confirm concurrency when profile save occurs during live auto-select (UI thread vs DataUpdate dispatcher).
+
+## Test checklist
+- Start session with known car/track; verify auto-select log and Fuel tab snapshot labels.
+- Save profile changes and ensure save log fires.
+- Update PB via telemetry and via manual edit; confirm logs and planner displays update.

--- a/Docs/Subsystems/Trace_Logging.md
+++ b/Docs/Subsystems/Trace_Logging.md
@@ -1,0 +1,44 @@
+# Trace Logging
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+## Purpose
+Capture and manage telemetry trace files for launch analysis, including lifecycle hooks during launch mode and manual deletion from UI.
+
+## Inputs (source + cadence)
+- Launch state transitions from `LalaLaunch` (primed/logging/completed/cancelled).【F:LalaLaunch.cs†L2470-L2510】【F:LalaLaunch.cs†L3045-L3074】
+- Telemetry samples during launch (`DataUpdate` per tick) streamed into `TelemetryTraceLogger.Update(...)` while state is Logging.【F:LalaLaunch.cs†L3572-L3664】
+- UI command to delete a trace file via `LaunchAnalysisControl` button click.【F:LaunchAnalysisControl.xaml.cs†L55-L70】
+
+## Internal state
+- `TelemetryTraceLogger` service (see `TelemetryLogger.cs`) holding current trace, target file path, and pending discard flag.
+- `_telemetryTraceLogger` owned by `LalaLaunch`; lifecycle managed on init/end and launch abort.
+- `_launchAbortLatched` prevents duplicate cancel logs when discarding a trace.【F:LalaLaunch.cs†L3045-L3074】
+
+## Calculation blocks (high level)
+1. **Start trace:** When launch transitions to Logging, trace logger begins collecting telemetry rows (speed, clutch, throttle, RPM, traction).【F:TelemetryLogger.cs†L1-L120】【F:LalaLaunch.cs†L3572-L3664】
+2. **Stop/commit:** On launch completion or plugin end, logger stops service; optional discard invoked during cleanup.
+3. **Abort/cancel:** `CancelLaunchToIdle` stops trace and discards current file, logging reason once.【F:LalaLaunch.cs†L3045-L3074】
+4. **Manual delete:** UI delete command removes a saved trace file and logs `[LaunchTrace] Deleted trace file: <path>`.【F:LaunchAnalysisControl.xaml.cs†L55-L70】
+
+## Outputs (exports + logs)
+- Files: launch trace CSVs (location configured in `TelemetryTraceLogger` settings — TODO/VERIFY exact path in current build).
+- Logs: launch trace cancel reasons, manual delete log; launch state logs indicate trace start/stop conditions.【F:LalaLaunch.cs†L3045-L3074】【F:LaunchAnalysisControl.xaml.cs†L55-L70】
+
+## Dependencies / ordering assumptions
+- `TelemetryTraceLogger` instantiated during plugin init; disposed in `End()` before plugin unload.【F:LalaLaunch.cs†L2585-L2633】【F:LalaLaunch.cs†L3006-L3035】
+- Launch state machine drives trace lifecycle; no independent scheduler.
+
+## Reset rules
+- Session token/type changes do not automatically discard traces unless launch abort occurs; plugin end discards/ends current trace.
+
+## Failure modes
+- Aborted launch without valid state could leave partial trace unless discard executed; `_launchAbortLatched` mitigates log spam.
+- TODO/VERIFY: Confirm behaviour when multiple launches occur in one session (file naming/rotation).
+
+## Test checklist
+- Trigger a full launch and verify trace file appears; open in analysis UI.
+- Abort a primed launch to confirm trace discard log and no leftover file.
+- Use UI delete button to remove a trace and check log entry.

--- a/Docs/Subsystems/_Template.md
+++ b/Docs/Subsystems/_Template.md
@@ -1,0 +1,17 @@
+# Subsystem Template
+
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Last updated: 2025-12-28  
+Branch: docs/refresh-index-subsystems
+
+Fill each section with concise, technician-focused details. Use TODO/VERIFY where validation is incomplete and cite evidence (file/class/method).
+
+- **Purpose** — What the subsystem does and which surfaces (dash/tab/exports) it feeds.
+- **Inputs (source + cadence)** — Telemetry or upstream signals, including polling interval or event latch.
+- **Internal state** — Key fields, windows, or latches that influence behaviour.
+- **Calculation blocks (high level)** — Ordered steps or algorithms that transform inputs to outputs.
+- **Outputs (exports + logs)** — SimHub exports, UI bindings, and log tags/messages.
+- **Dependencies / ordering assumptions** — Required init order, update ordering, or cross-subsystem contracts.
+- **Reset rules** — What triggers resets and which state clears or persists.
+- **Failure modes** — Known edge cases, safeguards, and how they are detected.
+- **Test checklist** — Minimal validation steps (telemetry scenarios, UI toggles, log expectations).


### PR DESCRIPTION
## Summary
- Added `Docs/Project_Index.md` as a navigation and canonical map with change-control rules and subsystem links.
- Refreshed core truth docs (`SimHubParameterInventory.md`, `SimHubLogMessages.md`, `FuelProperties_Spec.md`, `FuelTab_SourceFlowNotes.md`) and added `Reset_And_Session_Identity.md` with validation metadata.
- Introduced a subsystem template plus stubs for fuel, pit timing, pace/projection, launch, messaging, profiles/PB, trace logging, and dash integration under `Docs/Subsystems/`.

## Validation
- Commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1

## Deprecated/Legacy
- `SimHub_Parameter_Inventory.xlsx` (reference only)
- `FuelProperties_Spec.xlsx`; `FuelProperties_Spec (version 1).xlsx` (reference only)
- `Message_Catalog_v5.xlsx` and CSV signal maps (reference only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511bc873c0832fb29efe99e9421b5e)