### PR TITLE
Add Relearn buttons and reset logic for Pit, Dry and Wet track data

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -642,6 +642,92 @@ namespace LaunchPlugin
             FuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
         }
 
+        public void RelearnPitLoss()
+        {
+            PitLaneLossSeconds = null;
+            PitLaneLossSource = null;
+            PitLaneLossUpdatedUtc = null;
+            PitLaneLossBlockedCandidateSeconds = 0;
+            PitLaneLossBlockedCandidateSource = null;
+            PitLaneLossBlockedCandidateUpdatedUtc = null;
+        }
+
+        public void RelearnDryConditions()
+        {
+            _suppressBestLapDrySync = true;
+            BestLapMsDry = 0;
+            _suppressBestLapDrySync = false;
+            _bestLapMsDryText = string.Empty;
+            OnPropertyChanged(nameof(BestLapTimeDryText));
+
+            _suppressAvgLapDrySync = true;
+            AvgLapTimeDry = 0;
+            _suppressAvgLapDrySync = false;
+            _avgLapTimeDryText = string.Empty;
+            OnPropertyChanged(nameof(AvgLapTimeDryText));
+
+            _suppressDryMinFuelSync = true;
+            MinFuelPerLapDry = null;
+            _suppressDryMinFuelSync = false;
+            _minFuelPerLapDryText = string.Empty;
+            OnPropertyChanged(nameof(MinFuelPerLapDryText));
+
+            _suppressDryFuelSync = true;
+            AvgFuelPerLapDry = null;
+            _suppressDryFuelSync = false;
+            _avgFuelPerLapDryText = string.Empty;
+            OnPropertyChanged(nameof(AvgFuelPerLapDryText));
+
+            _suppressDryMaxFuelSync = true;
+            MaxFuelPerLapDry = null;
+            _suppressDryMaxFuelSync = false;
+            _maxFuelPerLapDryText = string.Empty;
+            OnPropertyChanged(nameof(MaxFuelPerLapDryText));
+
+            DryLapTimeSampleCount = 0;
+            DryFuelSampleCount = 0;
+            FuelUpdatedSource = null;
+            FuelUpdatedUtc = null;
+        }
+
+        public void RelearnWetConditions()
+        {
+            _suppressBestLapWetSync = true;
+            BestLapMsWet = 0;
+            _suppressBestLapWetSync = false;
+            _bestLapMsWetText = string.Empty;
+            OnPropertyChanged(nameof(BestLapTimeWetText));
+
+            _suppressAvgLapWetSync = true;
+            AvgLapTimeWet = 0;
+            _suppressAvgLapWetSync = false;
+            _avgLapTimeWetText = string.Empty;
+            OnPropertyChanged(nameof(AvgLapTimeWetText));
+
+            _suppressWetMinFuelSync = true;
+            MinFuelPerLapWet = null;
+            _suppressWetMinFuelSync = false;
+            _minFuelPerLapWetText = string.Empty;
+            OnPropertyChanged(nameof(MinFuelPerLapWetText));
+
+            _suppressWetFuelSync = true;
+            AvgFuelPerLapWet = null;
+            _suppressWetFuelSync = false;
+            _avgFuelPerLapWetText = string.Empty;
+            OnPropertyChanged(nameof(AvgFuelPerLapWetText));
+
+            _suppressWetMaxFuelSync = true;
+            MaxFuelPerLapWet = null;
+            _suppressWetMaxFuelSync = false;
+            _maxFuelPerLapWetText = string.Empty;
+            OnPropertyChanged(nameof(MaxFuelPerLapWetText));
+
+            WetLapTimeSampleCount = 0;
+            WetFuelSampleCount = 0;
+            FuelUpdatedSource = null;
+            FuelUpdatedUtc = null;
+        }
+
 
         /// --- Dry Conditions Data ---
         private double? _avgFuelPerLapDry;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -179,6 +179,12 @@ namespace LaunchPlugin
             ProfilesViewModel?.RefreshTrackMarkersSnapshotForSelectedTrack();
         }
 
+        public void ResetTrackMarkersForKey(string trackKey)
+        {
+            if (string.IsNullOrWhiteSpace(trackKey)) return;
+            _pit?.ResetTrackMarkersForKey(trackKey);
+        }
+
         private bool IsTrackMarkerPulseActive(DateTime utcTimestamp)
         {
             return utcTimestamp != DateTime.MinValue &&
@@ -2741,7 +2747,8 @@ namespace LaunchPlugin
                 () => this.CurrentTrackKey,
                 (trackKey) => GetTrackMarkersSnapshot(trackKey),
                 (trackKey, locked) => SetTrackMarkersLockedForKey(trackKey, locked),
-                () => ReloadTrackMarkersFromDisk()
+                () => ReloadTrackMarkersFromDisk(),
+                (trackKey) => ResetTrackMarkersForKey(trackKey)
             );
 
 

--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -635,6 +635,20 @@ namespace LaunchPlugin
             SimHub.Logging.Current.Info($"[LalaPlugin:TrackMarkers] lock trackKey={key} locked={locked}");
         }
 
