### PR TITLE
Add compact last-updated labels for Best/Avg laps and shorten fuel labels

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -313,7 +313,9 @@ namespace LaunchPlugin
 
                     if (!_suppressBestLapDrySync)
                     {
+                        _suppressBestLapDrySync = true;
                         BestLapTimeDryText = MillisecondsToLapTimeString(_bestLapMsDry);
+                        _suppressBestLapDrySync = false;
                     }
                 }
             }
@@ -337,8 +339,13 @@ namespace LaunchPlugin
                 {
                     _bestLapMsDryText = value;
                     OnPropertyChanged();
+                    var parsed = LapTimeStringToMilliseconds(value);
+                    if (!_suppressBestLapDrySync && parsed.HasValue && BestLapMsDry != parsed)
+                    {
+                        MarkBestLapUpdatedDry("Manual");
+                    }
                     _suppressBestLapDrySync = true;
-                    BestLapMsDry = LapTimeStringToMilliseconds(value);
+                    BestLapMsDry = parsed;
                     _suppressBestLapDrySync = false;
                 }
             }
@@ -368,7 +375,9 @@ namespace LaunchPlugin
 
                     if (!_suppressBestLapWetSync)
                     {
+                        _suppressBestLapWetSync = true;
                         BestLapTimeWetText = MillisecondsToLapTimeString(_bestLapMsWet);
+                        _suppressBestLapWetSync = false;
                     }
                 }
             }
@@ -383,8 +392,13 @@ namespace LaunchPlugin
                 {
                     _bestLapMsWetText = value;
                     OnPropertyChanged();
+                    var parsed = LapTimeStringToMilliseconds(value);
+                    if (!_suppressBestLapWetSync && parsed.HasValue && BestLapMsWet != parsed)
+                    {
+                        MarkBestLapUpdatedWet("Manual");
+                    }
                     _suppressBestLapWetSync = true;
-                    BestLapMsWet = LapTimeStringToMilliseconds(value);
+                    BestLapMsWet = parsed;
                     _suppressBestLapWetSync = false;
                 }
             }
@@ -691,16 +705,160 @@ namespace LaunchPlugin
             }
         }
 
