### PR TITLE
Update docs for recent fuel planner and reset changes

### DIFF
--- a/Docs/FuelTab_SourceFlowNotes.md
+++ b/Docs/FuelTab_SourceFlowNotes.md
@@ -1,16 +1,16 @@
 # Fuel Tab Data Source Flow (CANONICAL)
 
-Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Validated against commit: 88cfd6ba10558452391dd921d23ae69b94a0a44e  
 Last updated: 2025-12-28  
-Branch: docs/refresh-index-subsystems
+Branch: work
 
 Scope: technical flow of lap time and fuel-per-lap sources for the Fuel planner tab. See `Docs/SimHubParameterInventory.md` for exported properties and `Docs/FuelProperties_Spec.md` for fuel-model rules.
 
 ## Source precedence and automatic application
-Evidence: `FuelCalcs.cs` — planning source handling and auto-apply paths.【F:FuelCalcs.cs†L298-L339】【F:FuelCalcs.cs†L2635-L2706】
+Evidence: `FuelCalcs.cs` — planning source handling and auto-apply paths.【F:FuelCalcs.cs†L298-L339】【F:FuelCalcs.cs†L2648-L2711】
 
 - **Planning source selector:** `SelectedPlanningSourceMode` toggles between **Profile** and **LiveSnapshot**. Switching resets manual lap time/fuel flags and re-applies sources to auto fields.
-- **Auto-apply rules:** When planning source = Profile, profile averages (lap and fuel) are pushed automatically unless the corresponding manual flag is set. When planning source = LiveSnapshot and `IsFuelReady` is true, live averages are auto-applied (lap and fuel) only if the user has not marked them manual.
+- **Auto-apply rules:** When planning source = Profile, profile averages (lap and fuel) are pushed automatically unless the corresponding manual flag is set. When planning source = LiveSnapshot, lap time auto-applies whenever live lap pace is available (falling back to profile pace if live data is missing), while fuel still requires `IsFuelReady` before it auto-applies. Manual flags continue to block reapplication until the planning source changes.
 - **Manual override:** Typing lap time or fuel sets `IsEstimatedLapTimeManual` / `IsFuelPerLapManual`, blocking further auto-applies until the planning source is changed (which clears the manual flags).
 - **Buttons override source info:** PB/LIVE/PROFILE/MAX buttons set both the value and `SourceInfo` labels; the latest button press wins even if the planning source differs.
 
@@ -19,7 +19,7 @@ Evidence: `FuelCalcs.cs` — planning source handling and auto-apply paths.【F:
 - **PB button:** `LoadPersonalBestAsRacePace()` loads stored PB + delta, sets `LapTimeSourceInfo` = `"source: PB"`, and refreshes when PB changes while PB mode is active.【F:FuelCalcs.cs†L750-L778】【F:FuelCalcs.cs†L2319-L2332】
 - **LIVE button:** `UseLiveLapPace()` applies `_liveAvgLapSeconds`, sets `LapTimeSourceInfo` = `"source: live average"`. Live average maintained via `SetLiveLapPaceEstimate(...)` from `LalaLaunch`.【F:FuelCalcs.cs†L173-L216】【F:FuelCalcs.cs†L1693-L1758】【F:LalaLaunch.cs†L1895-L2143】
 - **PROFILE button:** `LoadProfileLapTime()` uses profile dry/wet average and marks `LapTimeSourceInfo` = `"source: profile"`. Profile loading defaults to dry average (PB/manual fallback) on load.【F:FuelCalcs.cs†L108-L150】【F:FuelCalcs.cs†L1085-L1161】【F:FuelCalcs.cs†L2142-L2226】
-- **Auto-apply:** When planning source LiveSnapshot and fuel is ready, live avg is auto-applied unless manually overridden; Profile mode auto-applies profile average similarly.【F:FuelCalcs.cs†L2635-L2706】
+- **Auto-apply:** In LiveSnapshot mode, lap auto-applies from live pace when available and otherwise reuses the profile average; fuel auto-applies only when `IsFuelReady` is true. Profile mode auto-applies profile averages for both fields unless manually overridden.【F:FuelCalcs.cs†L2648-L2711】
 
 ## Fuel per lap sources
 - **Manual entry:** `FuelPerLapText` setter parses text, sets `FuelPerLapSourceInfo` = `"source: manual"`, and marks fuel manual.【F:FuelCalcs.cs†L500-L546】
