### PR TITLE
Refresh Opponents subsystem docs and SimHub inventories (Opponents-Module)

### DIFF
--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,8 +1,8 @@
 # Project Index
 
-Validated against commit: work HEAD  
+Validated against commit: b31a0be584c2941a7d8d4d4c5dde2e852d7b32a2  
 Last updated: 2026-02-07  
-Branch: work
+Branch: Opponents-Module
 
 ## What this repo is
 LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control instrumentation, fuel strategy calculations, pit-cycle timing, rejoin assistance, messaging outputs, and dash/screen coordination across the Fuel, Pit, Launch, and Messaging tabs. Runtime behaviour lives in C# (e.g., `LalaLaunch.cs`, `FuelCalcs.cs`, `PitEngine.cs`) with SimHub exports documented below.
@@ -41,7 +41,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 | Trace logging | Telemetry trace lifecycle and launch trace handling | [Subsystems/Trace_Logging.md](Subsystems/Trace_Logging.md) |
 | Pit Entry Assist | Pit entry braking cues, margin/cue maths, decel capture instrumentation | [Pit_Entry_Assist.md](Pit_Entry_Assist.md) (driver/dash) / [Subsystems/Pit_Entry_Assist.md](Subsystems/Pit_Entry_Assist.md) (engine) |
 | Track markers | Auto-learned pit entry/exit markers (per track), locking, track-length change detection, MSGV1 notifications | [Subsystems/Track_Markers.md](Subsystems/Track_Markers.md) |
