### PR TITLE
Guard PitLite entry arming with pit stall/speed checks

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3839,7 +3839,10 @@ namespace LaunchPlugin
                 catch { /* keep avgUsed as 0.0 if anything goes wrong */ }
             }
 
-            _pitLite?.Update(inLane, completedLaps, lastLapSec, avgUsed);
+            bool isInPitStall = Convert.ToBoolean(
+                pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.Telemetry.PlayerCarInPitStall") ?? false);
+            double speedKph = data.NewData?.SpeedKmh ?? 0.0;
+            _pitLite?.Update(inLane, completedLaps, lastLapSec, avgUsed, isInPitStall, speedKph);
 
             bool pitEntryEdge = false;
             bool pitExitEdge = false;

--- a/PitCycleLite.cs
+++ b/PitCycleLite.cs
@@ -129,11 +129,19 @@ namespace LaunchPlugin
         /// <param name="completedLaps">Unused (kept for call-site compatibility).</param>
         /// <param name="lastLapSec">SimHub/iRacing LastLapTime.TotalSeconds.</param>
         /// <param name="avgLapSec">Baseline lap time used on the dash (0 if unknown).</param>
-        public void Update(bool isInPitLane, int completedLaps, double lastLapSec, double avgLapSec)
+        /// <param name="isInPitStall">True when car is in pit stall.</param>
+        /// <param name="speedKph">Current speed in kph.</param>
+        public void Update(bool isInPitLane, int completedLaps, double lastLapSec, double avgLapSec, bool isInPitStall, double speedKph)
         {
             // ---- 1) Edge detection FIRST (for the current, in-progress lap) ----
             if (isInPitLane && !_wasInLane)
             {
+                if (isInPitStall || speedKph <= 5.0)
+                {
+                    SimHub.Logging.Current.Info($"[LalaPlugin:Pit Lite] block entry arm pitStall={isInPitStall} speed={speedKph:F1}kph");
+                }
+                else
+                {
                 // Pit ENTRY this lap
                 _entrySeenThisLap = true;
                 SimHub.Logging.Current.Info("[LalaPlugin:Pit Lite] Entry detected. Arming cycle and clearing previous pit figures.");
@@ -149,6 +157,7 @@ namespace LaunchPlugin
                 DTLSec = 0.0;
 
                 Status = StatusKind.Armed;
+                }
             }
             if (!isInPitLane && _wasInLane)
             {


### PR DESCRIPTION
### Motivation
- Prevent PitCycleLite from arming a pit cycle when TrackMarkers would block entry capture by mirroring TrackMarkers gating (require not in pit stall and speedKph > 5.0).
- Avoid bogus DriveThrough-style cycles and tiny direct timers produced when the car is stationary or replaying inside a pit stall.

### Description
- Expanded `PitCycleLite.Update(...)` signature to add `isInPitStall` and `speedKph` parameters.
- Added a TrackMarkers-style guard in the entry-edge detection to skip arming and log `[LalaPlugin:Pit Lite] block entry arm pitStall={isInPitStall} speed={speedKph:F1}kph` when `isInPitStall` is true or `speedKph <= 5.0`.
- Plumbed values from `LalaLaunch` by reading `pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.Telemetry.PlayerCarInPitStall")` and `data.NewData?.SpeedKmh` and passing them to `_pitLite.Update(...)`.
- Did not change any other PitCycleLite behavior (exit detection, latching, timers, candidate logic).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f7845498832fabd59eb470fb92a6)