### PR TITLE
Align PitExitSnapshot with PitExitOutput (add ahead/behind fields)

### DIFF
--- a/Opponents.cs
+++ b/Opponents.cs
@@ -725,7 +725,15 @@ namespace LaunchPlugin
                     PlayerGapToLeader = playerGapToLeader,
                     PitLossSec = pitLoss,
                     PredictedPositionInClass = predictedPos,
-                    CarsAheadAfterPit = carsAheadAfterPit
+                    CarsAheadAfterPit = carsAheadAfterPit,
+                    AheadName = _output.AheadName,
+                    AheadCarNumber = _output.AheadCarNumber,
+                    AheadClassColor = _output.AheadClassColor,
+                    AheadGapSec = _output.AheadGapSec,
+                    BehindName = _output.BehindName,
+                    BehindCarNumber = _output.BehindCarNumber,
+                    BehindClassColor = _output.BehindClassColor,
+                    BehindGapSec = _output.BehindGapSec
                 };
                 _hasSnapshot = true;
 
@@ -1071,6 +1079,14 @@ namespace LaunchPlugin
             public double PitLossSec { get; set; }
             public int PredictedPositionInClass { get; set; }
             public int CarsAheadAfterPit { get; set; }
+            public string AheadName { get; set; } = string.Empty;
+            public string AheadCarNumber { get; set; } = string.Empty;
+            public string AheadClassColor { get; set; } = string.Empty;
+            public double AheadGapSec { get; set; }
+            public string BehindName { get; set; } = string.Empty;
+            public string BehindCarNumber { get; set; } = string.Empty;
+            public string BehindClassColor { get; set; } = string.Empty;
+            public double BehindGapSec { get; set; }
         }
 
         public class PitExitOutput


### PR DESCRIPTION
### Motivation
- Keep the one-time pit-in / pit-out snapshots consistent with the live `PitExit` outputs by including the same identity and gap details for the nearest ahead/behind cars.
- Ensure snapshots reflect the full prediction state used by UI/exports without changing any existing log formats.
- Preserve existing reset/invalidation behavior so defaults are restored on predictor invalidation.

### Description
- Added ahead/behind identity and gap fields to `PitExitSnapshot` (`AheadName`, `AheadCarNumber`, `AheadClassColor`, `AheadGapSec`, `BehindName`, `BehindCarNumber`, `BehindClassColor`, `BehindGapSec`).
- Populate those new snapshot fields inside `PitExitPredictor.Update(...)` from the predictor `_output` values so snapshots stay in sync with `PitExitOutput`.
- Confirmed `PitExitOutput.Reset()` continues to clear the related output fields and `PitExitPredictor.Reset()` still calls `_output.Reset()` so defaults are preserved.
- Did not modify `LogPitExitPitInSnapshot` or `LogPitExitPitOutSnapshot` (no changes to logging tokens or formats).

### Testing
- No automated tests were run as part of this change.
- Basic static inspection and compilation-oriented edits were performed locally (no test suite executed).
- No unit/integration test failures reported because tests were not executed.
- Manual verification limited to code diffs to ensure new fields are initialized and assigned where intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db670f764832fae6337e176e18c44)