### PR TITLE
Docs: refresh pit-exit logging and pit-loss lock docs

### DIFF
--- a/Docs/Profiles_And_PB.md
+++ b/Docs/Profiles_And_PB.md
@@ -1,7 +1,7 @@
 # Profiles and Personal Bests
 
-Validated against commit: 52bd57d7c618f4df094c68c4ea6f1e11cc5e328f  
-Last updated: 2026-02-06  
+Validated against commit: f542ae2  
+Last updated: 2026-02-08  
 Branch: work
 
 ## Purpose
@@ -18,6 +18,11 @@ Personal Bests (PBs) store best-observed lap times for reference and seeding.
 - **Defaults:** New profiles seed sensible defaults (≈14 m/s² decel, ≈15 m buffer) that can be tuned per car/track.  
 - **Storage:** Values are saved with the active car profile and copied when profiles are duplicated so braking cues remain consistent across tyres/ABS/regen settings.【F:CarProfiles.cs†L128-L150】【F:ProfilesManagerViewModel.cs†L503-L584】  
 - **UI location:** Dash tab sliders labeled “Pit Entry Decel” and “Pit Entry Buffer”; changes update the active profile immediately.【F:DashesTabView.xaml†L141-L142】【F:LalaLaunch.cs†L3380-L3387】
+
+## Profile contents (Pit loss controls)
+- **Pit Lane Loss (s):** Track-level pit loss value used for fuel planning and pit-exit prediction. Editable directly in the Profiles UI track table.【F:ProfilesManagerView.xaml†L286-L333】
+- **Lock:** When enabled, the stored pit loss is protected from automatic updates. New pit loss candidates are captured as “blocked candidate” info for review, and auto-save resumes once unlocked.【F:ProfilesManagerViewModel.cs†L405-L421】【F:LalaLaunch.cs†L3199-L3212】
+- **Blocked candidate display:** Shows the last blocked candidate time, timestamp, and source while the lock is active, making it easy to compare before unlocking.【F:CarProfiles.cs†L349-L359】【F:ProfilesManagerView.xaml†L315-L327】
 
 ## PB capture overview
 - PBs update when a **valid lap** beats the stored PB for the current car/track.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -3,7 +3,7 @@
 ## What exists in this checkout right now
 - Only one local branch is present: `work`.
 - There is no Git remote configured, so nothing in this checkout is currently linked to GitHub.
