### PR TITLE
Fix Pit Track Markers panel to follow selected track

### DIFF
--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -539,6 +539,37 @@ namespace LaunchPlugin
         public bool TrackMarkersSessionNeedsEntryRefresh => GetSessionState(_trackMarkersLastKey)?.NeedsEntryRefresh ?? false;
         public bool TrackMarkersSessionNeedsExitRefresh => GetSessionState(_trackMarkersLastKey)?.NeedsExitRefresh ?? false;
 
+        public bool TryGetStoredTrackMarkers(string trackKey, out double entryPct, out double exitPct, out DateTime lastUpdatedUtc, out bool locked)
+        {
+            EnsureTrackMarkerStoreLoaded();
+            string key = NormalizeTrackKey(trackKey);
+
+            if (string.IsNullOrWhiteSpace(key) || string.Equals(key, "unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                entryPct = double.NaN;
+                exitPct = double.NaN;
+                locked = true;
+                lastUpdatedUtc = DateTime.MinValue;
+                return false;
+            }
+
+            var record = GetStoredTrackMarkers(key);
+            if (record == null)
+            {
+                entryPct = double.NaN;
+                exitPct = double.NaN;
+                locked = true;
+                lastUpdatedUtc = DateTime.MinValue;
+                return false;
+            }
+
+            entryPct = record.PitEntryTrkPct;
+            exitPct = record.PitExitTrkPct;
+            locked = record.Locked;
+            lastUpdatedUtc = record.LastUpdatedUtc;
+            return true;
+        }
+
         public bool TryDequeueTrackMarkerTrigger(out TrackMarkerTriggerEvent trigger)
         {
             if (_trackMarkerTriggers.Count > 0)


### PR DESCRIPTION
## Summary
- add pit engine APIs and plugin helpers to fetch track marker snapshots for arbitrary track keys and toggle locks by key
- refresh the Profiles Tracks marker panel based on the currently selected track selection instead of live session properties
- remove live update overwrite of the panel while keeping existing SimHub exports intact

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f2202460832f9fe532d7b655a373)