### PR TITLE
Expose PitExit ahead/behind identity and gap fields

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3123,6 +3123,14 @@ namespace LaunchPlugin
             AttachCore("PitExit.PredictedPositionInClass", () => _opponentsEngine?.Outputs.PitExit.PredictedPositionInClass ?? 0);
             AttachCore("PitExit.CarsAheadAfterPitCount", () => _opponentsEngine?.Outputs.PitExit.CarsAheadAfterPitCount ?? 0);
             AttachCore("PitExit.Summary", () => _opponentsEngine?.Outputs.PitExit.Summary ?? string.Empty);
+            AttachCore("PitExit.Ahead.Name", () => _opponentsEngine?.Outputs.PitExit.AheadName ?? string.Empty);
+            AttachCore("PitExit.Ahead.CarNumber", () => _opponentsEngine?.Outputs.PitExit.AheadCarNumber ?? string.Empty);
+            AttachCore("PitExit.Ahead.ClassColor", () => _opponentsEngine?.Outputs.PitExit.AheadClassColor ?? string.Empty);
+            AttachCore("PitExit.Ahead.GapSec", () => _opponentsEngine?.Outputs.PitExit.AheadGapSec ?? 0.0);
+            AttachCore("PitExit.Behind.Name", () => _opponentsEngine?.Outputs.PitExit.BehindName ?? string.Empty);
+            AttachCore("PitExit.Behind.CarNumber", () => _opponentsEngine?.Outputs.PitExit.BehindCarNumber ?? string.Empty);
+            AttachCore("PitExit.Behind.ClassColor", () => _opponentsEngine?.Outputs.PitExit.BehindClassColor ?? string.Empty);
+            AttachCore("PitExit.Behind.GapSec", () => _opponentsEngine?.Outputs.PitExit.BehindGapSec ?? 0.0);
 
         }
 

--- a/Opponents.cs
+++ b/Opponents.cs
@@ -1019,6 +1019,14 @@ namespace LaunchPlugin
             public int PredictedPositionInClass { get; set; }
             public int CarsAheadAfterPitCount { get; set; }
             public string Summary { get; set; } = string.Empty;
+            public string AheadName { get; set; } = string.Empty;
+            public string AheadCarNumber { get; set; } = string.Empty;
+            public string AheadClassColor { get; set; } = string.Empty;
+            public double AheadGapSec { get; set; }
+            public string BehindName { get; set; } = string.Empty;
+            public string BehindCarNumber { get; set; } = string.Empty;
+            public string BehindClassColor { get; set; } = string.Empty;
+            public double BehindGapSec { get; set; }
 
             public void Reset()
             {
@@ -1026,6 +1034,14 @@ namespace LaunchPlugin
                 PredictedPositionInClass = 0;
                 CarsAheadAfterPitCount = 0;
                 Summary = string.Empty;
+                AheadName = string.Empty;
+                AheadCarNumber = string.Empty;
+                AheadClassColor = string.Empty;
+                AheadGapSec = 0.0;
+                BehindName = string.Empty;
+                BehindCarNumber = string.Empty;
+                BehindClassColor = string.Empty;
+                BehindGapSec = 0.0;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Provide richer pit-exit information by exposing the opponent immediately ahead and behind at pit exit for dashboards and plugins.
- Ensure those new fields are cleared when the pit-exit output is reset so stale values are not exported.

### Description
- Added eight new properties to `PitExitOutput`: `AheadName`, `AheadCarNumber`, `AheadClassColor`, `AheadGapSec`, `BehindName`, `BehindCarNumber`, `BehindClassColor`, and `BehindGapSec`.
- Updated `PitExitOutput.Reset()` to clear the new string fields to empty and numeric gap fields to `0.0`.
- Added exporters in `LalaLaunch.cs` via `AttachCore` for `PitExit.Ahead.Name`, `PitExit.Ahead.CarNumber`, `PitExit.Ahead.ClassColor`, `PitExit.Ahead.GapSec`, `PitExit.Behind.Name`, `PitExit.Behind.CarNumber`, `PitExit.Behind.ClassColor`, and `PitExit.Behind.GapSec` that return the corresponding `PitExit` properties.

### Testing
- No automated tests were run for this change.
- Code changes compile-time safety was not verified by automated test runs in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db0a52224832fac755202fc66d36c)