### PR TITLE
Add pit entry decel settings to car profiles

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -124,6 +124,10 @@ namespace LaunchPlugin
         public double SpinYawRateThreshold { get => _spinYawRateThreshold; set { if (_spinYawRateThreshold != value) { _spinYawRateThreshold = value; OnPropertyChanged(); } } }
         private double _trafficApproachWarnSeconds = 5.0;
         public double TrafficApproachWarnSeconds { get => _trafficApproachWarnSeconds; set { if (_trafficApproachWarnSeconds != value) { _trafficApproachWarnSeconds = value; OnPropertyChanged(); } } }
+        private double _pitEntryDecelMps2 = 13.5;
+        public double PitEntryDecelMps2 { get => _pitEntryDecelMps2; set { if (_pitEntryDecelMps2 != value) { _pitEntryDecelMps2 = value; OnPropertyChanged(); } } }
+        private double _pitEntryBufferM = 15.0;
+        public double PitEntryBufferM { get => _pitEntryBufferM; set { if (_pitEntryBufferM != value) { _pitEntryBufferM = value; OnPropertyChanged(); } } }
 
         // --- Helper methods (unchanged and preserved) ---
 

--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -138,6 +138,8 @@
                     <ui:TitledSlider Title="Rejoin Assist Clear Speed (kph): " Minimum="10" Maximum="250" Value="{Binding ActiveProfile.RejoinWarningMinSpeed, Mode=TwoWay}" />
                     <ui:TitledSlider Title="Spin Yaw Rate Threshold: " Minimum="10" Maximum="100" Value="{Binding ActiveProfile.SpinYawRateThreshold, Mode=TwoWay}" />
                     <ui:TitledSlider Title="Overtake Alert activation (sec): " Minimum="1" Maximum="20" Value="{Binding ActiveProfile.TrafficApproachWarnSeconds, Mode=TwoWay}" />
+                    <ui:TitledSlider Title="Pit Entry Decel (m/s²): " Minimum="8" Maximum="22" Value="{Binding ActiveProfile.PitEntryDecelMps2, Mode=TwoWay}" />
+                    <ui:TitledSlider Title="Pit Entry Buffer (m): " Minimum="0" Maximum="40" Value="{Binding ActiveProfile.PitEntryBufferM, Mode=TwoWay}" />
                 </StackPanel>
             </Grid>
             <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" />

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -85,6 +85,26 @@
                             </ui:TitledSlider.ToolTip>
                         </ui:TitledSlider>
 
+                        <ui:TitledSlider Title="Pit Entry Decel (m/s²)"
+                         Minimum="8" Maximum="22"
+                         Value="{Binding PitEntryDecelMps2, Mode=TwoWay}">
+                            <ui:TitledSlider.ToolTip>
+                                <ToolTip>
+                                    <TextBlock Text="Target deceleration for pit entry braking assist (m/s²)." TextWrapping="Wrap" Width="240"/>
+                                </ToolTip>
+                            </ui:TitledSlider.ToolTip>
+                        </ui:TitledSlider>
+
+                        <ui:TitledSlider Title="Pit Entry Buffer (m)"
+                         Minimum="0" Maximum="40"
+                         Value="{Binding PitEntryBufferM, Mode=TwoWay}">
+                            <ui:TitledSlider.ToolTip>
+                                <ToolTip>
+                                    <TextBlock Text="Distance before the pit entry trigger point to start the braking assist." TextWrapping="Wrap" Width="240"/>
+                                </ToolTip>
+                            </ui:TitledSlider.ToolTip>
+                        </ui:TitledSlider>
+
                     </StackPanel>
                 </styles:SHTabItem>
 


### PR DESCRIPTION
## Summary
- add pit entry deceleration and buffer properties to car profiles with heuristic seeding for legacy or new profiles
- copy the new settings when duplicating defaults and expose them as sliders on the Profiles and DASH tabs

## Testing
- dotnet build *(fails: dotnet SDK not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695279847dcc832f9ba6fa71338a63ae)