-| Opponents | Nearby pace/fight prediction and pit-exit class position forecasting (Race-only, lap gate ≥2) | [Subsystems/Opponents.md](Subsystems/Opponents.md) |
+| Opponents | Nearby pace/fight prediction and pit-exit class position forecasting (Race-only, lap gate ≥2, gaps absolute) | [Subsystems/Opponents.md](Subsystems/Opponents.md) |
 | Dash integration | Screen manager modes, pit screen, dash visibility toggles, and Pit Entry Assist visual guidance | [Dash_Integration.md](Dash_Integration.md) / [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## Canonical docs map
@@ -64,6 +64,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - Fuel tab/UI source or planner changes → update `FuelTab_SourceFlowNotes.md`.
 
 ## Freshness
-- Validated against commit: 88cfd6ba10558452391dd921d23ae69b94a0a44e  
-- Date: 2025-12-28  
-- Branch: work
+- Validated against commit: b31a0be584c2941a7d8d4d4c5dde2e852d7b32a2  
+- Date: 2026-02-07  
+- Branch: Opponents-Module

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -1,8 +1,8 @@
 # SimHub Log Messages (CANONICAL)
 
-Validated against commit: 52bd57d7c618f4df094c68c4ea6f1e11cc5e328f  
-Last updated: 2026-02-06  
-Branch: work
+Validated against commit: b31a0be584c2941a7d8d4d4c5dde2e852d7b32a2  
+Last updated: 2026-02-07  
+Branch: Opponents-Module
 
 Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
 
@@ -55,10 +55,10 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 
 ## Opponents and pit-exit prediction
 - **`[LalaPlugin:Opponents] Opponents subsystem active (Race session + lap gate met).`** — Gate opened (Race + CompletedLaps ≥2); outputs now live.【F:Opponents.cs†L72-L88】
-- **`[LalaPlugin:Opponents] Slot <slot> rebound -> <identity> (<name>)`** — Nearby slot (Ahead1/2, Behind1/2) re-bound to a new identity; pace cache persists per identity.【F:Opponents.cs†L264-L305】
-- **`[LalaPlugin:PitExit] Predictor valid -> true (pitLoss=X.Xs)`** — Pit-exit predictor became valid with leaderboard/player row found.【F:Opponents.cs†L520-L533】
-- **`[LalaPlugin:PitExit] Predicted class position changed -> P# (ahead=N)`** — Predicted post-stop class position changed while valid.【F:Opponents.cs†L525-L533】
-- **`[LalaPlugin:PitExit] Predictor valid -> false`** — Pit-exit predictor lost validity (no player row/leaderboard data).【F:Opponents.cs†L538-L548】
+- **`[LalaPlugin:Opponents] Slot <slot> rebound -> <identity> (<name>)`** — Nearby slot (Ahead1/2, Behind1/2) re-bound to a new identity; pace cache persists per identity (logs gated to lap ≥2).【F:Opponents.cs†L252-L361】
+- **`[LalaPlugin:PitExit] Predictor valid -> true (pitLoss=X.Xs)`** — Pit-exit predictor became valid with leaderboard/player row found.【F:Opponents.cs†L507-L566】
+- **`[LalaPlugin:PitExit] Predicted class position changed -> P# (ahead=N)`** — Predicted post-stop class position changed while valid.【F:Opponents.cs†L532-L566】
+- **`[LalaPlugin:PitExit] Predictor valid -> false`** — Pit-exit predictor lost validity (no player row/leaderboard data).【F:Opponents.cs†L568-L579】
 
 ## Pit, refuel, and PitLite
 - **`[LalaPlugin:Pit Cycle] Saved PitLaneLoss = Xs (src).`** — Persisted pit lane loss from PitLite/DTL (debounced).【F:LalaLaunch.cs†L2950-L3004】

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -1,10 +1,10 @@
 # SimHub Parameter Inventory (CANONICAL)
 
-Validated against commit: 52bd57d7c618f4df094c68c4ea6f1e11cc5e328f  
-Last updated: 2026-02-06  
-Branch: work
+Validated against commit: b31a0be584c2941a7d8d4d4c5dde2e852d7b32a2  
+Last updated: 2026-02-07  
+Branch: Opponents-Module
 
-- All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2606-L2955】【F:LalaLaunch.cs†L3235-L3585】
+- All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
 - Legacy spreadsheet `SimHub_Parameter_Inventory.xlsx` is reference-only; this file is canonical.
 - “Defined in” lists the class/method that computes the value before `AttachCore/AttachVerbose` publishes it.
 
@@ -59,20 +59,20 @@ Branch: work
 ## Opponents & Pit Exit
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Opp.Ahead1.Name / CarNumber / ClassColor | string | Identity of the closest class car ahead (slot bound by iRacing extras; identity = ClassColor:CarNumber). Empty before Race lap ≥2 gate. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — nearby slot ingestion + `AttachCore`【F:Opponents.cs†L42-L262】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Ahead1.GapToPlayerSec | double | Gap seconds to player from IRacing relative (ahead expected positive). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot read + `AttachCore`【F:Opponents.cs†L264-L305】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Ahead1.BlendedPaceSec | double | Blended pace (0.70×recent avg + 0.30×best×1.01) for ahead car; NaN when invalid. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — entity cache + `AttachCore`【F:Opponents.cs†L624-L687】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Ahead1.PaceDeltaSecPerLap | double | Closing rate vs player pace (opponent − mine; negative = you are faster). NaN when no pace. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — fight computation + `AttachCore`【F:Opponents.cs†L213-L262】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Ahead1.LapsToFight | double | Laps to reach/fight the ahead car based on gap/closing rate; NaN = no catch/invalid. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — fight computation + `AttachCore`【F:Opponents.cs†L213-L262】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Ahead2.* | string/double | Same fields as Ahead1 for the second car ahead in class. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot 2 ahead + `AttachCore`【F:Opponents.cs†L197-L262】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Behind1.* | string/double | Same fields for closest car behind in class. PaceDeltaSecPerLap = (mine − opponent). LapsToFight = laps until caught (NaN = no threat). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot behind + `AttachCore`【F:Opponents.cs†L197-L262】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Behind2.* | string/double | Same fields for second car behind in class. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot behind + `AttachCore`【F:Opponents.cs†L197-L262】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Leader.BlendedPaceSec / Opp.P2.BlendedPaceSec | double | Blended pace for class leader / P2 from leaderboard rows (NaN if unavailable or gated). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — leaderboard pace + `AttachCore`【F:Opponents.cs†L352-L401】【F:LalaLaunch.cs†L3058-L3098】 |
-| Opp.Summary | string | Compact summary of A1/A2/B1/B2 gap/Δ/fight status for dashboards. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — summary builder + `AttachCore`【F:Opponents.cs†L102-L135】【F:LalaLaunch.cs†L3058-L3098】 |
-| PitExit.Valid | bool | True when pit-exit predictor has a player row + leaderboard data while gated (Race, lap ≥2). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L456-L548】【F:LalaLaunch.cs†L3058-L3098】 |
-| PitExit.PredictedPositionInClass | int | Predicted class position after a pit stop using pitLossSec from FuelCalculator (1 + cars predicted ahead). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L477-L548】【F:LalaLaunch.cs†L3058-L3098】 |
-| PitExit.CarsAheadAfterPitCount | int | Count of same-class connected cars expected to be ahead after serving pit loss. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L500-L548】【F:LalaLaunch.cs†L3058-L3098】 |
-| PitExit.Summary | string | Human summary of predicted post-stop position (`PitExit: P# after stop (ahead=X, loss=Ys)`). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L518-L548】【F:LalaLaunch.cs†L3058-L3098】 |
+| Opp.Ahead1.Name / CarNumber / ClassColor | string | Identity of the closest class car ahead (slot bound by iRacing extras; identity = ClassColor:CarNumber). Empty before Race lap ≥2 gate. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — nearby slot ingestion + `AttachCore`【F:Opponents.cs†L42-L344】【F:LalaLaunch.cs†L3079-L3093】 |
+| Opp.Ahead1.GapToPlayerSec | double | Gap seconds to player from IRacing relative (stored absolute). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot read + `AttachCore`【F:Opponents.cs†L268-L317】【F:LalaLaunch.cs†L3079-L3093】 |
+| Opp.Ahead1.BlendedPaceSec | double | Blended pace (0.70×recent avg + 0.30×best×1.01) for ahead car; NaN when invalid. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — entity cache + `AttachCore`【F:Opponents.cs†L627-L717】【F:LalaLaunch.cs†L3079-L3093】 |
+| Opp.Ahead1.PaceDeltaSecPerLap | double | Closing rate vs player pace (opponent − mine; positive means you are faster by that margin). NaN when no pace. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — fight computation + `AttachCore`【F:Opponents.cs†L268-L317】【F:LalaLaunch.cs†L3079-L3093】 |
+| Opp.Ahead1.LapsToFight | double | Laps to reach/fight the ahead car; requires gap >0 and closingRate >0.05 s/lap, else NaN. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — fight computation + `AttachCore`【F:Opponents.cs†L268-L317】【F:LalaLaunch.cs†L3079-L3093】 |
+| Opp.Ahead2.* | string/double | Same fields as Ahead1 for the second car ahead in class. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot 2 ahead + `AttachCore`【F:Opponents.cs†L252-L344】【F:LalaLaunch.cs†L3079-L3094】 |
+| Opp.Behind1.* | string/double | Same fields for closest car behind in class. PaceDeltaSecPerLap = (mine − opponent). LapsToFight published only when closingRate >0.05 s/lap. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot behind + `AttachCore`【F:Opponents.cs†L252-L344】【F:LalaLaunch.cs†L3095-L3102】 |
+| Opp.Behind2.* | string/double | Same fields for second car behind in class. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — slot behind + `AttachCore`【F:Opponents.cs†L252-L344】【F:LalaLaunch.cs†L3103-L3109】 |
+| Opp.Leader.BlendedPaceSec / Opp.P2.BlendedPaceSec | double | Blended pace for class leader / P2 from leaderboard rows (NaN if unavailable or gated). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — leaderboard pace + `AttachCore`【F:Opponents.cs†L395-L444】【F:LalaLaunch.cs†L3111-L3113】 |
+| Opp.Summary | string | Compact summary of A1/A2/B1/B2 gap/Δ/fight status for dashboards. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — summary builder + `AttachCore`【F:Opponents.cs†L102-L135】【F:LalaLaunch.cs†L3111-L3113】 |
+| PitExit.Valid | bool | True when pit-exit predictor has a player row + leaderboard data while gated (Race, lap ≥2). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L507-L579】【F:LalaLaunch.cs†L3115-L3118】 |
+| PitExit.PredictedPositionInClass | int | Predicted class position after a pit stop using validated pitLossSec (1 + cars predicted ahead). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L507-L566】【F:LalaLaunch.cs†L3115-L3118】 |
+| PitExit.CarsAheadAfterPitCount | int | Count of same-class connected cars expected to be ahead after serving pit loss. | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L532-L566】【F:LalaLaunch.cs†L3115-L3118】 |
+| PitExit.Summary | string | Human summary of predicted post-stop position (`PitExit: P# after stop (ahead=X, loss=Ys)`). | Per tick (Race only, lap gate ≥2). | `Opponents.cs` — pit-exit predictor + `AttachCore`【F:Opponents.cs†L550-L566】【F:LalaLaunch.cs†L3115-L3118】 |
 
 ## Pit timing and PitLite
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
@@ -94,8 +94,8 @@ Branch: work
 | Pit.EntrySpeedDelta_kph | double | Current speed minus pit speed limit (session pit limit, fallback to iRacing extra). | Per tick when armed. | `PitEngine.UpdatePitEntryAssist` + `AttachCore`【F:PitEngine.cs†L251-L276】【F:LalaLaunch.cs†L2756-L2758】 |
 | Pit.EntryDecelProfile_mps2 | double | Profile-configured pit entry decel used for the constant-decel model (clamped to 5–25 m/s²). | Per tick when armed. | `PitEngine.UpdatePitEntryAssist` + `AttachCore`【F:PitEngine.cs†L240-L259】【F:LalaLaunch.cs†L2757-L2759】 |
 | Pit.EntryBuffer_m | double | Profile-configured buffer distance used for cue thresholds (clamped to 0–50 m). | Per tick when armed. | `PitEngine.UpdatePitEntryAssist` + `AttachCore`【F:PitEngine.cs†L240-L259】【F:LalaLaunch.cs†L2758-L2760】 |
-| PitExit.DistanceM | int | Forward distance in metres to the stored pit exit marker (wraps at S/F). Returns 0 if data missing. | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L3411-L3444】【F:LalaLaunch.cs†L3058-L3063】 |
-| PitExit.TimeS | int | Estimated time in seconds to pit exit using current speed (0 if speed too small or data missing). | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L3411-L3444】【F:LalaLaunch.cs†L3058-L3063】 |
+| PitExit.DistanceM | int | Forward distance in metres to the stored pit exit marker (wraps at S/F). Returns 0 if data missing. | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L4216-L4248】【F:LalaLaunch.cs†L3068-L3069】 |
+| PitExit.TimeS | int | Estimated time in seconds to pit exit using current speed (0 if speed too small or data missing). | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L4216-L4248】【F:LalaLaunch.cs†L3068-L3069】 |
 
 ## Launch
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/Subsystems/Opponents.md
+++ b/Docs/Subsystems/Opponents.md
@@ -3,35 +3,36 @@
 Purpose: own all opponent-facing calculations for nearby pace/fight prediction and pit-exit position forecasting with SimHub exports under `Opp.*` and `PitExit.*`.
 
 ## Gating and scope
-- Runs **race sessions only**; resets and publishes defaults outside Race.【F:Opponents.cs†L42-L88】
-- Additional lap gate: requires **CompletedLaps ≥ 2** before any Opp/PitExit outputs become valid. Gate opening logs once per activation.【F:Opponents.cs†L58-L88】
-- Uses **IRacingExtraProperties only**; no Dahl DLL or SDK arrays.
+- Runs **race sessions only**; resets caches/outputs if session leaves Race.【F:Opponents.cs†L42-L88】
+- Additional lap gate: requires **CompletedLaps ≥ 2** before any Opp/PitExit outputs become valid. Data is still ingested pre-gate, but outputs/logging are gated. Gate opening logs once per activation.【F:Opponents.cs†L58-L88】
+- Uses **IRacingExtraProperties only**; no Dahl DLL or SDK arrays.【F:Opponents.cs†L42-L88】
 
 ## Identity model
 - Stable key: `ClassColor:CarNumber`. Empty class+number returns blank identity (slot ignored).【F:Opponents.cs†L90-L100】
-- Nearby slot changes log once per rebind when active; identity caches persist pace history across slot swaps.【F:Opponents.cs†L197-L305】
+- Nearby slot changes log once per rebind when active; identity caches persist pace history across slot swaps. Logging follows the lap gate (no chatter before lap ≥2).【F:Opponents.cs†L252-L361】
 
 ## Data inputs
-- Nearby targets: `iRacing_DriverAheadInClass_00/01_*`, `iRacing_DriverBehindInClass_00/01_*` for Name, CarNumber, ClassColor, RelativeGapToPlayer, LastLapTime, BestLapTime, IsInPit, IsConnected.【F:Opponents.cs†L197-L305】
-- Leaderboard scan (00–63 until empty row): `iRacing_ClassLeaderboard_Driver_XX_*` for Name, CarNumber, ClassColor, PositionInClass, RelativeGapToLeader, IsInPit/IsConnected, LastLapTime, BestLapTime.【F:Opponents.cs†L352-L387】
-- Player identity: `iRacing_Player_ClassColor`, `iRacing_Player_CarNumber`. Pit-exit uses pit loss passed in from LalaLaunch (FuelCalculator.PitLaneTimeLoss).【F:Opponents.cs†L42-L88】【F:LalaLaunch.cs†L3622-L3633】
+- Nearby targets: `iRacing_DriverAheadInClass_00/01_*`, `iRacing_DriverBehindInClass_00/01_*` for Name, CarNumber, ClassColor, RelativeGapToPlayer, LastLapTime, BestLapTime, IsInPit, IsConnected.【F:Opponents.cs†L252-L344】
+- Leaderboard scan (00–63 until empty row): `iRacing_ClassLeaderboard_Driver_XX_*` for Name, CarNumber, ClassColor, PositionInClass, RelativeGapToLeader, IsInPit/IsConnected, LastLapTime, BestLapTime.【F:Opponents.cs†L395-L430】
+- Player identity: `iRacing_Player_ClassColor`, `iRacing_Player_CarNumber`. Pit-exit receives pit loss from LalaLaunch’s stop-loss calculation (validated to ≥0).【F:Opponents.cs†L42-L88】【F:LalaLaunch.cs†L4144-L4181】
 
 ## Pace cache & blended pace
-- Entity cache keyed by identity; keeps best lap and a 5-lap ring buffer of valid recent laps (rejects ≤0/NaN/huge, skips laps flagged in-pit).【F:Opponents.cs†L551-L688】
-- BlendedPaceSec = 0.70×RecentAvg + 0.30×(BestLap×1.01); falls back to recent-only or best×1.01 if missing.【F:Opponents.cs†L652-L687】
+- Entity cache keyed by identity; keeps best lap and a 5-lap ring buffer of valid recent laps (rejects ≤0/NaN/huge, skips laps flagged in-pit).【F:Opponents.cs†L627-L717】
+- BlendedPaceSec = 0.70×RecentAvg + 0.30×(BestLap×1.01); falls back to recent-only or best×1.01 if missing.【F:Opponents.cs†L693-L717】
 
 ## Fight prediction (dash support)
-- Uses my pace (from LalaLaunch) vs opponent blended pace once gate active.【F:Opponents.cs†L42-L88】【F:LalaLaunch.cs†L3622-L3633】
-- Ahead: closingRate = opponent − mine; if ≥ −0.05 → “no catch”; else LapsToFight = gap / −closingRate.【F:Opponents.cs†L213-L262】
-- Behind: closingRate = mine − opponent; if ≥ −0.05 → “no threat”; else LapsToFight = gap / −closingRate.【F:Opponents.cs†L213-L262】
+- Uses my pace (from LalaLaunch) vs opponent blended pace once gate active; my pace is sanitized to remove invalid/huge values.【F:Opponents.cs†L42-L88】【F:Opponents.cs†L82-L88】
+- Gap is stored as the absolute of the relative gap input for display consistency.【F:Opponents.cs†L268-L317】
+- Ahead: closingRate = opponent − mine; requires closingRate > +0.05 s/lap and positive gap to publish LapsToFight (capped at 999). Otherwise NaN (no catch).【F:Opponents.cs†L268-L317】
+- Behind: closingRate = mine − opponent; requires closingRate > +0.05 s/lap and positive gap to publish LapsToFight (NaN when no threat/invalid).【F:Opponents.cs†L268-L317】
 - Summary string concatenates A1/A2/B1/B2 compact status for dashboards.【F:Opponents.cs†L102-L135】
 
 ## Pit-exit prediction
-- Finds player row in class leaderboard; gapToPlayer = opp.RelGapToLeader − player.RelGapToLeader. predictedGapAfterPit = gapToPlayer − pitLossSec.【F:Opponents.cs†L477-L536】
-- PredictedPosition = 1 + count of same-class connected cars where predictedGapAfterPit < 0. Logs when validity toggles or predicted position changes while active.【F:Opponents.cs†L525-L548】
-- Publishes PitExit.Valid/PredictedPositionInClass/CarsAheadAfterPitCount/Summary; defaults reset when invalid.【F:Opponents.cs†L456-L548】【F:Opponents.cs†L745-L758】
+- Finds player row in class leaderboard; gapToPlayer = opp.RelGapToLeader − player.RelGapToLeader. predictedGapAfterPit = gapToPlayer − pitLossSec (pit loss forced to 0 when invalid).【F:Opponents.cs†L507-L553】
+- PredictedPosition = 1 + count of same-class connected cars where predictedGapAfterPit < 0. Logs when validity toggles or predicted position changes while active.【F:Opponents.cs†L532-L566】
+- Publishes PitExit.Valid/PredictedPositionInClass/CarsAheadAfterPitCount/Summary; defaults reset when invalid.【F:Opponents.cs†L507-L579】【F:Opponents.cs†L775-L789】
 
 ## Outputs
-- `Opp.Ahead1/2.*`, `Opp.Behind1/2.*` → Name, CarNumber, ClassColor, GapToPlayerSec, BlendedPaceSec, PaceDeltaSecPerLap, LapsToFight (NaN = no fight/invalid). Summary at `Opp.Summary`.【F:Opponents.cs†L205-L262】【F:Opponents.cs†L690-L743】
-- Optional leader pace: `Opp.Leader.BlendedPaceSec`, `Opp.P2.BlendedPaceSec`.【F:Opponents.cs†L84-L88】【F:Opponents.cs†L690-L720】
-- Pit exit exports: `PitExit.Valid`, `PitExit.PredictedPositionInClass`, `PitExit.CarsAheadAfterPitCount`, `PitExit.Summary`.【F:Opponents.cs†L477-L548】【F:Opponents.cs†L745-L758】
+- `Opp.Ahead1/2.*`, `Opp.Behind1/2.*` → Name, CarNumber, ClassColor, GapToPlayerSec (absolute), BlendedPaceSec, PaceDeltaSecPerLap, LapsToFight (NaN = no fight/invalid). Summary at `Opp.Summary`.【F:Opponents.cs†L252-L343】【F:Opponents.cs†L268-L317】【F:Opponents.cs†L720-L750】
+- Optional leader pace: `Opp.Leader.BlendedPaceSec`, `Opp.P2.BlendedPaceSec`.【F:Opponents.cs†L84-L88】【F:Opponents.cs†L720-L736】
+- Pit exit exports: `PitExit.Valid`, `PitExit.PredictedPositionInClass`, `PitExit.CarsAheadAfterPitCount`, `PitExit.Summary`.【F:Opponents.cs†L507-L566】【F:Opponents.cs†L775-L789】


### PR DESCRIPTION
### Motivation
- Bring documentation in-line with the implemented `Opponents` behaviour (lap-gated logging, absolute gap semantics, closing-rate thresholds, and pit-exit validation).
- Ensure SimHub export and log catalog references point to the correct source ranges and reflect the new branch snapshot.
- Keep the project index and canonical inventories consistent with the `Opponents-Module` documentation snapshot.

### Description
- Updated `Docs/Subsystems/Opponents.md` to reflect gated ingestion vs gated outputs, absolute gap storage, fight math thresholds, and pit-exit pit-loss handling with linked code ranges.
- Updated `Docs/SimHubParameterInventory.md` to refresh `Opp.*` / `PitExit.*` export rows, adjust line-range references, and correct `PitExit.DistanceM`/`PitExit.TimeS` source locations.
- Updated `Docs/SimHubLogMessages.md` to align Opponents- and PitExit-related log entries with current code line ranges and gated logging behaviour.
- Updated `Docs/Project_Index.md` metadata (validated commit, date, and branch = `Opponents-Module`) and a short description note for the Opponents subsystem.

### Testing
- No automated tests were executed because this is documentation-only work.
- Changes were applied and committed to the local branch and updated files were validated by inspection (diff/stat updates only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1dbd4240832f9164a4bd56839723)