+        private string _dryBestLapUpdatedSource;
+        [JsonProperty]
+        public string DryBestLapUpdatedSource
+        {
+            get => _dryBestLapUpdatedSource;
+            set
+            {
+                if (_dryBestLapUpdatedSource != value)
+                {
+                    _dryBestLapUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DryBestLapLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _dryBestLapUpdatedUtc;
+        [JsonProperty]
+        public DateTime? DryBestLapUpdatedUtc
+        {
+            get => _dryBestLapUpdatedUtc;
+            set
+            {
+                if (_dryBestLapUpdatedUtc != value)
+                {
+                    _dryBestLapUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DryBestLapLastUpdatedText));
+                }
+            }
+        }
+
+        private string _wetBestLapUpdatedSource;
+        [JsonProperty]
+        public string WetBestLapUpdatedSource
+        {
+            get => _wetBestLapUpdatedSource;
+            set
+            {
+                if (_wetBestLapUpdatedSource != value)
+                {
+                    _wetBestLapUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(WetBestLapLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _wetBestLapUpdatedUtc;
+        [JsonProperty]
+        public DateTime? WetBestLapUpdatedUtc
+        {
+            get => _wetBestLapUpdatedUtc;
+            set
+            {
+                if (_wetBestLapUpdatedUtc != value)
+                {
+                    _wetBestLapUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(WetBestLapLastUpdatedText));
+                }
+            }
+        }
+
+        private string _dryAvgLapUpdatedSource;
+        [JsonProperty]
+        public string DryAvgLapUpdatedSource
+        {
+            get => _dryAvgLapUpdatedSource;
+            set
+            {
+                if (_dryAvgLapUpdatedSource != value)
+                {
+                    _dryAvgLapUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DryAvgLapLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _dryAvgLapUpdatedUtc;
+        [JsonProperty]
+        public DateTime? DryAvgLapUpdatedUtc
+        {
+            get => _dryAvgLapUpdatedUtc;
+            set
+            {
+                if (_dryAvgLapUpdatedUtc != value)
+                {
+                    _dryAvgLapUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DryAvgLapLastUpdatedText));
+                }
+            }
+        }
+
+        private string _wetAvgLapUpdatedSource;
+        [JsonProperty]
+        public string WetAvgLapUpdatedSource
+        {
+            get => _wetAvgLapUpdatedSource;
+            set
+            {
+                if (_wetAvgLapUpdatedSource != value)
+                {
+                    _wetAvgLapUpdatedSource = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(WetAvgLapLastUpdatedText));
+                }
+            }
+        }
+
+        private DateTime? _wetAvgLapUpdatedUtc;
+        [JsonProperty]
+        public DateTime? WetAvgLapUpdatedUtc
+        {
+            get => _wetAvgLapUpdatedUtc;
+            set
+            {
+                if (_wetAvgLapUpdatedUtc != value)
+                {
+                    _wetAvgLapUpdatedUtc = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(WetAvgLapLastUpdatedText));
+                }
+            }
+        }
+
+        private static string NormalizeUpdateSource(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source)) return string.Empty;
+            var trimmed = source.Trim();
+            if (string.Equals(trimmed, "Manual fuel edit", StringComparison.OrdinalIgnoreCase)) return "Manual";
+            if (string.Equals(trimmed, "Telemetry fuel", StringComparison.OrdinalIgnoreCase)) return "Telemetry";
+            if (string.Equals(trimmed, "manual", StringComparison.OrdinalIgnoreCase)) return "Manual";
+            if (string.Equals(trimmed, "telemetry", StringComparison.OrdinalIgnoreCase)) return "Telemetry";
+            return trimmed;
+        }
+
+        private string FormatUpdatedText(DateTime? updatedUtc, string source, bool requireSource)
+        {
+            if (!updatedUtc.HasValue) return string.Empty;
+            var normalized = NormalizeUpdateSource(source);
+            if (requireSource && string.IsNullOrWhiteSpace(normalized)) return string.Empty;
+            var label = string.IsNullOrWhiteSpace(normalized) ? "Last updated" : normalized;
+            return $"{label} {updatedUtc.Value:yyyy-MM-dd HH:mm}";
+        }
+
         [JsonIgnore]
         public string FuelLastUpdatedText
         {
             get
             {
-                if (!_fuelUpdatedUtc.HasValue) return string.Empty;
-                var sourceLabel = string.IsNullOrWhiteSpace(_fuelUpdatedSource)
-                    ? "Last updated"
-                    : _fuelUpdatedSource;
-                return $"{sourceLabel}: {_fuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                return FormatUpdatedText(_fuelUpdatedUtc, _fuelUpdatedSource, requireSource: false);
             }
         }
 
@@ -711,17 +869,10 @@ namespace LaunchPlugin
             {
                 if (_dryFuelUpdatedUtc.HasValue)
                 {
-                    var sourceLabel = string.IsNullOrWhiteSpace(_dryFuelUpdatedSource)
-                        ? "Last updated"
-                        : _dryFuelUpdatedSource;
-                    return $"{sourceLabel}: {_dryFuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                    return FormatUpdatedText(_dryFuelUpdatedUtc, _dryFuelUpdatedSource, requireSource: false);
                 }
 
-                if (!_fuelUpdatedUtc.HasValue) return string.Empty;
-                var legacySourceLabel = string.IsNullOrWhiteSpace(_fuelUpdatedSource)
-                    ? "Last updated"
-                    : _fuelUpdatedSource;
-                return $"{legacySourceLabel}: {_fuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                return FormatUpdatedText(_fuelUpdatedUtc, _fuelUpdatedSource, requireSource: false);
             }
         }
 
