### PR TITLE
Improve opponent lap time parsing for pace outputs

### DIFF
--- a/Opponents.cs
+++ b/Opponents.cs
@@ -147,6 +147,61 @@ namespace LaunchPlugin
             }
         }
 
+        private static double SafeReadDouble(PluginManager pluginManager, string propertyName)
+        {
+            try
+            {
+                var raw = pluginManager?.GetPropertyValue(propertyName);
+                return ConvertRawToDouble(raw);
+            }
+            catch
+            {
+                return double.NaN;
+            }
+        }
+
+        private static double ConvertRawToDouble(object raw)
+        {
+            if (raw == null)
+            {
+                return double.NaN;
+            }
+
+            try
+            {
+                if (raw is TimeSpan ts)
+                {
+                    return ts.TotalSeconds;
+                }
+
+                if (raw is string s)
+                {
+                    if (TimeSpan.TryParse(s, CultureInfo.InvariantCulture, out var parsedTs))
+                    {
+                        return parsedTs.TotalSeconds;
+                    }
+
+                    if (double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsedDouble))
+                    {
+                        return parsedDouble;
+                    }
+
+                    return double.NaN;
+                }
+
+                if (raw is IConvertible)
+                {
+                    return Convert.ToDouble(raw, CultureInfo.InvariantCulture);
+                }
+            }
+            catch
+            {
+                return double.NaN;
+            }
+
+            return double.NaN;
+        }
+
         private static double SanitizePace(double paceSec)
         {
             if (paceSec <= 0.0 || double.IsNaN(paceSec) || double.IsInfinity(paceSec) || paceSec > 10000.0)
@@ -305,19 +360,6 @@ namespace LaunchPlugin
                 }
             }
 
-            private static double SafeReadDouble(PluginManager pluginManager, string propertyName)
-            {
-                try
-                {
-                    var raw = pluginManager?.GetPropertyValue(propertyName);
-                    return Convert.ToDouble(raw ?? double.NaN, CultureInfo.InvariantCulture);
-                }
-                catch
-                {
-                    return double.NaN;
-                }
-            }
-
             private static bool SafeReadBool(PluginManager pluginManager, string propertyName)
             {
                 try
@@ -410,19 +452,6 @@ namespace LaunchPlugin
                 catch
                 {
                     return string.Empty;
-                }
-            }
-
-            private static double SafeReadDouble(PluginManager pluginManager, string propertyName)
-            {
-                try
-                {
-                    var raw = pluginManager?.GetPropertyValue(propertyName);
-                    return Convert.ToDouble(raw ?? double.NaN, CultureInfo.InvariantCulture);
-                }
-                catch
-                {
-                    return double.NaN;
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Opponent pace outputs were often stuck at 0 because lap-time properties read from the plugin could be `TimeSpan` or time-formatted strings which previously failed conversion and produced `NaN`/zero downstream. 
- The goal is to robustly parse opponent lap-time inputs so blended pace, pace delta, and laps-to-fight stop being stuck at 0. 
- No changes to the blending/fighting algorithms are intended; this only fixes input parsing. 

### Description
- Added a reusable converter `ConvertRawToDouble(object)` that returns seconds for `TimeSpan`, parses time-formatted strings via `TimeSpan.TryParse`, parses numeric strings via `double.TryParse`, and falls back to converting `IConvertible` numeric types, returning `double.NaN` on failure. 
- Replaced previous fragile `SafeReadDouble` behavior in nearby slots and leaderboard reads to call the new converter so lap-time inputs are handled consistently. 
- All changes are contained in `Opponents.cs` and do not alter pace/fight calculation logic. 

### Testing
- Attempted to run an automated build with `dotnet build`, which failed because the `dotnet` command is not available in the current environment. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d17869690832f953e3d81a77e01de)