### PR TITLE
Fix Opponent pace delta & fight prediction sign/NaN handling

### DIFF
--- a/Opponents.cs
+++ b/Opponents.cs
@@ -274,7 +274,7 @@ namespace LaunchPlugin
 
                 if (string.IsNullOrWhiteSpace(sample.IdentityKey))
                 {
-                    target.BlendedPaceSec = 0.0;
+                    target.BlendedPaceSec = double.NaN;
                     target.PaceDeltaSecPerLap = double.NaN;
                     target.LapsToFight = double.NaN;
                     return;
@@ -289,7 +289,7 @@ namespace LaunchPlugin
                 }
                 else
                 {
-                    target.BlendedPaceSec = 0.0;
+                    target.BlendedPaceSec = double.NaN;
                 }
 
                 if (double.IsNaN(myPaceSec) || double.IsNaN(target.BlendedPaceSec) || target.BlendedPaceSec <= 0.0)
@@ -305,14 +305,15 @@ namespace LaunchPlugin
 
                 target.PaceDeltaSecPerLap = closingRate;
 
-                if (closingRate >= -0.05)
+                double gap = target.GapToPlayerSec;
+                if (gap > 0.0 && closingRate > 0.05)
                 {
-                    target.LapsToFight = double.NaN;
+                    double lapsToFight = gap / closingRate;
+                    target.LapsToFight = lapsToFight > 999.0 ? 999.0 : lapsToFight;
                 }
                 else
                 {
-                    double gap = target.GapToPlayerSec;
-                    target.LapsToFight = gap > 0.0 ? gap / (-closingRate) : double.NaN;
+                    target.LapsToFight = double.NaN;
                 }
             }
 
@@ -755,7 +756,7 @@ namespace LaunchPlugin
             public string CarNumber { get; set; } = string.Empty;
             public string ClassColor { get; set; } = string.Empty;
             public double GapToPlayerSec { get; set; } = 0.0;
-            public double BlendedPaceSec { get; set; } = 0.0;
+            public double BlendedPaceSec { get; set; } = double.NaN;
             public double PaceDeltaSecPerLap { get; set; } = double.NaN;
             public double LapsToFight { get; set; } = double.NaN;
 
@@ -765,7 +766,7 @@ namespace LaunchPlugin
                 CarNumber = string.Empty;
                 ClassColor = string.Empty;
                 GapToPlayerSec = 0.0;
-                BlendedPaceSec = 0.0;
+                BlendedPaceSec = double.NaN;
                 PaceDeltaSecPerLap = double.NaN;
                 LapsToFight = double.NaN;
             }


### PR DESCRIPTION
### Motivation
- Fix cases where opponent pace outputs were stuck at `0` by treating unknown pace as `double.NaN` instead of zero.
- Ensure `BlendedPaceSec` is propagated from the entity even when unknown so stale `0` values are not used.
- Make `PaceDeltaSecPerLap` follow a clear sign convention where positive means "closing" for both ahead and behind targets.
- Only surface `LapsToFight` when a real closing is happening using a sensible threshold to avoid spurious predictions.

### Description
- Replace zero defaults with `double.NaN` for `BlendedPaceSec` in `OpponentTargetOutput` and when a slot is empty or the entity is missing.
- Always assign the entity blended pace when available (`target.BlendedPaceSec = entity.GetBlendedPaceSec()`), allowing `NaN` to flow when unknown.
- Compute `closingRate` such that it is positive when closing and write it to `PaceDeltaSecPerLap` (ahead: `target.BlendedPaceSec - myPaceSec`, behind: `myPaceSec - target.BlendedPaceSec`).
- Compute `LapsToFight = gap / closingRate` only when `gap > 0.0` and `closingRate > 0.05`, clamp results to `999.0`, otherwise set `LapsToFight = double.NaN`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1996377c832fadf85a5714d8ae70)