@@ -732,19 +883,24 @@ namespace LaunchPlugin
             {
                 if (_wetFuelUpdatedUtc.HasValue)
                 {
-                    var sourceLabel = string.IsNullOrWhiteSpace(_wetFuelUpdatedSource)
-                        ? "Last updated"
-                        : _wetFuelUpdatedSource;
-                    return $"{sourceLabel}: {_wetFuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                    return FormatUpdatedText(_wetFuelUpdatedUtc, _wetFuelUpdatedSource, requireSource: false);
                 }
 
-                if (!_fuelUpdatedUtc.HasValue) return string.Empty;
-                var legacySourceLabel = string.IsNullOrWhiteSpace(_fuelUpdatedSource)
-                    ? "Last updated"
-                    : _fuelUpdatedSource;
-                return $"{legacySourceLabel}: {_fuelUpdatedUtc.Value:yyyy-MM-dd HH:mm}";
+                return FormatUpdatedText(_fuelUpdatedUtc, _fuelUpdatedSource, requireSource: false);
             }
         }
+
+        [JsonIgnore]
+        public string DryBestLapLastUpdatedText => FormatUpdatedText(_dryBestLapUpdatedUtc, _dryBestLapUpdatedSource, requireSource: true);
+
+        [JsonIgnore]
+        public string WetBestLapLastUpdatedText => FormatUpdatedText(_wetBestLapUpdatedUtc, _wetBestLapUpdatedSource, requireSource: true);
+
+        [JsonIgnore]
+        public string DryAvgLapLastUpdatedText => FormatUpdatedText(_dryAvgLapUpdatedUtc, _dryAvgLapUpdatedSource, requireSource: true);
+
+        [JsonIgnore]
+        public string WetAvgLapLastUpdatedText => FormatUpdatedText(_wetAvgLapUpdatedUtc, _wetAvgLapUpdatedSource, requireSource: true);
 
         public void MarkFuelUpdated(string source, DateTime? whenUtc = null)
         {
@@ -762,6 +918,30 @@ namespace LaunchPlugin
         {
             WetFuelUpdatedSource = source;
             WetFuelUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void MarkBestLapUpdatedDry(string source, DateTime? whenUtc = null)
+        {
+            DryBestLapUpdatedSource = source;
+            DryBestLapUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void MarkBestLapUpdatedWet(string source, DateTime? whenUtc = null)
+        {
+            WetBestLapUpdatedSource = source;
+            WetBestLapUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void MarkAvgLapUpdatedDry(string source, DateTime? whenUtc = null)
+        {
+            DryAvgLapUpdatedSource = source;
+            DryAvgLapUpdatedUtc = whenUtc ?? DateTime.UtcNow;
+        }
+
+        public void MarkAvgLapUpdatedWet(string source, DateTime? whenUtc = null)
+        {
+            WetAvgLapUpdatedSource = source;
+            WetAvgLapUpdatedUtc = whenUtc ?? DateTime.UtcNow;
         }
 
         public void RelearnPitLoss()
@@ -810,6 +990,10 @@ namespace LaunchPlugin
             DryFuelSampleCount = 0;
             DryFuelUpdatedSource = null;
             DryFuelUpdatedUtc = null;
+            DryBestLapUpdatedSource = null;
+            DryBestLapUpdatedUtc = null;
+            DryAvgLapUpdatedSource = null;
+            DryAvgLapUpdatedUtc = null;
         }
 
         public void RelearnWetConditions()
@@ -848,6 +1032,10 @@ namespace LaunchPlugin
             WetFuelSampleCount = 0;
             WetFuelUpdatedSource = null;
             WetFuelUpdatedUtc = null;
+            WetBestLapUpdatedSource = null;
+            WetBestLapUpdatedUtc = null;
+            WetAvgLapUpdatedSource = null;
+            WetAvgLapUpdatedUtc = null;
         }
 
 
@@ -899,7 +1087,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressDryFuelSync)
                         {
-                            MarkFuelUpdatedDry("Manual fuel edit");
+                            MarkFuelUpdatedDry("Manual");
                         }
                         _suppressDryFuelSync = true;
                         AvgFuelPerLapDry = parsedValue;
@@ -943,7 +1131,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressDryMinFuelSync)
                         {
-                            MarkFuelUpdatedDry("Manual fuel edit");
+                            MarkFuelUpdatedDry("Manual");
                         }
                         _suppressDryMinFuelSync = true;
                         MinFuelPerLapDry = parsedValue;
