### PR TITLE
Implement Option 2: per-condition live fuel persistence with lock gating

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -937,6 +937,10 @@ namespace LaunchPlugin
                     var parsedValue = StringToNullableDouble(value);
                     if (parsedValue.HasValue)
                     {
+                        if (!_suppressDryMinFuelSync)
+                        {
+                            MarkFuelUpdatedDry("Manual fuel edit");
+                        }
                         _suppressDryMinFuelSync = true;
                         MinFuelPerLapDry = parsedValue;
                         _suppressDryMinFuelSync = false;
@@ -975,6 +979,10 @@ namespace LaunchPlugin
                     var parsedValue = StringToNullableDouble(value);
                     if (parsedValue.HasValue)
                     {
+                        if (!_suppressDryMaxFuelSync)
+                        {
+                            MarkFuelUpdatedDry("Manual fuel edit");
+                        }
                         _suppressDryMaxFuelSync = true;
                         MaxFuelPerLapDry = parsedValue;
                         _suppressDryMaxFuelSync = false;
@@ -1129,6 +1137,10 @@ namespace LaunchPlugin
                     var parsedValue = StringToNullableDouble(value);
                     if (parsedValue.HasValue)
                     {
+                        if (!_suppressWetMinFuelSync)
+                        {
+                            MarkFuelUpdatedWet("Manual fuel edit");
+                        }
                         _suppressWetMinFuelSync = true;
                         MinFuelPerLapWet = parsedValue;
                         _suppressWetMinFuelSync = false;
@@ -1167,6 +1179,10 @@ namespace LaunchPlugin
                     var parsedValue = StringToNullableDouble(value);
                     if (parsedValue.HasValue)
                     {
+                        if (!_suppressWetMaxFuelSync)
+                        {
+                            MarkFuelUpdatedWet("Manual fuel edit");
+                        }
                         _suppressWetMaxFuelSync = true;
                         MaxFuelPerLapWet = parsedValue;
                         _suppressWetMaxFuelSync = false;


### PR DESCRIPTION
### Motivation
- Implement the Option 2 live persistence behaviour so telemetry mining updates ECO/MIN/AVG/MAX per condition (dry/wet) only when that condition is unlocked.
- Ensure sample counts are always updated for the active condition even when the condition is locked so live mining still collects counts.
- Stamp per-condition metadata fields (dry/wet) using `MarkFuelUpdatedDry` / `MarkFuelUpdatedWet` rather than the legacy shared `MarkFuelUpdated` when writing condition-specific values.
- Remove/refactor the legacy "dry AVG only" write path to avoid conflicting writes and make behaviour consistent across dry and wet.

### Description
- Added a guard constant `FuelPersistMinLaps = 3` and updated `UpdateLiveFuelCalcs` in `LalaLaunch.cs` to always set `DryFuelSampleCount` / `WetFuelSampleCount` and to persist `MinFuelPerLap`, `AvgFuelPerLap`, and `MaxFuelPerLap` only when the corresponding condition is unlocked and the valid-sample threshold is met, then call `MarkFuelUpdatedDry("Telemetry fuel")` or `MarkFuelUpdatedWet("Telemetry fuel")`.
- Resolved track records robustly via `FindTrack(CurrentTrackKey)` or `ResolveTrackByNameOrKey(CurrentTrackName)` before attempting writes to avoid missing records.
- Updated manual-edit text setters in `CarProfiles.cs` (`Avg/Min/MaxFuelPerLap` text properties for dry and wet) to call `MarkFuelUpdatedDry("Manual fuel edit")` or `MarkFuelUpdatedWet("Manual fuel edit")` when not suppressed so manual edits stamp the correct per-condition metadata.
- Preserved UI layout and existing bindings (no XAML layout changes); only minimal model-level binding/metadata stamping logic was changed.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962faab7814832f89bbff801a6d5682)