### PR TITLE
Persist live pace averages to TrackStats (dry/wet)

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -1013,7 +1013,7 @@ namespace LaunchPlugin
                     // LOG: Avg dry lap changed
                     try
                     {
-                        SimHub.Logging.Current.Info(
+                        SimHub.Logging.Current.Debug(
                             $"[LalaPlugin:Profile/Pace] AvgDry updated for track '{DisplayName ?? "(null)"}' ({Key ?? "(null)"}): " +
                             $"'{MillisecondsToLapTimeString(old)}' -> '{MillisecondsToLapTimeString(_avgLapTimeDry)}'"
                         );


### PR DESCRIPTION
### Motivation
- Live pace averages (`Pace_StintAvgLapTimeSec`) and sample counts were computed but never persisted, leaving `AvgLapTimeDry/Wet` null in profiles and the TRACKS tab blank.
- Pace persistence should mirror the existing fuel Option 2 behaviour: always update sample counts, but only persist averages when unlocked and enough samples exist.
- Prevent accidental writes of 0ms and avoid overwriting locked averages.
- Reduce noisy logging from avg lap setter to avoid duplicate info-level messages when the plugin persists values.

### Description
- Added pace persistence logic in `LalaLaunch.cs` alongside the fuel persistence block to set `WetLapTimeSampleCount` or `DryLapTimeSampleCount` from `_recentLapTimes.Count` on each update and always write the sample count regardless of lock state.
- Persist `AvgLapTimeWet` / `AvgLapTimeDry` only when `paceSamples >= FuelPersistMinLaps`, `Pace_StintAvgLapTimeSec > 0`, rounded milliseconds `> 0`, and the corresponding `WetConditionsLocked` / `DryConditionsLocked` is false, using the existing `FuelPersistMinLaps` guard.
- Call `ProfilesViewModel?.SaveProfiles()` after a successful avg write and emit a single INFO log line when an avg lap time is persisted with details including car, track, lap time, ms, samples and lock state.
- Lowered the avg-dry setter logging from `Info` to `Debug` in `CarProfiles.cs` to avoid duplicate info entries produced by persistence.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ad81aa8c832fa43bc7d5cfe8e86e)