### PR TITLE
Clamp preset max fuel override and gate Live Snapshot selection

### DIFF
--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -123,7 +123,8 @@
                                          Margin="0,0,8,0"/>
                                     <RadioButton Content="Live snapshot"
                                          IsChecked="{Binding IsPlanningSourceLiveSnapshot, Mode=TwoWay}"
-                                         GroupName="PlanningSourceMode"/>
+                                         GroupName="PlanningSourceMode"
+                                         IsEnabled="{Binding CanSelectLiveSnapshot}"/>
                                 </StackPanel>
                             </Grid>
                             <!-- Live session telemetry, styled like LAUNCH SUMMARY on Post-Launch tab -->


### PR DESCRIPTION
### Motivation
- Presets must never leave `MaxFuelOverride` above the profile base tank when in `Profile` mode to avoid invalid race setups.
- Selecting `Live Snapshot` when no live session is active produces misleading placeholders and persistent errors.
- A `DriverCarMaxFuelPct` of `0` should be treated as unavailable rather than silently fabricating a tiny live cap.

### Description
- Ensure `ClampMaxFuelOverrideToProfileBaseTank()` runs after preset application by calling it at the end of `ApplyPresetValues` when `SelectedPlanningSourceMode == PlanningSourceMode.Profile`.
- Add `CanSelectLiveSnapshot` property backed by `IsLiveSessionActive`, raise `PropertyChanged` when live availability changes, and bind the Live Snapshot radio button `IsEnabled` to `CanSelectLiveSnapshot` in `FuelCalculatorView.xaml`.
- Automatically switch `SelectedPlanningSourceMode` back to `Profile` when `IsLiveSessionActive` becomes false while `LiveSnapshot` is selected.
- Improve live-cap detection in `GetLiveSessionCapLitresOrNull()` by reading BoP with `SafeReadDouble(..., double.NaN)`, returning `null` for `NaN`, `Infinity`, or `<= 0.0`, and only clamping to `[0.01 .. 1.0]` after validation; also preserve applying the selected preset when transitioning back into `Profile` mode.

### Testing
- No automated tests were executed for these changes.
- No automated test failures were reported because tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696612bbb0ec832f91c664309bab8398)