### PR TITLE
Ensure pit lane state persists through pre-lap early return

### DIFF
--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -201,6 +201,9 @@ namespace LaunchPlugin
                 {
                     UpdateTrackMarkers(trackKey, carPct, trackLenM, isInPitLane, justExitedPits, isInPitStall, speedKph);
                     _paceDeltaState = PaceDeltaState.Idle;
+                    IsOnPitRoad = isInPitLane;
+                    _wasInPitLane = isInPitLane;
+                    _wasInPitStall = isInPitStall;
                     return;
                 }
             }


### PR DESCRIPTION
## Summary
- keep pit lane/stall edge memory updated even when returning early before the first completed lap
- ensure pit-road flag mirrors current lane state during the early-return guard

## Testing
- not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a016dab4832f878d5f28b551aac5)