@@ -987,7 +1175,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressDryMaxFuelSync)
                         {
-                            MarkFuelUpdatedDry("Manual fuel edit");
+                            MarkFuelUpdatedDry("Manual");
                         }
                         _suppressDryMaxFuelSync = true;
                         MaxFuelPerLapDry = parsedValue;
@@ -1028,7 +1216,9 @@ namespace LaunchPlugin
 
                     if (!_suppressAvgLapDrySync)
                     {
+                        _suppressAvgLapDrySync = true;
                         AvgLapTimeDryText = MillisecondsToLapTimeString(_avgLapTimeDry);
+                        _suppressAvgLapDrySync = false;
                     }
                 }
             }
@@ -1044,8 +1234,13 @@ namespace LaunchPlugin
                 {
                     _avgLapTimeDryText = value;
                     OnPropertyChanged();
+                    var parsed = LapTimeStringToMilliseconds(value);
+                    if (!_suppressAvgLapDrySync && parsed.HasValue && AvgLapTimeDry != parsed)
+                    {
+                        MarkAvgLapUpdatedDry("Manual");
+                    }
                     _suppressAvgLapDrySync = true;
-                    AvgLapTimeDry = LapTimeStringToMilliseconds(value);
+                    AvgLapTimeDry = parsed;
                     _suppressAvgLapDrySync = false;
                 }
             }
@@ -1105,7 +1300,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressWetFuelSync)
                         {
-                            MarkFuelUpdatedWet("Manual fuel edit");
+                            MarkFuelUpdatedWet("Manual");
                         }
                         _suppressWetFuelSync = true;
                         AvgFuelPerLapWet = parsedValue;
@@ -1149,7 +1344,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressWetMinFuelSync)
                         {
-                            MarkFuelUpdatedWet("Manual fuel edit");
+                            MarkFuelUpdatedWet("Manual");
                         }
                         _suppressWetMinFuelSync = true;
                         MinFuelPerLapWet = parsedValue;
@@ -1193,7 +1388,7 @@ namespace LaunchPlugin
                     {
                         if (!_suppressWetMaxFuelSync)
                         {
-                            MarkFuelUpdatedWet("Manual fuel edit");
+                            MarkFuelUpdatedWet("Manual");
                         }
                         _suppressWetMaxFuelSync = true;
                         MaxFuelPerLapWet = parsedValue;
@@ -1234,7 +1429,9 @@ namespace LaunchPlugin
 
                     if (!_suppressAvgLapWetSync)
                     {
+                        _suppressAvgLapWetSync = true;
                         AvgLapTimeWetText = MillisecondsToLapTimeString(_avgLapTimeWet);
+                        _suppressAvgLapWetSync = false;
                     }
                 }
             }
@@ -1250,8 +1447,13 @@ namespace LaunchPlugin
                 {
                     _avgLapTimeWetText = value;
                     OnPropertyChanged();
+                    var parsed = LapTimeStringToMilliseconds(value);
+                    if (!_suppressAvgLapWetSync && parsed.HasValue && AvgLapTimeWet != parsed)
+                    {
+                        MarkAvgLapUpdatedWet("Manual");
+                    }
                     _suppressAvgLapWetSync = true;
-                    AvgLapTimeWet = LapTimeStringToMilliseconds(value);
+                    AvgLapTimeWet = parsed;
                     _suppressAvgLapWetSync = false;
                 }
             }

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2228,7 +2228,7 @@ namespace LaunchPlugin
 
         if (fuelStamped)
         {
-            var source = isLiveSession ? "Telemetry fuel" : "Planner save";
+            var source = isLiveSession ? "Telemetry" : "Planner save";
             if (saveWet)
             {
                 trackRecord.MarkFuelUpdatedWet(source);

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1899,7 +1899,7 @@ namespace LaunchPlugin
                                         if (_minWetFuelPerLap > 0) trackRecord.MinFuelPerLapWet = _minWetFuelPerLap;
                                         if (_avgWetFuelPerLap > 0) trackRecord.AvgFuelPerLapWet = _avgWetFuelPerLap;
                                         if (_maxWetFuelPerLap > 0) trackRecord.MaxFuelPerLapWet = _maxWetFuelPerLap;
-                                        trackRecord.MarkFuelUpdatedWet("Telemetry fuel");
+                                        trackRecord.MarkFuelUpdatedWet("Telemetry");
                                     }
                                 }
                                 else
