### PR TITLE
Add pit track markers display and locking controls

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -2665,7 +2665,8 @@ namespace LaunchPlugin
                     SimHub.Logging.Current.Info("[LalaPlugin:Profiles] Applied profile to live and refreshed Fuel.");
                 },
                 () => this.CurrentCarModel,
-                () => this.CurrentTrackKey
+                () => this.CurrentTrackKey,
+                (locked) => SetTrackMarkersLocked(locked)
             );
 
 
@@ -3746,6 +3747,8 @@ namespace LaunchPlugin
                 // =======================================================================
                 // ======================= MODIFIED BLOCK END ============================
                 // =======================================================================
+
+                ProfilesViewModel?.RefreshTrackMarkersSnapshot(pluginManager);
             }
 
             UpdateLiveProperties(pluginManager, ref data);

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -458,6 +458,32 @@
                                     </StackPanel>
                                 </StackPanel>
 
+                                <GroupBox Header="Pit Track Markers" Margin="0,12,0,0" DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                    <Grid Margin="8,6,8,8">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Stored Pit Entry %:" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding StoredPitEntryPctText}" VerticalAlignment="Center"/>
+
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Stored Pit Exit %:" Margin="0,4,10,0" VerticalAlignment="Center"/>
+                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding StoredPitExitPctText}" Margin="0,4,0,0" VerticalAlignment="Center"/>
+
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Last Updated (UTC):" Margin="0,4,10,0" VerticalAlignment="Center"/>
+                                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding TrackMarkersLastUpdatedText}" Margin="0,4,0,0" VerticalAlignment="Center"/>
+
+                                        <CheckBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Content="Locked" Margin="0,6,0,0" IsChecked="{Binding TrackMarkersLocked, Mode=TwoWay}" />
+                                    </Grid>
+                                </GroupBox>
+
                             </StackPanel>
                         </ScrollViewer>
                     </Grid>


### PR DESCRIPTION
## Summary
- show stored pit entry/exit percentages and last updated time on the Tracks tab
- add a locked checkbox that updates stored track markers without feedback loops
- refresh the pit track markers snapshot from plugin state alongside identity updates

## Testing
- `dotnet build LaunchPlugin.sln` *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695823acb6c4832f989bb36b35076c58)