### PR TITLE
Document pit entry markers and MSGV1 integration

### DIFF
--- a/Docs/Code_Snapshot.md
+++ b/Docs/Code_Snapshot.md
@@ -4,6 +4,12 @@
 - Commit: 1bd403867a1752de9e705163a4a2a599905ebe2c
 - Date: 2025-12-28
 
+## Architectural notes (pit markers, MSGV1, and host wiring)
+- `PitEngine` now owns pit entry/exit marker auto-learning, storage, and track-length change detection (threshold 50 m). It emits trigger events for first capture, length delta, line refresh, and locked mismatches, and persists markers immediately into `PluginsData/Common/LalaLaunch/LalaLaunch.TrackMarkers.json`. Lock/unlock semantics are enforced at capture time to keep stored markers authoritative unless refreshed or manually unlocked.【F:PitEngine.cs†L525-L769】【F:PitEngine.cs†L669-L714】【F:PitEngine.cs†L968-L1034】
+- `LalaLaunch` manages marker pulses, attaches marker exports (`TrackMarkers.*` stored/session/trigger fields), and exposes actions to lock/unlock markers plus a reload hook for manual JSON edits. Track marker trigger pulses are routed to MSGV1 via pulsed objects held for ~3 s to allow evaluators to consume them once.【F:LalaLaunch.cs†L134-L182】【F:LalaLaunch.cs†L3047-L3179】
+- `SignalProvider` extends MSGV1 signals with `TrackMarkers.Pulse.*` entries that return the most recent pulse payloads for evaluators; these are polled per evaluation tick and cleared on consumption.【F:Messaging/SignalProvider.cs†L86-L102】
+- `MessageDefinitionStore` registers new definition-driven MSGV1 messages for pit marker capture, track-length delta, and locked mismatch, each paired with dedicated evaluators that latch per-track tokens to avoid repeats. Messages live in `Messages.json` (definition store) and replace any legacy/adhoc messaging for this area.【F:Messaging/MessageDefinitionStore.cs†L393-L452】【F:Messaging/MessageEvaluators.cs†L401-L476】
+
 ## Included .cs Files
 - CarProfiles.cs — last modified 2025-12-27T12:32:10+00:00
 - CopyProfileDialog.xaml.cs — last modified 2025-09-14T19:32:49+01:00

--- a/Docs/Pit_Entry_Assist.md
+++ b/Docs/Pit_Entry_Assist.md
@@ -88,6 +88,7 @@ Branch: work
 - **Limiter-friendly arming:** Limiter ON + overspeed prevents missing the assist on ultra-short entries where phase changes late.
 - **Latched decel/buffer:** Outputs retain the last-used decel and buffer after reset to aid post-run debugging.
 - **Per-car profiles:** Values are stored with car profiles to keep braking cues stable across tyre compounds and ABS/regen behaviours.
+- **Pit entry markers & storage:** Pit entry/exit markers auto-learn per track (locked by default) into `PluginsData/Common/LalaLaunch/LalaLaunch.TrackMarkers.json`; track-length deltas >50 m force unlock and MSGV1 notifications. Lock/refresh controls live in Profiles → Tracks. See `Subsystems/Track_Markers.md` for the full capture/lock/notify flow.
 
 ## Known limitations
 - Relies on sim-provided pit distance; if both primary and fallback sources are absent, the assist cannot arm.  

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -15,12 +15,14 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - [Reset_And_Session_Identity.md](Reset_And_Session_Identity.md) — canonical reset/session rules.
 - [Pit_Entry_Assist.md](Pit_Entry_Assist.md) — driver/dash/log spec for pit entry braking cues.
 - [Dash_Integration.md](Dash_Integration.md) — dash consumption and visualisation contracts (Pit Entry Assist included).
+- [Subsystems/Track_Markers.md](Subsystems/Track_Markers.md) — pit entry/exit marker auto-learn, storage, locking, and MSGV1 notifications.
+- [Subsystems/Message_System_V1.md](Subsystems/Message_System_V1.md) — notification layer for pit markers and other signals (definition-driven, no legacy messages).
 - [BranchWorkflow.md](BranchWorkflow.md) — branching policy.
 - [ConflictResolution.md](ConflictResolution.md) — merge/conflict process.
 
 ## Doc inventory & canonicalisation
 - **Truth docs:** `SimHubParameterInventory.md`, `SimHubLogMessages.md`, `FuelProperties_Spec.md`, `FuelTab_SourceFlowNotes.md`, `Reset_And_Session_Identity.md`, `TimerZeroBehavior.md`.
