### PR TITLE
Split Best Lap PB into Dry/Wet and make PB condition-aware for Fuel tab

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1117,7 +1117,16 @@ namespace LaunchPlugin
 
     public void SetPersonalBestSeconds(double pbSeconds)
     {
-        if (pbSeconds <= 0) return;
+        if (pbSeconds <= 0)
+        {
+            _loadedBestLapTimeSeconds = 0;
+            IsPersonalBestAvailable = false;
+            HistoricalBestLapDisplay = "-";
+            LiveBestLapDisplay = "-";
+            OnPropertyChanged(nameof(IsPersonalBestAvailable));
+            OnPropertyChanged(nameof(HistoricalBestLapDisplay));
+            return;
+        }
 
         _loadedBestLapTimeSeconds = pbSeconds;
         IsPersonalBestAvailable = true;
@@ -1586,6 +1595,7 @@ namespace LaunchPlugin
                         LapTimeSourceInfo = FormatConditionSourceLabel("Profile avg");
                     }
                 }
+                UpdateProfileBestLapForCondition(ts);
                 UpdateProfileAverageDisplaysForCondition();
                 RefreshProfilePlanningData();
                 UpdateTrackDerivedSummaries();
@@ -1792,7 +1802,7 @@ namespace LaunchPlugin
             var ts = profile.ResolveTrackByNameOrKey(trackKey) ?? profile.ResolveTrackByNameOrKey(trackName);
             if (ts == null) return null;
 
-            int? ms = ts.BestLapMs;
+            int? ms = ts.GetBestLapMsForCondition(isWetEffective: false);
             if (!ms.HasValue || ms.Value <= 0) return null;
 
             return ms.Value / 1000.0;
@@ -2225,7 +2235,13 @@ namespace LaunchPlugin
         trackRecord.PitLaneLossSeconds = this.PitLaneTimeLoss;
 
         if (IsPersonalBestAvailable && _loadedBestLapTimeSeconds > 0)
-            trackRecord.BestLapMs = (int)(_loadedBestLapTimeSeconds * 1000);
+        {
+            int pbMs = (int)(_loadedBestLapTimeSeconds * 1000);
+            if (saveWet)
+                trackRecord.BestLapMsWet = pbMs;
+            else
+                trackRecord.BestLapMsDry = pbMs;
+        }
 
         var trackCondition = trackRecord.GetConditionMultipliers(saveWet);
         trackCondition.FormationLapBurnLiters = this.FormationLapFuelLiters;
@@ -3579,21 +3595,7 @@ namespace LaunchPlugin
                 this.WetFactorPercent = car.WetFuelMultiplier;
             }
 
-            if (ts?.BestLapMs is int ms && ms > 0)
-            {
-                _loadedBestLapTimeSeconds = ms / 1000.0;
-                IsPersonalBestAvailable = true;
-                HistoricalBestLapDisplay = TimeSpan.FromMilliseconds(ms).ToString(@"m\:ss\.fff");
-            }
-            else
-            {
-                _loadedBestLapTimeSeconds = 0;
-                IsPersonalBestAvailable = false;
-                HistoricalBestLapDisplay = "-";
-            }
-            // Manually notify the UI that these properties have changed
-            OnPropertyChanged(nameof(IsPersonalBestAvailable));
-            OnPropertyChanged(nameof(HistoricalBestLapDisplay));
+            UpdateProfileBestLapForCondition(ts);
 
 
             // --- Set the initial estimated lap time from the profile's condition average ---
