### PR TITLE
Add per-car Base Tank (L) to Profiles with Learn-from-Live and schema bump

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -75,6 +75,7 @@ namespace LaunchPlugin
         public double RefuelRate { get => _refuelRate; set { if (_refuelRate != value) { _refuelRate = value; OnPropertyChanged(); } } }
 
         private double? _baseTankLitres;
+        [JsonProperty]
         public double? BaseTankLitres
         {
             get => _baseTankLitres;

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -249,7 +249,7 @@
                                     <TextBox Grid.Column="0"
                                              Margin="0,0,0,0"
                                              TextAlignment="Right"
-                                             Text="{Binding BaseTankLitres, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"/>
+                                             Text="{Binding BaseTankLitres, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"/>
                                     <styles:SHButtonSecondary Grid.Column="1"
                                                               Content="Learn from Live"
                                                               Margin="8,0,0,0"

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -805,17 +805,14 @@ namespace LaunchPlugin
                     }
                     if (loadedProfiles != null)
                     {
-                        if (schemaVersion.HasValue && schemaVersion.Value < 2)
+                        foreach (var profile in loadedProfiles)
                         {
-                            foreach (var profile in loadedProfiles)
+                            if (profile.BaseTankLitres.HasValue)
                             {
-                                if (profile.BaseTankLitres.HasValue)
+                                var value = profile.BaseTankLitres.Value;
+                                if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
                                 {
-                                    var value = profile.BaseTankLitres.Value;
-                                    if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
-                                    {
-                                        profile.BaseTankLitres = null;
-                                    }
+                                    profile.BaseTankLitres = null;
                                 }
                             }
                         }


### PR DESCRIPTION
### Motivation

- Store an unscaled per-car base tank size in the Car Profiles so percent-based presets and profile-mode planning can later use an authoritative base tank value.
- Allow per-profile editing and an explicit UI action to learn the base tank from live game data rather than inferring or storing session-capped values.
- Ensure backward compatibility when loading older profile files by bumping the schema and treating missing values as unknown.

### Description

- Added a nullable `double? BaseTankLitres` property to `CarProfile` and included it in profile copying/creation flows (`NewProfile`, `CopyProfileProperties`, and default copying from `Default Settings`).
- Bumped `CarProfilesStore.SchemaVersion` to `2` and updated `SaveProfiles()` to write `SchemaVersion = 2`, while `LoadProfiles()` reads the store and treats older schema (<2) profiles as having `BaseTankLitres = null` where appropriate.
- Exposed a `Base Tank (L)` editable field and a `Learn from Live` button in `ProfilesManagerView.xaml`, wired to a new `LearnBaseTankCommand` on `ProfilesManagerViewModel`.
- Implemented `LearnBaseTankFromLive()` to read `DataCorePlugin.GameData.MaxFuel` via the plugin manager, validate (>0 and finite), round to one decimal, write to `SelectedProfile.BaseTankLitres`, and log a DEBUG line including the profile name and learned value.

### Testing

- No automated tests were run as part of this change.
- Manual/compile checks performed during development (build/commit) — no runtime UI or integration tests executed.
- Loading logic includes a migration guard to avoid breaking existing `CarProfiles.json` (older schema loads as unknown/null `BaseTankLitres`).
- Saving will now persist `BaseTankLitres` with `SchemaVersion = 2` so the value survives restarts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696556eeb02c832fae0322491d761d6a)