### PR TITLE
Split fuel Last-updated metadata into Dry and Wet

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -603,6 +603,8 @@ namespace LaunchPlugin
                     _fuelUpdatedSource = value;
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(FuelLastUpdatedText));
+                    OnPropertyChanged(nameof(DryFuelLastUpdatedText));
+                    OnPropertyChanged(nameof(WetFuelLastUpdatedText));
                 }
             }
         }
@@ -619,6 +621,72 @@ namespace LaunchPlugin
                     _fuelUpdatedUtc = value;
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(FuelLastUpdatedText));
+                    OnPropertyChanged(nameof(DryFuelLastUpdatedText));
+                    OnPropertyChanged(nameof(WetFuelLastUpdatedText));
+                }
+            }
+        }
+
+        private string _dryFuelUpdatedSource;
+        [JsonProperty]
+        public string DryFuelUpdatedSource
+        {
+            get => _dryFuelUpdatedSource;
+            set
+            {
+                if (_dryFuelUpdatedSource != value)
+                {
+                    _dryFuelUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DryFuelLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _dryFuelUpdatedUtc;
+        [JsonProperty]
+        public DateTime? DryFuelUpdatedUtc
+        {
+            get => _dryFuelUpdatedUtc;
+            set
+            {
+                if (_dryFuelUpdatedUtc != value)
+                {
+                    _dryFuelUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DryFuelLastUpdatedText));
+                }
+            }
+        }
+
+        private string _wetFuelUpdatedSource;
+        [JsonProperty]
+        public string WetFuelUpdatedSource
+        {
+            get => _wetFuelUpdatedSource;
+            set
+            {
+                if (_wetFuelUpdatedSource != value)
+                {
+                    _wetFuelUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(WetFuelLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _wetFuelUpdatedUtc;
+        [JsonProperty]
+        public DateTime? WetFuelUpdatedUtc
+        {
+            get => _wetFuelUpdatedUtc;
+            set
+            {
+                if (_wetFuelUpdatedUtc != value)
+                {
+                    _wetFuelUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(WetFuelLastUpdatedText));
                 }
             }
         }
@@ -636,10 +704,64 @@ namespace LaunchPlugin
             }
         }
 
+        [JsonIgnore]
+        public string DryFuelLastUpdatedText
+        {
+            get
+            {
+                if (_dryFuelUpdatedUtc.HasValue)
+                {
+                    var sourceLabel = string.IsNullOrWhiteSpace(_dryFuelUpdatedSource)
+                        ? "Last updated"
+                        : _dryFuelUpdatedSource;
+                    return $"{sourceLabel}: {_dryFuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                }
+
+                if (!_fuelUpdatedUtc.HasValue) return string.Empty;
+                var legacySourceLabel = string.IsNullOrWhiteSpace(_fuelUpdatedSource)
+                    ? "Last updated"
+                    : _fuelUpdatedSource;
+                return $"{legacySourceLabel}: {_fuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+            }
+        }
+
+        [JsonIgnore]
+        public string WetFuelLastUpdatedText
+        {
+            get
+            {
+                if (_wetFuelUpdatedUtc.HasValue)
+                {
+                    var sourceLabel = string.IsNullOrWhiteSpace(_wetFuelUpdatedSource)
+                        ? "Last updated"
+                        : _wetFuelUpdatedSource;
+                    return $"{sourceLabel}: {_wetFuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                }
+
+                if (!_fuelUpdatedUtc.HasValue) return string.Empty;
+                var legacySourceLabel = string.IsNullOrWhiteSpace(_fuelUpdatedSource)
+                    ? "Last updated"
+                    : _fuelUpdatedSource;
+                return $"{legacySourceLabel}: {_fuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+            }
+        }
+
         public void MarkFuelUpdated(string source, DateTime? whenUtc = null)
         {
             FuelUpdatedSource = source;
             FuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void MarkFuelUpdatedDry(string source, DateTime? whenUtc = null)
+        {
+            DryFuelUpdatedSource = source;
+            DryFuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void MarkFuelUpdatedWet(string source, DateTime? whenUtc = null)
+        {
+            WetFuelUpdatedSource = source;
+            WetFuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
         }
 
         public void RelearnPitLoss()
@@ -686,8 +808,8 @@ namespace LaunchPlugin
 
             DryLapTimeSampleCount = 0;
             DryFuelSampleCount = 0;
-            FuelUpdatedSource = null;
-            FuelUpdatedUtc = null;
+            DryFuelUpdatedSource = null;
+            DryFuelUpdatedUtc = null;
         }
 
         public void RelearnWetConditions()
@@ -724,8 +846,8 @@ namespace LaunchPlugin
 
             WetLapTimeSampleCount = 0;
             WetFuelSampleCount = 0;
-            FuelUpdatedSource = null;
-            FuelUpdatedUtc = null;
+            WetFuelUpdatedSource = null;
+            WetFuelUpdatedUtc = null;
         }
 
 
@@ -775,7 +897,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressDryFuelSync)
                         {
-                            MarkFuelUpdated("Manual fuel edit");
+                            MarkFuelUpdatedDry("Manual fuel edit");
                         }
                         _suppressDryFuelSync = true;
                         AvgFuelPerLapDry = parsedValue;
@@ -967,7 +1089,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressWetFuelSync)
                         {
-                            MarkFuelUpdated("Manual fuel edit");
+                            MarkFuelUpdatedWet("Manual fuel edit");
                         }
                         _suppressWetFuelSync = true;
                         AvgFuelPerLapWet = parsedValue;

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2229,7 +2229,14 @@ namespace LaunchPlugin
         if (fuelStamped)
         {
             var source = isLiveSession ? "Telemetry fuel" : "Planner save";
-            trackRecord.MarkFuelUpdated(source);
+            if (saveWet)
+            {
+                trackRecord.MarkFuelUpdatedWet(source);
+            }
+            else
+            {
+                trackRecord.MarkFuelUpdatedDry(source);
+            }
         }
 
         trackRecord.PitLaneLossSeconds = this.PitLaneTimeLoss;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1890,7 +1890,7 @@ namespace LaunchPlugin
                             if (trackRecord != null)
                             {
                                 trackRecord.AvgFuelPerLapDry = _avgDryFuelPerLap;
-                                trackRecord.MarkFuelUpdated("Telemetry fuel");
+                                trackRecord.MarkFuelUpdatedDry("Telemetry fuel");
                             }
                         }
 

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -508,7 +508,7 @@
                                                 Margin="0,0,10,0"/>
 
                                             <TextBlock
-                                                Text="{Binding FuelLastUpdatedText, Mode=OneWay}"
+                                                Text="{Binding DryFuelLastUpdatedText, Mode=OneWay}"
                                                 FontStyle="Italic"
                                                 Foreground="#FF9AA0A6"
                                                 TextWrapping="Wrap"/>
@@ -627,7 +627,7 @@
                                                 Margin="0,0,10,0"/>
 
                                             <TextBlock
-                                                Text="{Binding FuelLastUpdatedText, Mode=OneWay}"
+                                                Text="{Binding WetFuelLastUpdatedText, Mode=OneWay}"
                                                 FontStyle="Italic"
                                                 Foreground="#FF9AA0A6"
                                                 TextWrapping="Wrap"/>


### PR DESCRIPTION
### Motivation
- Dry and wet fuel metadata were using a single shared `FuelUpdatedUtc`/`FuelUpdatedSource`, causing the Dry and Wet "Last updated" display to overwrite each other.
- After adding Relearn buttons, resetting one condition cleared the other's last-updated text, so condition-specific metadata is required.
- The goal is to preserve backward compatibility by falling back to the legacy `FuelUpdatedUtc`/`FuelUpdatedSource` when condition-specific fields are absent.

### Description
- Added persisted fields `DryFuelUpdatedUtc`, `DryFuelUpdatedSource`, `WetFuelUpdatedUtc`, and `WetFuelUpdatedSource` (marked with `JsonProperty`) and new read-only display properties `DryFuelLastUpdatedText` and `WetFuelLastUpdatedText` with legacy fallback logic in `CarProfiles.cs`.
- Introduced `MarkFuelUpdatedDry` and `MarkFuelUpdatedWet` and kept `MarkFuelUpdated` for legacy usage, and updated manual-edit code paths to call the condition-specific methods (`MarkFuelUpdatedDry`/`MarkFuelUpdatedWet`).
- Updated relearn routines to only clear the corresponding condition-specific fields (`DryFuelUpdated*` or `WetFuelUpdated*`) and left legacy shared fields untouched.
- Wired UI to the new properties by changing `ProfilesManagerView.xaml` bindings to `DryFuelLastUpdatedText` and `WetFuelLastUpdatedText`, and updated telemetry/planner call sites in `LalaLaunch.cs` and `FuelCalcs.cs` to stamp the correct condition-specific metadata.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962de9225f4832f885e347c855083b8)