@@ -1911,7 +1911,7 @@ namespace LaunchPlugin
                                         if (_minDryFuelPerLap > 0) trackRecord.MinFuelPerLapDry = _minDryFuelPerLap;
                                         if (_avgDryFuelPerLap > 0) trackRecord.AvgFuelPerLapDry = _avgDryFuelPerLap;
                                         if (_maxDryFuelPerLap > 0) trackRecord.MaxFuelPerLapDry = _maxDryFuelPerLap;
-                                        trackRecord.MarkFuelUpdatedDry("Telemetry fuel");
+                                        trackRecord.MarkFuelUpdatedDry("Telemetry");
                                     }
                                 }
 
@@ -1937,6 +1937,7 @@ namespace LaunchPlugin
                                             if (!trackRecord.WetConditionsLocked)
                                             {
                                                 trackRecord.AvgLapTimeWet = ms;
+                                                trackRecord.MarkAvgLapUpdatedWet("Telemetry");
                                                 persistedAvgLap = true;
                                                 persistedMs = ms;
                                             }
@@ -1946,6 +1947,7 @@ namespace LaunchPlugin
                                             if (!trackRecord.DryConditionsLocked)
                                             {
                                                 trackRecord.AvgLapTimeDry = ms;
+                                                trackRecord.MarkAvgLapUpdatedDry("Telemetry");
                                                 persistedAvgLap = true;
                                                 persistedMs = ms;
                                             }

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -443,6 +443,13 @@
                                         <TextBox Grid.Row="0" Grid.Column="1"
                                              TextAlignment="Right"
                                              Text="{Binding BestLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="2"
+                                               Margin="12,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Text="{Binding DryBestLapLastUpdatedText, Mode=OneWay}"
+                                               FontStyle="Italic"
+                                               Foreground="#FF9AA0A6"
+                                               TextWrapping="Wrap"/>
 
                                         <!-- Avg lap time -->
                                         <TextBlock Grid.Row="1" Grid.Column="0"
@@ -453,10 +460,23 @@
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
                                              Text="{Binding AvgLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="2"
-                                               Margin="12,6,0,0"
-                                               VerticalAlignment="Center"
-                                               Text="{Binding DryLapTimeSampleCount, StringFormat=Sample: {0}}"/>
+                                        <StackPanel
+                                            Grid.Row="1"
+                                            Grid.Column="2"
+                                            Orientation="Horizontal"
+                                            Margin="12,6,0,0"
+                                            VerticalAlignment="Center">
+
+                                            <TextBlock
+                                                Text="{Binding DryLapTimeSampleCount, StringFormat=Sample: {0}}"
+                                                Margin="0,0,10,0"/>
+
+                                            <TextBlock
+                                                Text="{Binding DryAvgLapLastUpdatedText, Mode=OneWay}"
+                                                FontStyle="Italic"
+                                                Foreground="#FF9AA0A6"
+                                                TextWrapping="Wrap"/>
+                                        </StackPanel>
 
                                         <!-- Fuel burn label (only once) -->
                                         <TextBlock Grid.Row="2" Grid.Column="0"
@@ -562,6 +582,13 @@
                                         <TextBox Grid.Row="0" Grid.Column="1"
                                              TextAlignment="Right"
                                              Text="{Binding BestLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="2"
+                                           Margin="12,0,0,0"
+                                           VerticalAlignment="Center"
+                                           Text="{Binding WetBestLapLastUpdatedText, Mode=OneWay}"
+                                           FontStyle="Italic"
+                                           Foreground="#FF9AA0A6"
+                                           TextWrapping="Wrap"/>
 
                                         <!-- Avg lap time -->
                                         <TextBlock Grid.Row="1" Grid.Column="0"