@@ -27,12 +27,15 @@ Evidence: `FuelCalcs.cs` — planning source handling and auto-apply paths.【F:
 - **MAX button:** `UseMaxFuelPerLap()` uses session max (`_liveMaxFuel` per condition) or plugin max display; sets `FuelPerLapSourceInfo` accordingly.【F:FuelCalcs.cs†L1188-L1220】
 - **PROFILE button:** `UseProfileFuelPerLap()` loads profile dry average and marks `FuelPerLapSourceInfo` = `"source: profile"`. Profile data also seeds availability flags on load.【F:FuelCalcs.cs†L1188-L1249】【F:FuelCalcs.cs†L2142-L2226】
 - **Save/eco helpers:** `UseLiveFuelSave()` pulls live min burn when available; `FuelPerLapSourceInfo` notes `"Live save"`.【F:FuelCalcs.cs†L1195-L1205】
-- **Auto-apply:** When planning source LiveSnapshot and fuel is ready, `ApplySetLiveFuelPerLap` auto-applies live fuel to planner if fuel is not manual; Profile mode auto-applies profile fuel similarly.【F:FuelCalcs.cs†L1250-L1257】【F:FuelCalcs.cs†L2635-L2706】
+- **Auto-apply:** When planning source LiveSnapshot and fuel is ready, `ApplySetLiveFuelPerLap` auto-applies live fuel to planner if fuel is not manual; Profile mode auto-applies profile fuel similarly.【F:FuelCalcs.cs†L1250-L1257】【F:FuelCalcs.cs†L2648-L2711】
 
 ## Live snapshot integration
 - `LalaLaunch` pushes identity and live stats via `SetLiveSession`, `SetLiveLapPaceEstimate`, `SetLiveFuelPerLap`, `SetMaxFuelPerLap`, and `UpdateLiveDisplay`. These update the snapshot header, availability flags, and strategy displays in `FuelCalcs`.【F:LalaLaunch.cs†L3200-L3233】【F:LalaLaunch.cs†L1895-L2143】【F:FuelCalcs.cs†L1729-L1918】【F:FuelCalcs.cs†L2298-L2316】
-- Live lap pace availability gate: `IsLiveLapPaceAvailable` drives the LIVE button enablement and helper hints.【F:FuelCalcs.cs†L353-L365】【F:FuelCalcs.cs†L1693-L1758】
-- Live fuel readiness gate: auto-apply from live snapshot requires `IsFuelReady` (stable confidence) from the plugin.【F:FuelCalcs.cs†L2635-L2706】【F:LalaLaunch.cs†L468-L506】
+- Live lap pace availability gate: `IsLiveLapPaceAvailable` drives the LIVE button enablement, helper hints, and lap-time auto-apply in LiveSnapshot mode.【F:FuelCalcs.cs†L353-L365】【F:FuelCalcs.cs†L1693-L1758】【F:FuelCalcs.cs†L2648-L2680】
+- Live fuel readiness gate: auto-apply from live snapshot still requires `IsFuelReady` (stable confidence) for fuel-per-lap auto-fill.【F:FuelCalcs.cs†L2648-L2711】【F:LalaLaunch.cs†L468-L506】
+
+## Planner-only refresh behaviour
+- `RefreshPlannerView()` now preserves the current car/track selections when no live session is active, recomputing derived outputs without rebinding to the active profile or live track identifiers so planner-only workflows do not collapse back to defaults. Live-session refresh still realigns to the active profile and live track identity before recomputing planner data.【F:FuelCalcs.cs†L3441-L3494】
 
 ## Max fuel suggestion vs. override
 - `HasLiveMaxFuelSuggestion` surfaces when live max fuel is known; `SetLiveMaxFuelOverrideCommand` calls `ApplyLiveMaxFuelSuggestion()` to copy it into `MaxFuelOverride`. No auto-apply occurs without user command.【F:FuelCalcs.cs†L588-L605】【F:FuelCalcs.cs†L1222-L1227】【F:FuelCalcs.cs†L2575-L2595】
@@ -42,4 +45,4 @@ Evidence: `FuelCalcs.cs` — planning source handling and auto-apply paths.【F:
 - Live availability flags (`IsLiveLapPaceAvailable`, `IsLiveFuelPerLapAvailable`, `HasLiveMaxFuelSuggestion`) control button enablement; manual flags block automatic reapplication until the planning source changes.【F:FuelCalcs.cs†L298-L365】【F:FuelCalcs.cs†L2142-L2226】
 
 ## TODO/VERIFY
-- TODO/VERIFY: Confirm whether any UI flow surfaces wet/dry profile eco choices beyond min fuel; current code auto-applies only average values (`TryGetProfileFuelForCondition`).【F:FuelCalcs.cs†L2635-L2706】
+- TODO/VERIFY: Confirm whether any UI flow surfaces wet/dry profile eco choices beyond min fuel; current code auto-applies only average values (`TryGetProfileFuelForCondition`).【F:FuelCalcs.cs†L2648-L2711】

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,8 +1,8 @@
 # Project Index
 
-Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Validated against commit: 88cfd6ba10558452391dd921d23ae69b94a0a44e  
 Last updated: 2025-12-28  
-Branch: docs/refresh-index-subsystems
+Branch: work
 
 ## What this repo is
 LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control instrumentation, fuel strategy calculations, pit-cycle timing, rejoin assistance, messaging outputs, and dash/screen coordination across the Fuel, Pit, Launch, and Messaging tabs. Runtime behaviour lives in C# (e.g., `LalaLaunch.cs`, `FuelCalcs.cs`, `PitEngine.cs`) with SimHub exports documented below.
@@ -56,6 +56,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - Fuel tab/UI source or planner changes → update `FuelTab_SourceFlowNotes.md`.
 
 ## Freshness
-- Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+- Validated against commit: 88cfd6ba10558452391dd921d23ae69b94a0a44e  
 - Date: 2025-12-28  
-- Branch: docs/refresh-index-subsystems
+- Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -3,7 +3,7 @@
 ## What exists in this checkout right now
 - Only one local branch is present: `work`.
 - There is no Git remote configured, so nothing in this checkout is currently linked to GitHub.
-- The latest commit on `work` is `1b8efb1` with the message “Ensure live snapshot car/track labels refresh.” Use `git log --oneline -n 5` to see the last few commits if you want to double-check.
+- The latest commit on `work` is `ca8c893` with the message “Update docs for recent fuel planner and reset changes.” The most recent code-bearing commit is `88cfd6b` (“Improve lap time and planner refresh logic”). Use `git log --oneline -n 5` to see the last few commits if you want to double-check.
 
 ## How to connect this checkout to your GitHub repo
 1. Add your GitHub remote (replace the URL with your actual repository clone URL):

--- a/Docs/Reset_And_Session_Identity.md
+++ b/Docs/Reset_And_Session_Identity.md
@@ -1,8 +1,8 @@
 # Reset & Session Identity (CANONICAL)
 
-Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
+Validated against commit: 88cfd6ba10558452391dd921d23ae69b94a0a44e  
 Last updated: 2025-12-28  
-Branch: docs/refresh-index-subsystems
+Branch: work
 
 ## Definitions
 - **Session identity/token:** `SessionID:SubSessionID` string derived from `WeekendInfo.SessionID/SubSessionID`, exported as `Reset.ThisSession`; prior value exported as `Reset.LastSession`.【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L2737-L2740】
@@ -23,6 +23,9 @@ Branch: docs/refresh-index-subsystems
 | Messaging (MSGV1) | Session type change; session token change. | Message stack, active outputs, missing-evaluator state. | None (definitions stay loaded). | Implicit via `ResetSession()`; no dedicated log (use MSGV1 stack logs for evidence).【F:LalaLaunch.cs†L3308-L3365】【F:LalaLaunch.cs†L3649-L3676】 |
 | Rejoin assist | Session token change. | Logic code, threat state, pit-phase detection. | None. | Reset invoked in session-token change block (no direct log).【F:LalaLaunch.cs†L3308-L3365】 |
 | Dash/pit screen | Session token change resets snapshot car/track and pits dismissed flag; auto-dash re-armed on session-type change for ignition transitions. | Live snapshot car/track labels, pit screen dismissed flag, auto-dash arming tokens. | User visibility toggles (settings) persist. | `[LalaPlugin:Profile] Session start snapshot...`【F:LalaLaunch.cs†L3308-L3365】; auto-dash logs on ignition events.【F:LalaLaunch.cs†L3690-L3730】 |
+
+## Dashboard-facing fuel/projection outputs
+- Both session-token resets and session-type transitions now clear all fuel instruction exports (deltas, will-add, laps remaining, projections) alongside smoothed projections so dashboards never retain stale lap/fuel values after a reset. This clearing happens together with the existing fuel/pit resets described above.【F:LalaLaunch.cs†L3340-L3370】【F:LalaLaunch.cs†L3669-L3684】【F:LalaLaunch.cs†L4136-L4168】
 
 ## Timer-zero considerations
 - **Contract:** Timed races should follow the leader-white-flag after timer zero; see `Docs/TimerZeroBehavior.md` for expected iRacing rules.


### PR DESCRIPTION
## Summary
- Refresh repository status and project index metadata to reflect the latest work branch commit
- Document updated LiveSnapshot lap-time auto-apply behaviour and planner-only refresh flow in the fuel tab notes
- Capture the new fuel/projection output clearing performed on session resets and phase changes

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951883aa000832f98544d453d09907a)