### PR TITLE
Add manual reload button for track markers

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -173,6 +173,12 @@ namespace LaunchPlugin
             _pit?.SetTrackMarkersLock(trackKey, locked);
         }
 
+        public void ReloadTrackMarkersFromDisk()
+        {
+            _pit?.ReloadTrackMarkerStore();
+            ProfilesViewModel?.RefreshTrackMarkersSnapshotForSelectedTrack();
+        }
+
         private bool IsTrackMarkerPulseActive(DateTime utcTimestamp)
         {
             return utcTimestamp != DateTime.MinValue &&
@@ -2703,7 +2709,8 @@ namespace LaunchPlugin
                 () => this.CurrentCarModel,
                 () => this.CurrentTrackKey,
                 (trackKey) => GetTrackMarkersSnapshot(trackKey),
-                (trackKey, locked) => SetTrackMarkersLockedForKey(trackKey, locked)
+                (trackKey, locked) => SetTrackMarkersLockedForKey(trackKey, locked),
+                () => ReloadTrackMarkersFromDisk()
             );
 
 

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -469,6 +469,7 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
 
                                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Stored Pit Entry %:" Margin="0,0,10,0" VerticalAlignment="Center"/>
@@ -480,7 +481,8 @@
                                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Last Updated (UTC):" Margin="0,4,10,0" VerticalAlignment="Center"/>
                                         <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding TrackMarkersLastUpdatedText}" Margin="0,4,0,0" VerticalAlignment="Center"/>
 
-                                        <CheckBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Content="Locked" Margin="0,6,0,0" IsChecked="{Binding TrackMarkersLocked, Mode=TwoWay}" />
+                                        <CheckBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Content="Locked" Margin="0,6,6,0" IsChecked="{Binding TrackMarkersLocked, Mode=TwoWay}" />
+                                        <Button Grid.Row="3" Grid.Column="2" Content="Reload markers" Command="{Binding ReloadTrackMarkersCommand}" Margin="0,6,0,0" ToolTip="Reload LalaLaunch.TrackMarkers.json from disk (for manual edits)." />
                                     </Grid>
                                 </GroupBox>
 


### PR DESCRIPTION
## Summary
- add a reload pathway in PitEngine and expose it through LalaLaunch to refresh track markers from disk
- extend the profiles view model with a reload command and wire it to a new UI button for track markers
- ensure marker reloads refresh the displayed snapshot while keeping the previous cache if a load fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596ed9e778832fafdf5cd409201841)