-- The latest commit on `work` is the current HEAD with the message “Docs: document PitExit ahead/behind exports.” The preceding commits include `40b4cd1` (“Merge pull request #216 from Lalabot77/codex/add-pit-exit-distance-and-time-properties”) and `c803deb` (“Add pit exit distance/time SimHub outputs”). Use `git log --oneline -n 5` to see the last few commits if you want to double-check.
+- The latest commit on `work` is the current HEAD with the message “Update LalaLaunch.cs.” The preceding merges include PRs #234–#237 for pit-exit audit/logging and pit-loss locking improvements; use `git log --oneline -n 8` to see the recent merges if you want to double-check.
 
 ## How to connect this checkout to your GitHub repo
 1. Add your GitHub remote (replace the URL with your actual repository clone URL):
@@ -56,4 +56,6 @@
 - **Track Markers:** **COMPLETE** — pit entry/exit markers auto-learned per track with lock/unlock semantics, track-length change detection, and MSGV1 notifications. Stored in `PluginsData/Common/LalaLaunch/LalaLaunch.TrackMarkers.json`.
 - **MSGV1 for pit markers:** **INTEGRATED** — pit marker capture/length-delta/lock-mismatch messages defined in `Messaging/Messages.json` via `MessageDefinitionStore`; MSGV1 core continues elsewhere but this repo ships pit marker hooks.
 - **Legacy messaging:** **Not used** — only MSGV1 definition-driven messages fire; no legacy/adhoc messaging paths remain for pit markers.
+- **Pit loss locking:** **COMPLETE** — per-track pit loss values can be locked to block auto-updates; blocked candidates are captured and surfaced in the Profiles UI for review before manual unlock.
+- **Pit-exit prediction audit + settled logging:** **COMPLETE** — pit-exit predictor now locks pit-loss and gap inputs at pit entry to avoid drift, logs richer pit-in/out snapshots plus math audit, and emits a one-lap-delayed “pit-out settled” confirmation.
 - **Known/accepted limitations:** Replay session identity quirks remain (see `Reset_And_Session_Identity.md`) and track-length deltas are informational only; both are understood/accepted for current shipping state.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -1,8 +1,8 @@
 # SimHub Log Messages (CANONICAL)
 
-Validated against commit: b31a0be584c2941a7d8d4d4c5dde2e852d7b32a2  
-Last updated: 2026-02-07  
-Branch: Opponents-Module
+Validated against commit: f542ae2  
+Last updated: 2026-02-08  
+Branch: work
 
 Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
 
@@ -59,12 +59,14 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 - **`[LalaPlugin:PitExit] Predictor valid -> true (pitLoss=X.Xs)`** — Pit-exit predictor became valid with leaderboard/player row found.【F:Opponents.cs†L507-L566】
 - **`[LalaPlugin:PitExit] Predicted class position changed -> P# (ahead=N)`** — Predicted post-stop class position changed while valid (gated to lap ≥1 and debug toggle).【F:Opponents.cs†L532-L566】
 - **`[LalaPlugin:PitExit] Predictor valid -> false`** — Pit-exit predictor lost validity (no player row/leaderboard data).【F:Opponents.cs†L568-L579】
-- **`[LalaPlugin:PitExit] Pit-in snapshot: lap=... t=... posClass=... posOverall=... gapLdr=... pitLoss=... predPosClass=... carsAhead=... srcPitLoss=... laneRef=... boxRef=... directRef=...`** — One-time pit entry snapshot logging player positions, pit loss inputs, and prediction summary.【F:LalaLaunch.cs†L4598-L4638】
-- **`[LalaPlugin:PitExit] Math audit: pitLoss=... playerGap=... | aheadCandidates=[...] | behindCandidates=[...]`** — Pit-in audit of boundary candidates and deltas around the pit-loss comparison, emitted alongside the pit-in snapshot.【F:Opponents.cs†L713-L782】
-- **`[LalaPlugin:PitExit] Pit-out snapshot: lap=... t=... posClass=... posOverall=... predPosClassNow=... carsAheadNow=... lane=... box=... direct=... pitTripActive=...`** — One-time pit exit snapshot logging rejoin position and latched pit lane timings.【F:LalaLaunch.cs†L4640-L4664】
+- **`[LalaPlugin:PitExit] Pit-in snapshot: lap=... t=... posClass=... posOverall=... gapLdr=... pitLoss=... predPosClass=... carsAhead=... srcPitLoss=... laneRef=... boxRef=... directRef=... entryGapLdr=... gapLdrLive=... gapLdrUsed=... pitLossLive=... pitLossUsed=... predGapAfterPit=... lock=...`** — One-time pit entry snapshot logging player positions, pit loss inputs, locked pit-trip gap/pit loss, and prediction summary (see trailing lock/used/live fields).【F:LalaLaunch.cs†L4712-L4747】
+- **`[LalaPlugin:PitExit] Math audit: pitLoss=... playerGap=... | aheadCandidates=[...] | behindCandidates=[...]`** — Pit-in audit of boundary candidates and deltas around the pit-loss comparison, emitted alongside the pit-in snapshot.【F:Opponents.cs†L950-L1038】
+- **`[LalaPlugin:PitExit] Pit-out snapshot: lap=... t=... posClass=... posOverall=... predPosClassNow=... carsAheadNow=... lane=... box=... direct=... pitTripActive=... entryGapLdr=... gapLdrLiveNow=... gapLdrUsed=... predGapAfterPit=... lock=...`** — One-time pit exit snapshot logging rejoin position, latched pit lane timings, and locked pit-trip context values.【F:LalaLaunch.cs†L4754-L4784】
+- **`[LalaPlugin:PitExit] Pit-out settled: lap=... t=... exitLine_t=... exitLine_pct=... posClass=... posOverall=... gapLdrLiveNow=...`** — One-lap-delayed confirmation log once the post-pit lap crosses, capturing settled position/gap plus the pit-exit line timing snapshot.【F:Opponents.cs†L695-L738】
 
 ## Pit, refuel, and PitLite
 - **`[LalaPlugin:Pit Cycle] Saved PitLaneLoss = Xs (src).`** — Persisted pit lane loss from PitLite/DTL (debounced).【F:LalaLaunch.cs†L2950-L3004】
+- **`[LalaPlugin:Pit Cycle] PitLoss locked, blocked candidate Xs source=...`** — Pit lane loss candidate was blocked due to a locked profile value; candidate details saved for UI display.【F:LalaLaunch.cs†L3201-L3212】
 - **`[LalaPlugin:Pit Cycle] Pit Lite Data used for DTL.`** — Consumed PitLite out-lap candidate to save pit loss.【F:LalaLaunch.cs†L3004-L3035】
 - **`[LalaPlugin:Refuel Rate] Learned refuel rate ... Cooldown until ...`** — Refuel EMA learning completed from detected fuel added/time. 【F:LalaLaunch.cs†L3488-L3507】
 - **`[LalaPlugin:Pit Lite] ...`** — See PitCycleLite section below for entry/exit/out-lap/publish logs.
@@ -78,6 +80,7 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 - **`[LalaPlugin:Pace] PB Updated: car @ track -> lap`** — PB update accepted via ProfilesManagerViewModel.【F:ProfilesManagerViewModel.cs†L66-L88】
 - **`[LalaPlugin:Profiles] Track resolved: key='...'`** — Track resolution during profile operations.【F:ProfilesManagerViewModel.cs†L160-L182】
 - **`[LalaPlugin:Profiles] Default Settings profile not found, creating baseline profile.`** — Baseline profile auto-created on load miss.【F:ProfilesManagerViewModel.cs†L551-L570】
+- **`[LalaPlugin:Profile] PitLoss lock set to ... for '...'`** — Pit lane loss lock toggled for the selected track in the Profiles UI.【F:ProfilesManagerViewModel.cs†L405-L421】
 - **`[LalaPlugin:Profile/Pace] PB updated for track '...' (...) ...`** — CarProfiles PB change (live or manual).【F:CarProfiles.cs†L230-L251】
 - **`[LalaPlugin:Profile/Pace] AvgDry updated ...`** — Dry average lap time edited for a track.【F:CarProfiles.cs†L526-L547】
 - **`[LalaPlugin:Profile / Pace] AvgWet updated ...`** — Wet average lap time edited for a track.【F:CarProfiles.cs†L718-L740】

--- a/Docs/Subsystems/Opponents.md
+++ b/Docs/Subsystems/Opponents.md
@@ -1,5 +1,9 @@
 # Opponents subsystem
 
+Validated against commit: f542ae2  
+Last updated: 2026-02-08  
+Branch: work
+
 Purpose: own all opponent-facing calculations for nearby pace/fight prediction and pit-exit position forecasting with SimHub exports under `Opp.*` and `PitExit.*`.
 
 ## Gating and scope
@@ -29,11 +33,13 @@ Purpose: own all opponent-facing calculations for nearby pace/fight prediction a
 
 ## Pit-exit prediction
 - Finds player row in class leaderboard; predicted gap to leader after pit = player.RelGapToLeader + pitLossSec (pit loss forced to 0 when invalid). Each same-class, connected row computes `delta = row.RelGapToLeader − playerPredictedGapToLeaderAfterPit`. Negative delta means the car is ahead after pit; positive delta means behind.【F:Opponents.cs†L507-L553】
+- On pit entry, the predictor **locks** the player gap-to-leader and pit-loss inputs for the duration of the pit trip, preventing drift if leaderboard gaps update mid-stop. Lock clears once pitTripActive ends.【F:Opponents.cs†L783-L832】
 - PredictedPosition = 1 + count of same-class connected cars where delta < 0. Logs when validity toggles or predicted position changes while active; predicted-position-change logs require debug toggle + lap gate.【F:Opponents.cs†L532-L566】
 - Update cadence: runs every tick on pit road; off pit road, runs only when the player enters a new lap quarter (TrackPct × 4 → 0-3). Prediction is skipped near race end if reliable session time remaining is ≤120 s.【F:Opponents.cs†L612-L742】
 - Nearest ahead/behind exports come from the same scan: nearest ahead = largest negative delta (closest ahead); nearest behind = smallest positive delta (closest behind). Only same-class, connected cars are considered.【F:Opponents.cs†L532-L658】
 - Prediction-change logs are gated to reduce chatter: emits only on ≥2 place change, ≥2 s since last log, or pitTripActive/onPitRoad transitions (predictor outputs unchanged).【F:Opponents.cs†L676-L694】
-- Snapshot data (player positions, gap-to-leader, pitLoss, predicted pos, cars ahead) is captured for one-shot pit-in/out logging in LalaLaunch. Math audit lists boundary candidates around the pit-loss compare and uses `d = (candidateGap - playerGap) - pitLoss` for the same-class set; it is emitted with the pit-in snapshot.【F:Opponents.cs†L655-L773】【F:LalaLaunch.cs†L4640-L4689】
+- Snapshot data (player positions, gap-to-leader, pitLoss, predicted pos, cars ahead, **locked gap/pit loss**, and derived predicted gap) is captured for one-shot pit-in/out logging in LalaLaunch. Math audit lists boundary candidates around the pit-loss compare and uses `d = (candidateGap - playerGap) - pitLoss` for the same-class set; it is emitted with the pit-in snapshot.【F:Opponents.cs†L862-L978】【F:LalaLaunch.cs†L4712-L4784】
+- A one-lap-delayed “pit-out settled” log is emitted after crossing the lap boundary following pit exit to record the final settled position and gap-to-leader at the end of the out-lap.【F:Opponents.cs†L695-L738】
 - Publishes PitExit.Valid/PredictedPositionInClass/CarsAheadAfterPitCount/Summary plus nearest ahead/behind identity/gap fields; defaults reset when invalid.【F:Opponents.cs†L507-L579】【F:Opponents.cs†L775-L789】
 
 ## Outputs

--- a/Docs/Subsystems/Pit_Timing_And_PitLoss.md
+++ b/Docs/Subsystems/Pit_Timing_And_PitLoss.md
@@ -1,8 +1,8 @@
 # Pit Timing and Pit Loss
 
-Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
-Last updated: 2025-12-28  
-Branch: docs/refresh-index-subsystems
+Validated against commit: f542ae2  
+Last updated: 2026-02-08  
+Branch: work
 
 ## Purpose
 The Pit Timing & Pit Loss subsystem measures **real pit lane time loss** during live sessions and exposes a **stable pit-loss figure** used by:
@@ -164,6 +164,11 @@ Published values update:
 
 Once published, the value remains until superseded by a newer valid cycle.
 
+#### Locking and blocked candidates
+- Per-track pit loss values can be **locked** in Profiles. When locked, new candidates are **not** applied to the stored pit loss value.
+- Blocked candidates are captured with timestamp and source so the UI can show what was rejected while locked.
+- When unlocked, the next valid cycle can overwrite the stored pit loss normally.
+
 ---
 
 ## Outputs (exports + logs)
@@ -191,6 +196,7 @@ The subsystem emits structured INFO logs for:
 - In-lap / out-lap capture.
 - DTL computation and fallback usage.
 - Publication decision (DTL vs direct).
+- Locking blocks (candidate blocked + logged) when the profile pit loss is locked.
 
 Log semantics are canonical in `SimHubLogMessages.md`.
 
@@ -269,6 +275,5 @@ Reset semantics are centralised in:
 - TODO/VERIFY: Confirm exact speed threshold and dwell time used to classify “box stop” vs drive-through.
 - TODO/VERIFY: Confirm whether DTL uses session-average or stint-average pace as baseline.
 - TODO/VERIFY: Confirm pit loss publication gating for non-race sessions (practice/qualifying).
-
 
 


### PR DESCRIPTION
### Motivation
- Recent runtime changes (PRs `#234`–`#237`) added pit-exit audit/settled logging and per-track pit-loss lock behavior, requiring doc updates to stay accurate.
- The SimHub log catalog and parameter exports must reflect the new pit-in/pit-out snapshots, math audit, and blocked-candidate logs.
- Profiles UI and guidance need entries describing the new `Pit Lane Loss` field, lock semantics, and blocked-candidate display.
- Repo status should record the updated HEAD and the recent merge activity for traceability.

### Description
- Updated `Docs/RepoStatus.md` to reflect the current HEAD message and note the recent merges for pit-exit audit and pit-loss locking (`PRs #234–#237`).
- Expanded `Docs/SimHubLogMessages.md` with new `PitExit` snapshot lines, the math-audit entry, the one-lap-delayed “pit-out settled” log, and the `PitLoss locked, blocked candidate` message.
- Updated `Docs/Subsystems/Opponents.md` and `Docs/Subsystems/Pit_Timing_And_PitLoss.md` to document predictor locking of gap/pit-loss at pit entry, blocked candidate capture, and the one-lap-delayed settled confirmation.
- Added profile guidance in `Docs/Profiles_And_PB.md` describing the `Pit Lane Loss (s)` track field, the `Lock` behavior, and the blocked-candidate display in the Profiles UI.

### Testing
- No automated tests were run; these are documentation-only changes.
- Changes were committed to the `work` branch as a documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fea7e6500832f83c0f1351da68a5e)