### PR TITLE
Restore live pit-exit snapshot semantics and tighten pit-in/out logs

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4676,6 +4676,13 @@ namespace LaunchPlugin
             int predPosClass = hasSnapshot ? snapshot.PredictedPositionInClass : 0;
             int carsAhead = hasSnapshot ? snapshot.CarsAheadAfterPit : 0;
             double pitLoss = hasSnapshot ? snapshot.PitLossSec : pitLossSec;
+            double entryGapLdr = hasSnapshot ? snapshot.PitEntryGapToLeaderSec : double.NaN;
+            double gapLdrLive = hasSnapshot ? snapshot.GapToLeaderLiveSec : gapLdr;
+            double gapLdrUsed = hasSnapshot ? snapshot.GapToLeaderUsedSec : gapLdr;
+            double pitLossLive = hasSnapshot ? snapshot.PitLossLiveSec : pitLossSec;
+            double pitLossUsed = hasSnapshot ? snapshot.PitLossUsedSec : pitLoss;
+            double predGapAfterPit = hasSnapshot ? snapshot.PredGapAfterPitSec : double.NaN;
+            bool pitTripLockActive = hasSnapshot && snapshot.PitTripLockActive;
 
             double laneRef = _pitLite?.TimePitLaneSec ?? 0.0;
             double boxRef = _pitLite?.TimePitBoxSec ?? 0.0;
@@ -4687,7 +4694,11 @@ namespace LaunchPlugin
                 $"posClass=P{posClass} posOverall=P{posOverall} gapLdr={FormatSecondsWithSuffix(gapLdr)} " +
                 $"pitLoss={FormatSecondsWithSuffix(pitLoss)} predPosClass=P{predPosClass} carsAhead={carsAhead} " +
                 $"srcPitLoss={srcPitLoss} laneRef={FormatSecondsWithSuffix(laneRef)} " +
-                $"boxRef={FormatSecondsWithSuffix(boxRef)} directRef={FormatSecondsWithSuffix(directRef)}"
+                $"boxRef={FormatSecondsWithSuffix(boxRef)} directRef={FormatSecondsWithSuffix(directRef)} " +
+                $"entryGapLdr={FormatSecondsWithSuffix(entryGapLdr)} gapLdrLive={FormatSecondsWithSuffix(gapLdrLive)} " +
+                $"gapLdrUsed={FormatSecondsWithSuffix(gapLdrUsed)} pitLossLive={FormatSecondsWithSuffix(pitLossLive)} " +
+                $"pitLossUsed={FormatSecondsWithSuffix(pitLossUsed)} predGapAfterPit={FormatSecondsWithSuffix(predGapAfterPit)} " +
+                $"lock={pitTripLockActive}"
             );
 
             if (_opponentsEngine.TryGetPitExitMathAudit(out var auditLine))
@@ -4705,6 +4716,11 @@ namespace LaunchPlugin
             int posOverall = hasSnapshot ? snapshot.PlayerPositionOverall : 0;
             int predPosClass = hasSnapshot ? snapshot.PredictedPositionInClass : 0;
             int carsAhead = hasSnapshot ? snapshot.CarsAheadAfterPit : 0;
+            double entryGapLdr = hasSnapshot ? snapshot.PitEntryGapToLeaderSec : double.NaN;
+            double gapLdrLive = hasSnapshot ? snapshot.GapToLeaderLiveSec : double.NaN;
+            double gapLdrUsed = hasSnapshot ? snapshot.GapToLeaderUsedSec : double.NaN;
+            double predGapAfterPit = hasSnapshot ? snapshot.PredGapAfterPitSec : double.NaN;
+            bool pitTripLockActive = hasSnapshot && snapshot.PitTripLockActive;
 
             double laneRef = _pitLite?.TimePitLaneSec ?? 0.0;
             double boxRef = _pitLite?.TimePitBoxSec ?? 0.0;
@@ -4714,7 +4730,10 @@ namespace LaunchPlugin
                 $"[LalaPlugin:PitExit] Pit-out snapshot: lap={lapNumber} t={sessionTime:F1} " +
                 $"posClass=P{posClass} posOverall=P{posOverall} predPosClassNow=P{predPosClass} " +
                 $"carsAheadNow={carsAhead} lane={FormatSecondsWithSuffix(laneRef)} box={FormatSecondsWithSuffix(boxRef)} " +
-                $"direct={FormatSecondsWithSuffix(directRef)} pitTripActive={pitTripActive}"
+                $"direct={FormatSecondsWithSuffix(directRef)} pitTripActive={pitTripActive} " +
+                $"entryGapLdr={FormatSecondsWithSuffix(entryGapLdr)} gapLdrLiveNow={FormatSecondsWithSuffix(gapLdrLive)} " +
+                $"gapLdrUsed={FormatSecondsWithSuffix(gapLdrUsed)} predGapAfterPit={FormatSecondsWithSuffix(predGapAfterPit)} " +
+                $"lock={pitTripLockActive}"
             );
         }
 


### PR DESCRIPTION
### Motivation
- Restore unambiguous snapshot semantics so `PlayerGapToLeader` and `PitLossSec` always represent LIVE inputs and not the locked/used values.  
- Keep existing pit-trip lock behavior (use `gapUsed + pitLossUsed` for prediction) while making logs/audits clear and comparable.  
- Improve auditability for pit-in vs pit-out comparisons by moving used/locked values into explicit audit fields.  
- Avoid behavioral, cadence, or smoothing changes and keep C# 7.3 compatibility.

### Description
- In `Opponents.cs` `PitExitPredictor.Update` the snapshot now assigns `PlayerGapToLeader = playerGapToLeader` and `PitLossSec = pitLoss` so snapshot fields retain live semantics.  
- Added and populated explicit audit fields on `PitExitSnapshot`: `GapToLeaderLiveSec`, `GapToLeaderUsedSec`, `PitEntryGapToLeaderSec`, `PitLossLiveSec`, `PitLossUsedSec`, `PredGapAfterPitSec`, and `PitTripLockActive`.  
- Preserved the pit-trip latch math (`gapUsed` / `pitLossUsed`) and ensured `TryBuildMathAudit` still prefers `GapToLeaderUsedSec` and `PitLossUsedSec` for math auditing.  
- In `LalaLaunch.cs` tightened `LogPitExitPitInSnapshot` and `LogPitExitPitOutSnapshot` local assignments so log tokens like `gapLdr=` and `pitLoss=` reflect LIVE semantics and the used/locked values are emitted only via the explicit audit tokens.

### Testing
- Attempted `dotnet build LaunchPlugin.sln` for a quick compile sanity check but the command failed because `dotnet` is not available in the environment.  
- No automated unit tests were run as part of this change.  
- No in-sim pit drive-through test was performed, so pit-in and pit-out snapshot lines are not available.  
- Source-level review and local variable alignment checks were performed and reflect the requested semantics and logging consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef48a4e28832f9dffd2ff8c189607)