@@ -572,10 +599,23 @@
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
                                              Text="{Binding AvgLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="2"
-                                           Margin="12,6,0,0"
-                                           VerticalAlignment="Center"
-                                           Text="{Binding WetLapTimeSampleCount, StringFormat=Sample: {0}}"/>
+                                        <StackPanel
+                                            Grid.Row="1"
+                                            Grid.Column="2"
+                                            Orientation="Horizontal"
+                                            Margin="12,6,0,0"
+                                            VerticalAlignment="Center">
+
+                                            <TextBlock
+                                                Text="{Binding WetLapTimeSampleCount, StringFormat=Sample: {0}}"
+                                                Margin="0,0,10,0"/>
+
+                                            <TextBlock
+                                                Text="{Binding WetAvgLapLastUpdatedText, Mode=OneWay}"
+                                                FontStyle="Italic"
+                                                Foreground="#FF9AA0A6"
+                                                TextWrapping="Wrap"/>
+                                        </StackPanel>
 
                                         <!-- Fuel burn label (only once) -->
                                         <TextBlock Grid.Row="2" Grid.Column="0"

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -97,11 +97,13 @@ namespace LaunchPlugin
             {
                 ts.BestLapMsWet = lapMs;
                 ts.BestLapTimeWetText = ts.MillisecondsToLapTimeString(ts.BestLapMsWet);
+                ts.MarkBestLapUpdatedWet("Telemetry");
             }
             else
             {
                 ts.BestLapMsDry = lapMs;
                 ts.BestLapTimeDryText = ts.MillisecondsToLapTimeString(ts.BestLapMsDry);
+                ts.MarkBestLapUpdatedDry("Telemetry");
             }
             SaveProfiles();
 


### PR DESCRIPTION
### Motivation

- Provide compact "last updated" indicators for Best Lap and Avg Lap (dry/wet) using only a compact source label and timestamp so the UI stays concise.  
- Place the info text to the right of the corresponding fields (same layout area used for Avg Lap sample display) to keep grid alignment and spacing unchanged.  
- Shorten existing fuel update wording so fuel info lines read only `Manual` or `Telemetry` plus date/time.  
- Prevent false "Manual" marks on startup or JSON hydration by applying the same suppression pattern used for fuel numeric/text synchronization.

### Description

- Added per-condition fields and JSON properties to `TrackStats` in `CarProfiles.cs`: `DryBestLapUpdatedUtc/Source`, `WetBestLapUpdatedUtc/Source`, `DryAvgLapUpdatedUtc/Source`, and `WetAvgLapUpdatedUtc/Source`, plus computed UI text properties `DryBestLapLastUpdatedText`, `WetBestLapLastUpdatedText`, `DryAvgLapLastUpdatedText`, and `WetAvgLapLastUpdatedText`.  
- Implemented `MarkBestLapUpdatedDry/Wet` and `MarkAvgLapUpdatedDry/Wet` helpers, plus a `NormalizeUpdateSource`/`FormatUpdatedText` path to standardize source labels to `Manual` / `Telemetry` and keep timestamp formatting consistent.  
- Applied suppression around numeric->text sync in lap setters so programmatic/JSON loads do not call the `Mark*...("Manual")` paths, and added logic in text setters to call `Mark*...("Manual")` only for real user edits.  
- Wire telemetry paths to update sources: `ProfilesManagerViewModel` now calls `MarkBestLapUpdatedDry/Wet("Telemetry")` when PBs are updated by telemetry, `LalaLaunch` calls `MarkAvgLapUpdatedDry/Wet("Telemetry")` when avg lap persistence occurs, and `FuelCalcs` / `LalaLaunch` were adjusted to use the shortened `Telemetry` source; updated UI in `ProfilesManagerView.xaml` to place the compact labels to the right of Best/Avg rows and append avg info after the sample count.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c0533628832f8704525ff41714fe)