-- **Subsystem notes:** `Message_Catalog_v5_Signal_Mapping_Report.md`, `FuelTab_LeaderPaceFlow.md`, `FuelTabActionPlanOptions.md`, `FuelTabAnalysis.md`, `LALA-036-extra-time-sanity.md`, `LalaLaunch_Handover_Summary-20251130.docx`, `Pit_Entry_Assist.md`, `Dash_Integration.md`, `Profiles_And_PB.md`.
+- **Subsystem notes:** `Message_Catalog_v5_Signal_Mapping_Report.md`, `FuelTab_LeaderPaceFlow.md`, `FuelTabActionPlanOptions.md`, `FuelTabAnalysis.md`, `LALA-036-extra-time-sanity.md`, `LalaLaunch_Handover_Summary-20251130.docx`, `Pit_Entry_Assist.md`, `Subsystems/Track_Markers.md`, `Dash_Integration.md`, `Profiles_And_PB.md`.
 - **Workflow/process:** `BranchWorkflow.md`, `ConflictResolution.md`, `RepoStatus.md`.
 - **Legacy / reference-only:** `SimHub_Parameter_Inventory.xlsx`, `FuelProperties_Spec.xlsx`, `FuelProperties_Spec (version 1).xlsx`, `Message_Catalog_v5.xlsx`, `Message_Catalog_v5_MessageToSignal_Map.csv`, `Message_Catalog_v5_Signals.csv`, `CarInfo_AllCars.xlsx`, `Codex_Task_Backlog-20251215.xlsx`, `Dahl Design → Lala Launch Mapping (lala Dash).docx`, `Dahl Design → Lala Launch Message Properties Mapping.docx`, `Dash Design.pptx`, `Dual Clutch Logic.docx`, `Phase 1 and 2 Test Script-20251202.docx`, `SessionResetIssues.docx`, `SimHub_DualClutch_Paddle_Guide.docx`, `TestingData.djson`, `UI Work.pptx`. Keep for reference; they are superseded by the canonical files above unless explicitly cited.
 - **Archived:** leave everything under `/Docs/Archived` untouched.
@@ -37,6 +39,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 | Profiles & PB | Profile resolution, PB updates, and identity snapshots | [Subsystems/Profiles_And_PB.md](Subsystems/Profiles_And_PB.md) |
 | Trace logging | Telemetry trace lifecycle and launch trace handling | [Subsystems/Trace_Logging.md](Subsystems/Trace_Logging.md) |
 | Pit Entry Assist | Pit entry braking cues, margin/cue maths, decel capture instrumentation | [Pit_Entry_Assist.md](Pit_Entry_Assist.md) (driver/dash) / [Subsystems/Pit_Entry_Assist.md](Subsystems/Pit_Entry_Assist.md) (engine) |
+| Track markers | Auto-learned pit entry/exit markers (per track), locking, track-length change detection, MSGV1 notifications | [Subsystems/Track_Markers.md](Subsystems/Track_Markers.md) |
 | Dash integration | Screen manager modes, pit screen, dash visibility toggles, and Pit Entry Assist visual guidance | [Dash_Integration.md](Dash_Integration.md) / [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## Canonical docs map

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -50,3 +50,10 @@
 
 ## Where to ask SimHub for car/track live data
 - SimHub exposes the live car and track via data references such as `DataCorePlugin.GameData.CarModel` and `DataCorePlugin.GameData.TrackNameWithConfig`. The UI dropdowns use these live values, so once your GitHub branches are synced you can verify that both the pre-race and snapshot fields bind to the same live strings.
+
+## Feature delivery status (docs canonical)
+- **Pit Entry Assist:** **COMPLETE** — stable, shipped, and represented in driver/dash docs. Uses pit speed + distance sources with decel/buffer tuning; no pending work in this repo.
+- **Track Markers:** **COMPLETE** — pit entry/exit markers auto-learned per track with lock/unlock semantics, track-length change detection, and MSGV1 notifications. Stored in `PluginsData/Common/LalaLaunch/LalaLaunch.TrackMarkers.json`.
+- **MSGV1 for pit markers:** **INTEGRATED** — pit marker capture/length-delta/lock-mismatch messages defined in `Messaging/Messages.json` via `MessageDefinitionStore`; MSGV1 core continues elsewhere but this repo ships pit marker hooks.
+- **Legacy messaging:** **Not used** — only MSGV1 definition-driven messages fire; no legacy/adhoc messaging paths remain for pit markers.
+- **Known/accepted limitations:** Replay session identity quirks remain (see `Reset_And_Session_Identity.md`) and track-length deltas are informational only; both are understood/accepted for current shipping state.


### PR DESCRIPTION
## Summary
- Capture pit entry/exit marker auto-learn, locking, track-length change handling, and MSGV1 notifications in a dedicated subsystem doc with UI guidance
- Refresh RepoStatus and Project Index to mark Pit Entry Assist and Track Markers as complete and MSGV1-backed, and update Code_Snapshot to describe the new responsibilities and wiring
- Note pit marker messaging flow in Message System V1 docs and cross-link Pit Entry Assist to the stored marker/lock workflow

## Testing
- Not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b3d663fc832f86e5c037cf2cf156)