@@ -3755,6 +3757,34 @@ namespace LaunchPlugin
     {
         if (IsWet) { FuelPerLap = _baseDryFuelPerLap * (WetFactorPercent / 100.0); }
         UpdateProfileFuelChoiceDisplays();
+    }
+
+    private void UpdateProfileBestLapForCondition(TrackStats ts = null)
+    {
+        if (ts == null)
+        {
+            ts = SelectedTrackStats ?? ResolveSelectedTrackStats();
+        }
+
+        int? ms = ts?.GetBestLapMsForCondition(IsWet);
+        if (ms.HasValue && ms.Value > 0)
+        {
+            _loadedBestLapTimeSeconds = ms.Value / 1000.0;
+            IsPersonalBestAvailable = true;
+            var formatted = TimeSpan.FromMilliseconds(ms.Value).ToString(@"m\:ss\.fff");
+            HistoricalBestLapDisplay = formatted;
+            LiveBestLapDisplay = formatted;
+        }
+        else
+        {
+            _loadedBestLapTimeSeconds = 0;
+            IsPersonalBestAvailable = false;
+            HistoricalBestLapDisplay = "-";
+            LiveBestLapDisplay = "-";
+        }
+
+        OnPropertyChanged(nameof(IsPersonalBestAvailable));
+        OnPropertyChanged(nameof(HistoricalBestLapDisplay));
     }
 
     private void UpdateProfileAverageDisplaysForCondition(TrackStats ts = null)

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -268,7 +268,6 @@
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
                                         </Grid.RowDefinitions>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" MinWidth="170"/>
@@ -276,29 +275,19 @@
                                             <ColumnDefinition Width="*" SharedSizeGroup="InfoColumn" MinWidth="220"/>
                                         </Grid.ColumnDefinitions>
 
-                                        <!-- Best lap -->
-                                        <TextBlock Grid.Row="0" Grid.Column="0"
-                                           Text="Best Lap Time (m:ss.fff):"
-                                           Margin="0,0,10,0"
-                                           VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="0" Grid.Column="1"
-                                             TextAlignment="Right"
-                                             Text="{Binding BestLapMsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                             />
-
                                         <!-- Pit loss -->
-                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                        <TextBlock Grid.Row="0" Grid.Column="0"
                                                Text="Pit Lane Loss (s):"
                                                Margin="0,6,10,0"
                                                VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="1" Grid.Column="1"
+                                        <TextBox Grid.Row="0" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
                                              Text="{Binding PitLaneLossSecondsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                              />
 
                                         <!-- Lock + messages -->
-                                        <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,8,0,0">
+                                        <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,8,0,0">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="*"/>
@@ -339,6 +328,7 @@
                                     <Grid Margin="8,6,8,8" Grid.IsSharedSizeScope="True">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
                                             <!-- Avg lap -->
                                             <RowDefinition Height="Auto"/>
                                             <!-- Fuel ECO -->
@@ -356,58 +346,68 @@
                                             <ColumnDefinition Width="*" SharedSizeGroup="InfoColumn" MinWidth="220"/>
                                         </Grid.ColumnDefinitions>
 
-                                        <!-- Avg lap time -->
+                                        <!-- Best lap time -->
                                         <TextBlock Grid.Row="0" Grid.Column="0"
-                                           Text="Avg Lap Time (m:ss.fff):"
+                                           Text="Best Lap Time (m:ss.fff):"
                                            Margin="0,0,10,0"
                                            VerticalAlignment="Center"/>
                                         <TextBox Grid.Row="0" Grid.Column="1"
                                              TextAlignment="Right"
+                                             Text="{Binding BestLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                        <!-- Avg lap time -->
+                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                           Text="Avg Lap Time (m:ss.fff):"
+                                           Margin="0,6,10,0"
+                                           VerticalAlignment="Center"/>
+                                        <TextBox Grid.Row="1" Grid.Column="1"
+                                             Margin="0,6,0,0"
+                                             TextAlignment="Right"
                                              Text="{Binding AvgLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                        <TextBlock Grid.Row="0" Grid.Column="2"
-                                               Margin="12,0,0,0"
+                                        <TextBlock Grid.Row="1" Grid.Column="2"
+                                               Margin="12,6,0,0"
                                                VerticalAlignment="Center"
                                                Text="{Binding DryLapTimeSampleCount, StringFormat=Sample: {0}}"/>
 
                                         <!-- Fuel burn label (only once) -->
-                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                        <TextBlock Grid.Row="2" Grid.Column="0"
                                            Text="Fuel Burn (L/lap):"
                                            Margin="0,6,10,0"
                                            VerticalAlignment="Center"/>
 
                                         <!-- ECO -->
