### PR TITLE
Default missing live BOP fuel percent to 1.0 in GetLiveSessionCapLitresOrNull

### DIFF
--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -1739,7 +1739,7 @@ namespace LaunchPlugin
         double bopPercent = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverCarMaxFuelPct", double.NaN);
         if (double.IsNaN(bopPercent) || double.IsInfinity(bopPercent) || bopPercent <= 0.0)
         {
-            return null;
+            bopPercent = 1.0;
         }
 
         bopPercent = Math.Min(1.0, Math.Max(0.01, bopPercent));


### PR DESCRIPTION
### Motivation
- Fix an inconsistency between `GetLiveSessionCapLitresOrNull()` and `LalaLaunch.ComputeLiveMaxFuelFromSimhub` where a non-positive BOP percent was treated as missing in one place but returned `null` in the other. 
- Ensure the Live Snapshot remains usable when the BOP percent is absent or reported as `0` while avoiding the 1% cap artefact. 
- Preserve the behavior that an invalid base max fuel (`<=0`/NaN/Inf) should still yield `null`. 

### Description
- Updated `GetLiveSessionCapLitresOrNull()` in `FuelCalcs.cs` to set `bopPercent = 1.0` when the read value is NaN, Infinity, or `<= 0.0` instead of returning `null`. 
- Kept the early-return `null` when `baseMaxFuel` is invalid (`NaN`/`Inf`/`<=0`). 
- Continued to clamp `bopPercent` to the range `[0.01 .. 1.0]` and return `baseMaxFuel * bopPercent`. 
- Change aligns live-cap calculation with existing handling in `LalaLaunch.ComputeLiveMaxFuelFromSimhub` and avoids the 1% cap artifact. 

### Testing
- No automated tests were run for this change.
- The change was compiled and committed as a single-line edit in `FuelCalcs.cs` (no additional automated verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69668fbb2880832facdcfc1a14250da9)