### PR TITLE
Trim TrackStats JSON schema (opt-in serialization, drop legacy/display fields)

### DIFF
--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -82,7 +82,7 @@ namespace LaunchPlugin
 
             int? baselineMs = isWetEffective
                 ? ts.BestLapMsWet
-                : (ts.BestLapMsDry ?? ts.BestLapMs);
+                : ts.BestLapMsDry;
 
             bool improved = !baselineMs.HasValue || lapMs <= baselineMs.Value - PB_IMPROVE_MS;
             if (!improved)
@@ -223,7 +223,6 @@ namespace LaunchPlugin
 
             // --- FIX: Manually initialize the text properties after creation ---
             // This is crucial because the UI now relies on them.
-            ts.BestLapMsText = ts.MillisecondsToLapTimeString(ts.BestLapMs);
             ts.BestLapTimeDryText = ts.MillisecondsToLapTimeString(ts.BestLapMsDry);
             ts.BestLapTimeWetText = ts.MillisecondsToLapTimeString(ts.BestLapMsWet);
             ts.AvgLapTimeDryText = ts.MillisecondsToLapTimeString(ts.AvgLapTimeDry);
@@ -827,7 +826,6 @@ namespace LaunchPlugin
                 {
                     DisplayName = "Default",
                     Key = "default",
-                    BestLapMs = null,
                     BestLapMsDry = null,
                     BestLapMsWet = null,
                     PitLaneLossSeconds = 25.0,


### PR DESCRIPTION
### Motivation
- Prevent display/UI helper and legacy fields from being persisted to `LalaLaunch_CarProfiles.json` so on-disk schema only contains canonical runtime/config fields.
- Remove legacy shared PB/fuel fallback fields (`BestLapMs`, `BestLapMsText`, `FuelUpdatedSource`, `FuelUpdatedUtc`) from the persisted schema and rely on per-condition dry/wet fields instead.
- Keep runtime calculations, UI layout and default-profile/bootstrap behaviour unchanged while making the JSON schema minimal and honest.
- Avoid back-compat/migration logic because the profile file can be deleted and recreated.

### Description
- Switched `TrackStats` and `ConditionMultipliers` to opt-in JSON serialization by adding `[JsonObject(MemberSerialization.OptIn)]` and keeping only canonical persisted properties annotated with `[JsonProperty]` (`CarProfiles.cs`).
- Removed legacy/shared persisted fields: deleted `BestLapMs`/`BestLapMsText` persistence and removed `FuelUpdatedSource`/`FuelUpdatedUtc` persistence and the `MarkFuelUpdated` method, and adjusted relevant getters to prefer per-condition dry/wet metadata (`CarProfiles.cs`).
- Stopped persisting display-only/text helpers and unused temperature fields by removing `[JsonProperty]` from `AvgDryTrackTemp`/`AvgWetTrackTemp` and retaining UI binding properties as non-persisted members (`CarProfiles.cs`).
- Updated code that referenced removed legacy fallbacks to use the dry/wet canonical fields (baseline selection in `TryUpdatePBByCondition` and default-track bootstrapping in `ProfilesManagerViewModel.cs`).
- Example before/after JSON (illustrative): before had `"BestLapMs"`/`"BestLapMsText"`/`"FuelUpdatedSource"`, after contains only `"BestLapMsDry"`/`"DryFuelUpdatedSource"`/`"AvgFuelPerLapDry"`.

### Testing
- No automated tests were executed as part of this change.
- The change set is limited to serialization annotations and cleanup to avoid logic regressions, and UI-binding helpers remain unchanged so runtime behavior should be unaffected.
- Manual verification steps described in the task (fresh start, normal run, UI edit) are expected to validate acceptance but were not run automatically.
- If desired, run the plugin and perform the acceptance tests: delete `LalaLaunch_CarProfiles.json`, start SimHub, exercise PB/fuel edits and confirm saved JSON no longer contains `*Text` or legacy fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69642af0094c832f8ae9ace9db74b413)