-                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                        <TextBlock Grid.Row="2" Grid.Column="0"
                                            Margin="120,6,10,0"
                                            Text="ECO"
                                            FontWeight="SemiBold"
                                            VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="1" Grid.Column="1"
+                                        <TextBox Grid.Row="2" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
                                              Text="{Binding MinFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- AVG -->
-                                        <TextBlock Grid.Row="2" Grid.Column="0"
+                                        <TextBlock Grid.Row="3" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="AVG"
                                            FontWeight="SemiBold"
                                            VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="2" Grid.Column="1"
+                                        <TextBox Grid.Row="3" Grid.Column="1"
                                              TextAlignment="Right"
                                              Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- MAX -->
-                                        <TextBlock Grid.Row="3" Grid.Column="0"
+                                        <TextBlock Grid.Row="4" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="MAX"
                                            FontWeight="SemiBold"
                                            VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="3" Grid.Column="1"
+                                        <TextBox Grid.Row="4" Grid.Column="1"
                                              TextAlignment="Right"
                                              Text="{Binding MaxFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- Fuel sample / updated -->
-                                        <StackPanel Grid.Row="1" Grid.Column="2" Grid.RowSpan="3" Margin="12,6,0,0" VerticalAlignment="Top">
+                                        <StackPanel Grid.Row="2" Grid.Column="2" Grid.RowSpan="3" Margin="12,6,0,0" VerticalAlignment="Top">
                                             <TextBlock Text="{Binding DryFuelSampleCount, StringFormat=Sample: {0}}"/>
                                             <TextBlock Text="{Binding FuelLastUpdatedText, Mode=OneWay}"
                                                FontStyle="Italic"
@@ -416,7 +416,7 @@
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
-                                        <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
+                                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
                                           Content="Locked"
                                           IsChecked="{Binding DryConditionsLocked, Mode=TwoWay}"
                                           Margin="0,8,0,0"/>
@@ -429,6 +429,7 @@
                                     <Grid Margin="8,6,8,8" Grid.IsSharedSizeScope="True">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
                                             <!-- Avg lap -->
                                             <RowDefinition Height="Auto"/>
                                             <!-- Fuel ECO -->
@@ -446,58 +447,68 @@
                                             <ColumnDefinition Width="*" SharedSizeGroup="InfoColumn" MinWidth="220"/>
                                         </Grid.ColumnDefinitions>
 
-                                        <!-- Avg lap time -->
+                                        <!-- Best lap time -->
                                         <TextBlock Grid.Row="0" Grid.Column="0"
-                                           Text="Avg Lap Time (m:ss.fff):"
+                                           Text="Best Lap Time (m:ss.fff):"
                                            Margin="0,0,10,0"
                                            VerticalAlignment="Center"/>
                                         <TextBox Grid.Row="0" Grid.Column="1"
                                              TextAlignment="Right"
+                                             Text="{Binding BestLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                        <!-- Avg lap time -->
+                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                           Text="Avg Lap Time (m:ss.fff):"
+                                           Margin="0,6,10,0"
+                                           VerticalAlignment="Center"/>
+                                        <TextBox Grid.Row="1" Grid.Column="1"
+                                             Margin="0,6,0,0"
+                                             TextAlignment="Right"
                                              Text="{Binding AvgLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                        <TextBlock Grid.Row="0" Grid.Column="2"
-                                           Margin="12,0,0,0"
+                                        <TextBlock Grid.Row="1" Grid.Column="2"
+                                           Margin="12,6,0,0"
                                            VerticalAlignment="Center"
                                            Text="{Binding WetLapTimeSampleCount, StringFormat=Sample: {0}}"/>
 
                                         <!-- Fuel burn label (only once) -->
-                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                        <TextBlock Grid.Row="2" Grid.Column="0"
                                            Text="Fuel Burn (L/lap):"
                                            Margin="0,6,10,0"
                                            VerticalAlignment="Center"/>
 
                                         <!-- ECO -->
-                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                        <TextBlock Grid.Row="2" Grid.Column="0"
                                            Margin="120,6,10,0"
                                            Text="ECO"
                                            FontWeight="SemiBold"
                                            VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="1" Grid.Column="1"
+                                        <TextBox Grid.Row="2" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
                                              Text="{Binding MinFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- AVG -->
