### PR TITLE
Add “Relearn” buttons and commands to reset Pit, Dry and Wet track data

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -224,6 +224,17 @@ namespace LaunchPlugin
         [JsonIgnore]
         public Action RequestSaveProfiles { get; set; }
 
+        [JsonIgnore]
+        public string ParentProfileName { get; set; }
+
+        private RelayCommand _relearnDryCommand;
+        [JsonIgnore]
+        public RelayCommand RelearnDryCommand => _relearnDryCommand ?? (_relearnDryCommand = new RelayCommand(p => RelearnDryConditions()));
+
+        private RelayCommand _relearnWetCommand;
+        [JsonIgnore]
+        public RelayCommand RelearnWetCommand => _relearnWetCommand ?? (_relearnWetCommand = new RelayCommand(p => RelearnWetConditions()));
+
 
         // --- Core Data ---
         private string _displayName;
@@ -640,6 +651,57 @@ namespace LaunchPlugin
         {
             FuelUpdatedSource = source;
             FuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void RelearnPitLoss()
+        {
+            PitLaneLossSeconds = null;
+            PitLaneLossSource = string.Empty;
+            PitLaneLossUpdatedUtc = null;
+            PitLaneLossBlockedCandidateSeconds = 0;
+            PitLaneLossBlockedCandidateUpdatedUtc = null;
+            PitLaneLossBlockedCandidateSource = null;
+            RequestSaveProfiles?.Invoke();
+        }
+
+        public void RelearnDryConditions()
+        {
+            BestLapMsDry = null;
+            AvgLapTimeDry = null;
+            MinFuelPerLapDry = null;
+            AvgFuelPerLapDry = null;
+            MaxFuelPerLapDry = null;
+            DryLapTimeSampleCount = 0;
+            DryFuelSampleCount = 0;
+            FuelUpdatedSource = null;
+            FuelUpdatedUtc = null;
+            DryConditionsLocked = false;
+
+            var carName = string.IsNullOrWhiteSpace(ParentProfileName) ? "(unknown)" : ParentProfileName;
+            var trackName = DisplayName ?? Key ?? "(unknown)";
+            SimHub.Logging.Current.Info($"[LalaPlugin:Profiles] Relearn Dry Conditions for {carName} @ {trackName}");
+
+            RequestSaveProfiles?.Invoke();
+        }
+
+        public void RelearnWetConditions()
+        {
+            BestLapMsWet = null;
+            AvgLapTimeWet = null;
+            MinFuelPerLapWet = null;
+            AvgFuelPerLapWet = null;
+            MaxFuelPerLapWet = null;
+            WetLapTimeSampleCount = 0;
+            WetFuelSampleCount = 0;
+            FuelUpdatedSource = null;
+            FuelUpdatedUtc = null;
+            WetConditionsLocked = false;
+
+            var carName = string.IsNullOrWhiteSpace(ParentProfileName) ? "(unknown)" : ParentProfileName;
+            var trackName = DisplayName ?? Key ?? "(unknown)";
+            SimHub.Logging.Current.Info($"[LalaPlugin:Profiles] Relearn Wet Conditions for {carName} @ {trackName}");
+
+            RequestSaveProfiles?.Invoke();
         }
 
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -173,6 +173,12 @@ namespace LaunchPlugin
             _pit?.SetTrackMarkersLock(trackKey, locked);
         }
 
+        public void ResetTrackMarkersForKey(string trackKey)
+        {
+            if (string.IsNullOrWhiteSpace(trackKey)) return;
+            _pit?.ResetTrackMarkersForKey(trackKey);
+        }
+
         public void ReloadTrackMarkersFromDisk()
         {
             _pit?.ReloadTrackMarkerStore();
@@ -2741,7 +2747,8 @@ namespace LaunchPlugin
                 () => this.CurrentTrackKey,
                 (trackKey) => GetTrackMarkersSnapshot(trackKey),
                 (trackKey, locked) => SetTrackMarkersLockedForKey(trackKey, locked),
-                () => ReloadTrackMarkersFromDisk()
+                () => ReloadTrackMarkersFromDisk(),
+                (trackKey) => ResetTrackMarkersForKey(trackKey)
             );
 
 

--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -635,6 +635,20 @@ namespace LaunchPlugin
             SimHub.Logging.Current.Info($"[LalaPlugin:TrackMarkers] lock trackKey={key} locked={locked}");
         }
 