+        public void ResetTrackMarkersForKey(string trackKey)
+        {
+            EnsureTrackMarkerStoreLoaded();
+            string key = NormalizeTrackKey(trackKey);
+            if (string.Equals(key, "unknown", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var record = GetOrCreateTrackMarkerRecord(key);
+            record.PitEntryTrkPct = double.NaN;
+            record.PitExitTrkPct = double.NaN;
+            record.LastUpdatedUtc = DateTime.MinValue;
+            SaveTrackMarkers();
+        }
+
         private void UpdateTrackMarkers(string trackKey, double carPct, double trackLenM, bool isInPitLane, bool justExitedPits, bool isInPitStall, double speedKph)
         {
             EnsureTrackMarkerStoreLoaded();

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -389,14 +389,22 @@
                                                Text="{Binding TrackMarkersLastUpdatedText}"
                                                VerticalAlignment="Center"/>
 
-                                            <styles:SHButtonPrimary
+                                            <StackPanel
                                                 Grid.Row="3"
                                                 Grid.Column="0"
-                                                Content="Reload markers"
-                                                Command="{Binding ReloadTrackMarkersCommand}"
-                                                Margin="0,10,10,0"
-                                                HorizontalAlignment="Left"
-                                                ToolTip="Reload LalaLaunch.TrackMarkers.json from disk (for manual edits)."/>
+                                                Grid.ColumnSpan="3"
+                                                Orientation="Horizontal"
+                                                Margin="0,10,0,0"
+                                                HorizontalAlignment="Left">
+                                                <styles:SHButtonPrimary
+                                                    Content="Reload markers"
+                                                    Command="{Binding ReloadTrackMarkersCommand}"
+                                                    Margin="0,0,10,0"
+                                                    ToolTip="Reload LalaLaunch.TrackMarkers.json from disk (for manual edits)."/>
+                                                <styles:SHButtonPrimary
+                                                    Content="Relearn"
+                                                    Command="{Binding RelearnPitDataCommand}"/>
+                                            </StackPanel>
 
 
                                         </Grid>
@@ -507,10 +515,18 @@
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
-                                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
-                                          Content="Locked"
-                                          IsChecked="{Binding DryConditionsLocked, Mode=TwoWay}"
-                                          Margin="0,8,0,0"/>
+                                        <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
+                                            Orientation="Horizontal"
+                                            Margin="0,8,0,0"
+                                            HorizontalAlignment="Left">
+                                            <CheckBox
+                                                Content="Locked"
+                                                IsChecked="{Binding DryConditionsLocked, Mode=TwoWay}"/>
+                                            <styles:SHButtonPrimary
+                                                Content="Relearn"
+                                                Command="{Binding DataContext.RelearnDryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                Margin="10,0,0,0"/>
+                                        </StackPanel>
                                     </Grid>
                                 </GroupBox>
 
@@ -618,10 +634,18 @@
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
-                                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
-                                          Content="Locked"
-                                          IsChecked="{Binding WetConditionsLocked, Mode=TwoWay}"
-                                          Margin="0,8,0,0"/>
+                                        <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
+                                            Orientation="Horizontal"
+                                            Margin="0,8,0,0"
+                                            HorizontalAlignment="Left">
+                                            <CheckBox
+                                                Content="Locked"
+                                                IsChecked="{Binding WetConditionsLocked, Mode=TwoWay}"/>
+                                            <styles:SHButtonPrimary
+                                                Content="Relearn"
+                                                Command="{Binding DataContext.RelearnWetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                Margin="10,0,0,0"/>
+                                        </StackPanel>
                                     </Grid>
                                 </GroupBox>
 


### PR DESCRIPTION
### Motivation
- Provide a simple UI action to reset learned per-track data back to an unlearned state so mining can repopulate values.
- Keep existing layout and shared-size alignment while adding left-aligned action buttons next to existing controls.
- Ensure resets persist immediately so users don't need to click "Save All Changes" after using Relearn.

### Description
- Added model methods on `TrackStats`: `RelearnPitLoss()`, `RelearnDryConditions()`, and `RelearnWetConditions()` to clear the relevant fields and raise `PropertyChanged` so the UI updates.
- Added `PitEngine.ResetTrackMarkersForKey(string)` to clear stored pit entry/exit pct and last-updated timestamp and call `SaveTrackMarkers()`, and exposed it via `LalaLaunch.ResetTrackMarkersForKey(string)`.
- Wired new commands in `ProfilesManagerViewModel`: `RelearnPitDataCommand`, `RelearnDryCommand`, and `RelearnWetCommand`, implemented the handlers to call the model resets, unlock dry/wet when required, call `SaveProfiles()`, and log INFO messages with the `SimHub.Logging` prefix.
- Inserted `Relearn` `SHButtonPrimary` controls in `ProfilesManagerView.xaml` next to the existing `Reload markers` button and the Dry/Wet `Locked` checkboxes, preserving the single Grid-per-GroupBox / SharedSizeGroup layout and left alignment.

### Testing
- No automated tests were executed as part of this change (no unit/integration test suite invoked).
- Code built and changes were committed locally; automated CI/test runs were not triggered in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d36dc060832fa354624f005ab269)