-                                        <TextBlock Grid.Row="2" Grid.Column="0"
+                                        <TextBlock Grid.Row="3" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="AVG"
                                            FontWeight="SemiBold"
                                            VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="2" Grid.Column="1"
+                                        <TextBox Grid.Row="3" Grid.Column="1"
                                              TextAlignment="Right"
                                              Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- MAX -->
-                                        <TextBlock Grid.Row="3" Grid.Column="0"
+                                        <TextBlock Grid.Row="4" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="MAX"
                                            FontWeight="SemiBold"
                                            VerticalAlignment="Center"/>
-                                        <TextBox Grid.Row="3" Grid.Column="1"
+                                        <TextBox Grid.Row="4" Grid.Column="1"
                                              TextAlignment="Right"
                                              Text="{Binding MaxFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- Fuel sample / updated -->
-                                        <StackPanel Grid.Row="1" Grid.Column="2" Grid.RowSpan="3" Margin="12,6,0,0" VerticalAlignment="Top">
+                                        <StackPanel Grid.Row="2" Grid.Column="2" Grid.RowSpan="3" Margin="12,6,0,0" VerticalAlignment="Top">
                                             <TextBlock Text="{Binding WetFuelSampleCount, StringFormat=Sample: {0}}"/>
                                             <TextBlock Text="{Binding FuelLastUpdatedText, Mode=OneWay}"
                                                FontStyle="Italic"
@@ -506,7 +517,7 @@
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
-                                        <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
+                                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
                                           Content="Locked"
                                           IsChecked="{Binding WetConditionsLocked, Mode=TwoWay}"
                                           Margin="0,8,0,0"/>


### PR DESCRIPTION
### Motivation

- Make personal best (PB) unambiguous by splitting the single `BestLapMs` into condition-specific `BestLapMsDry` and `BestLapMsWet` so PBs reflect dry vs wet laps.
- Move PB display/editor out of the Core Data block and into the existing Dry/Wet condition blocks in the Tracks UI while preserving the refactored shared-grid layout.
- Ensure live PB updates and the Fuel tab use the PB matching the effective condition (respecting manual override vs auto detection) for correct fuel planning.
- Preserve backward compatibility by falling back to legacy `BestLapMs` when a condition-specific PB is not set.

### Description

- Added persisted fields `BestLapMsDry` and `BestLapMsWet` (with `JsonProperty`) and corresponding text wrapper properties `BestLapTimeDryText` / `BestLapTimeWetText` plus `GetBestLapMsForCondition` in `TrackStats` (`CarProfiles.cs`).
- Introduced `TryUpdatePBByCondition(string carName, string trackKey, int lapMs, bool isWetEffective)` in `ProfilesManagerViewModel.cs` and updated logic to compare/update the appropriate dry/wet PB (respecting a simple fallback to legacy `BestLapMs` for baseline comparisons) and to refresh/save profiles.
- Updated `LalaLaunch.cs` to call `TryUpdatePBByCondition` when telemetry reports a new best lap and to set the `FuelCalculator` PB via the condition-appropriate selection (prefers condition PB, falls back to other values including legacy `BestLapMs`).
- Updated `FuelCalcs.cs` to load and display the condition-appropriate PB via a new `UpdateProfileBestLapForCondition` helper, to persist PB into the correct condition slot when saving, and to update PB displays (`HistoricalBestLapDisplay`/`LiveBestLapDisplay`) accordingly.
- Moved the PB UI controls out of Core Data and added them into the Dry and Wet Groups in `ProfilesManagerView.xaml` while preserving the single parent `Grid` per `GroupBox` and `SharedSizeGroup` alignment.
- Ensured UI text properties are initialized in `EnsureCarTrack` and that `OnPropertyChanged` calls refresh dependent displays when condition PBs change.

### Testing

- No automated tests were run for this change.
- Manual verification steps intended: open Tracks tab and confirm Core Data no longer shows PB, Dry/Wet blocks show PB rows, and a live telemetry PB updates the appropriate Dry/Wet PB and the Fuel tab PB selection (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69629d1908c0832f98201374d4f82865)