+        public void ResetTrackMarkersForKey(string trackKey)
+        {
+            EnsureTrackMarkerStoreLoaded();
+            string key = NormalizeTrackKey(trackKey);
+            if (string.IsNullOrWhiteSpace(key) || string.Equals(key, "unknown", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var record = GetOrCreateTrackMarkerRecord(key);
+            record.PitEntryTrkPct = double.NaN;
+            record.PitExitTrkPct = double.NaN;
+            record.LastUpdatedUtc = DateTime.MinValue;
+            SaveTrackMarkers();
+        }
+
         private void UpdateTrackMarkers(string trackKey, double carPct, double trackLenM, bool isInPitLane, bool justExitedPits, bool isInPitStall, double speedKph)
         {
             EnsureTrackMarkerStoreLoaded();

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -416,10 +416,15 @@
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
-                                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
+                                        <CheckBox Grid.Row="5" Grid.Column="0"
                                           Content="Locked"
                                           IsChecked="{Binding DryConditionsLocked, Mode=TwoWay}"
                                           Margin="0,8,0,0"/>
+                                        <styles:SHButtonPrimary Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                                          Content="Relearn"
+                                          Command="{Binding RelearnDryCommand}"
+                                          Margin="8,8,0,0"
+                                          HorizontalAlignment="Left"/>
                                     </Grid>
                                 </GroupBox>
 
@@ -517,10 +522,15 @@
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
-                                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
+                                        <CheckBox Grid.Row="5" Grid.Column="0"
                                           Content="Locked"
                                           IsChecked="{Binding WetConditionsLocked, Mode=TwoWay}"
                                           Margin="0,8,0,0"/>
+                                        <styles:SHButtonPrimary Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                                          Content="Relearn"
+                                          Command="{Binding RelearnWetCommand}"
+                                          Margin="8,8,0,0"
+                                          HorizontalAlignment="Left"/>
                                     </Grid>
                                 </GroupBox>
 
@@ -561,7 +571,10 @@
                                         <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding TrackMarkersLastUpdatedText}" Margin="0,4,0,0" VerticalAlignment="Center"/>
 
                                         <CheckBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Content="Locked" Margin="0,6,6,0" IsChecked="{Binding TrackMarkersLocked, Mode=TwoWay}" />
-                                        <Button Grid.Row="3" Grid.Column="2" Content="Reload markers" Command="{Binding ReloadTrackMarkersCommand}" Margin="0,6,0,0" ToolTip="Reload LalaLaunch.TrackMarkers.json from disk (for manual edits)." />
+                                        <StackPanel Grid.Row="3" Grid.Column="2" Orientation="Horizontal" Margin="0,6,0,0" HorizontalAlignment="Left">
+                                            <styles:SHButtonPrimary Content="Reload markers" Command="{Binding ReloadTrackMarkersCommand}" ToolTip="Reload LalaLaunch.TrackMarkers.json from disk (for manual edits)." />
+                                            <styles:SHButtonPrimary Content="Relearn" Command="{Binding RelearnPitDataCommand}" Margin="6,0,0,0" />
+                                        </StackPanel>
                                     </Grid>
                                 </GroupBox>
 


### PR DESCRIPTION
### Motivation
- Provide UI controls to reset learned track data back to an unlearned state for Pit Data, Dry Conditions and Wet Conditions, and persist those resets immediately.
- Ensure pit markers and pit-loss reset are linked so a single Pit Data action clears both subsystems while preserving lock state.
- Keep the existing Tracks tab layout strategy and `Grid`/`SharedSizeGroup` alignment without changing binding modes.
- Add logging so each relearn action is visible in plugin logs for diagnostics.

### Description
- Added `RelearnPitDataCommand` to `ProfilesManagerViewModel` and a private `RelearnPitData()` handler that calls `SelectedTrack.RelearnPitLoss()` and invokes a new `_resetTrackMarkersForKey` action; the command is wired to the Pit Data UI button `Relearn` in `ProfilesManagerView.xaml` next to `Reload markers` using `styles:SHButtonPrimary`.
- Exposed a `ResetTrackMarkersForKey` bridge on `LalaLaunch` and implemented `ResetTrackMarkersForKey` in `PitEngine` to clear stored entry/exit percentages and last-updated timestamp while leaving `Locked` unchanged and calling `SaveTrackMarkers()`.
- Implemented per-track reset methods on `TrackStats` (`RelearnPitLoss()`, `RelearnDryConditions()`, `RelearnWetConditions()`) that clear the appropriate fields, set sample counts or values consistent with existing conventions, unlock Dry/Wet as required, invoke `RequestSaveProfiles` to persist immediately, and log an INFO message.
- Added `RelearnDryCommand` and `RelearnWetCommand` accessors to the track model (exposed via `RelearnDryCommand`/`RelearnWetCommand` on `TrackStats`) and added corresponding `Relearn` buttons in `ProfilesManagerView.xaml` placed to the right of the `Locked` checkbox for Dry and Wet, preserving one parent `Grid` per `GroupBox` and existing shared column alignment.
- Ensured the viewmodel sets `ParentProfileName` on tracks when populating the list so the new logging can include car/profile context, and refreshed track marker snapshot after pit relearn to update UI texts.

### Testing
- No automated tests were executed for this change.
- Changes were limited to viewmodel, model and engine APIs and UI XAML to minimize layout impact and follow existing binding patterns.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cacf0c14832fb45a387bce1db4b3)