### PR TITLE
Prevent fuel text sync from marking manual edits

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -877,7 +877,9 @@ namespace LaunchPlugin
                     NotifyWetVsDryDeltasChanged();
                     if (!_suppressDryFuelSync)
                     {
+                        _suppressDryFuelSync = true;
                         AvgFuelPerLapDryText = _avgFuelPerLapDry?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                        _suppressDryFuelSync = false;
                     }
                 }
             }
@@ -919,7 +921,9 @@ namespace LaunchPlugin
                     OnPropertyChanged();
                     if (!_suppressDryMinFuelSync)
                     {
+                        _suppressDryMinFuelSync = true;
                         MinFuelPerLapDryText = _minFuelPerLapDry?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                        _suppressDryMinFuelSync = false;
                     }
                 }
             }
@@ -961,7 +965,9 @@ namespace LaunchPlugin
                     OnPropertyChanged();
                     if (!_suppressDryMaxFuelSync)
                     {
+                        _suppressDryMaxFuelSync = true;
                         MaxFuelPerLapDryText = _maxFuelPerLapDry?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                        _suppressDryMaxFuelSync = false;
                     }
                 }
             }
@@ -1077,7 +1083,9 @@ namespace LaunchPlugin
                     NotifyWetVsDryDeltasChanged();
                     if (!_suppressWetFuelSync)
                     {
+                        _suppressWetFuelSync = true;
                         AvgFuelPerLapWetText = _avgFuelPerLapWet?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                        _suppressWetFuelSync = false;
                     }
                 }
             }
@@ -1119,7 +1127,9 @@ namespace LaunchPlugin
                     OnPropertyChanged();
                     if (!_suppressWetMinFuelSync)
                     {
+                        _suppressWetMinFuelSync = true;
                         MinFuelPerLapWetText = _minFuelPerLapWet?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                        _suppressWetMinFuelSync = false;
                     }
                 }
             }
@@ -1161,7 +1171,9 @@ namespace LaunchPlugin
                     OnPropertyChanged();
                     if (!_suppressWetMaxFuelSync)
                     {
+                        _suppressWetMaxFuelSync = true;
                         MaxFuelPerLapWetText = _maxFuelPerLapWet?.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+                        _suppressWetMaxFuelSync = false;
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- Deserialization on startup caused numeric fuel setters to update their corresponding `*Text` properties and inadvertently trigger `MarkFuelUpdatedDry`/`MarkFuelUpdatedWet`, changing the provenance label to "Manual fuel edit".
- The problem affected the six fuel numeric properties `AvgFuelPerLapDry`, `MinFuelPerLapDry`, `MaxFuelPerLapDry`, `AvgFuelPerLapWet`, `MinFuelPerLapWet`, and `MaxFuelPerLapWet`.
- The intent is to preserve the stored fuel "Updated" source/time from JSON and only mark "Manual fuel edit" when the user actually edits the text fields.

### Description
- Wrapped the numeric-to-text assignments in each numeric setter with the matching suppression flag set to `true` before the assignment and `false` after to prevent the `Text` setter from treating programmatic sync as a manual edit.
- Applied the suppression pattern in `CarProfiles.cs` for `AvgFuelPerLapDryText`, `MinFuelPerLapDryText`, `MaxFuelPerLapDryText`, `AvgFuelPerLapWetText`, `MinFuelPerLapWetText`, and `MaxFuelPerLapWetText`.
- Did not modify `MarkFuelUpdatedDry`/`MarkFuelUpdatedWet`, telemetry persistence, UI/XAML, or existing text formatting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963be44dfc0832f8b05819287d4a10f)