### PR TITLE
docs: clarify canonical vs snapshot references and surface known compromises

### DIFF
--- a/Docs/Code_Snapshot.md
+++ b/Docs/Code_Snapshot.md
@@ -1,6 +1,15 @@
+# SNAPSHOT / GENERATED / NON-CANONICAL
+
 # Code Snapshot
 
+- Source commit/PR: 9f784a9 (current HEAD; PR unknown)
+- Generated date: 2026-01-14
+- Regeneration: manual snapshot; no regen pipeline defined
 - Branch: work
+
+If this conflicts with Project_Index.md or contract docs, treat this as stale.
+
+## Snapshot metadata (legacy)
 - Commit: 9f784a9 (current HEAD)
 - Date: 2026-01-14
 

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -23,6 +23,18 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - [BranchWorkflow.md](BranchWorkflow.md) — branching policy.
 - [ConflictResolution.md](ConflictResolution.md) — merge/conflict process.
 
+## Known Lies / Allowed Compromises
+- Replay session identity: Session tokens can look inconsistent in replays — accepted because replay identity data is unreliable; resets are documented to tolerate this. (last reviewed: 2026-01-14)
+- Track-length delta alerts: Track-length delta messages are informational only and do not block usage — accepted to avoid false lockouts while still surfacing drift. (last reviewed: 2026-01-14)
+- Pit loss (DTL): DTL includes traffic impact, so “loss” can exceed idealized pit time — accepted because it reflects real race loss. (last reviewed: 2026-01-14)
+- Fuel planner separation: Planner-only values intentionally remain decoupled from live volatility — accepted to keep strategy settings stable. (last reviewed: 2026-01-14)
+- Rejoin alert linger: Dismissal requires both time + speed gates, so warnings can persist if speed stays low — accepted for safety gating. (last reviewed: 2026-01-14)
+
+## Doc Authority & Freshness
+- **CANONICAL contracts:** `SimHubParameterInventory.md`, `SimHubLogMessages.md`, `FuelProperties_Spec.md`, `FuelTab_SourceFlowNotes.md`, `Reset_And_Session_Identity.md`, and subsystem specs called out in Start Here are the source of truth.
+- **Snapshot/reference docs:** `Code_Snapshot.md`, ad-hoc analysis notes, and legacy spreadsheets are **non-canonical** and may be stale.
+- If any snapshot conflicts with canonical docs, treat the snapshot as stale. `Code_Snapshot.md` is not authoritative unless explicitly regenerated for the current commit.
+
 ## Doc inventory & canonicalisation
 - **Truth docs:** `SimHubParameterInventory.md`, `SimHubLogMessages.md`, `FuelProperties_Spec.md`, `FuelTab_SourceFlowNotes.md`, `Reset_And_Session_Identity.md`, `TimerZeroBehavior.md`, `CarProfiles-Legacy-Map.md` (schema + storage).
 - **Subsystem notes:** `Message_Catalog_v5_Signal_Mapping_Report.md`, `FuelTab_LeaderPaceFlow.md`, `FuelTabActionPlanOptions.md`, `FuelTabAnalysis.md`, `LALA-036-extra-time-sanity.md`, `LalaLaunch_Handover_Summary-20251130.docx`, `Subsystems/Pit_Entry_Assist.md`, `Subsystems/Track_Markers.md`, `Subsystems/Dash_Integration.md`, `Subsystems/MessageEngineV1_Notes.md`, `Profiles_And_PB.md`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -68,4 +68,9 @@
 - **Fuel planner max-fuel handling:** **COMPLETE** — profile-mode max fuel override is clamped to per-car base tank; Live Snapshot mode uses live session cap (MaxFuel × BoP, defaulting BoP to 1.0) and raises a clear error when live cap is unavailable. The Live Session panel clears max-fuel displays when the cap is missing.
 - **Live Snapshot + presets:** **COMPLETE** — changing car/track clears the Live Snapshot UI to avoid stale data; switching back to Profile mode restores the previous profile max-fuel override and re-applies the selected preset.
 - **Messaging signals:** **COMPLETE** — `MSG.OtherClassBehindGap` exported for multi-class approach messaging; no `MSGOtherClassBehindGap` alias remains.
-- **Known/accepted limitations:** Replay session identity quirks remain (see `Reset_And_Session_Identity.md`) and track-length deltas are informational only; both are understood/accepted for current shipping state.
+
+## Known/accepted limitations (intentional)
+- Replay session identity quirks can surface inconsistent session tokens in replays — accepted because replay identity data is unreliable (see `Reset_And_Session_Identity.md`).
+- Track-length delta messages are informational only and do not block use — accepted to avoid false lockouts while still surfacing drift.
+
+Items in this section should be mirrored (top 5–10 only) into Project_Index.md → Known Lies / Allowed Compromises.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -1,6 +1,9 @@
-# SimHub Log Messages (CANONICAL)
+# SimHub Log Messages
 
-Validated against commit: 298accf  
+**CANONICAL OBSERVABILITY MAP**
+
+Validated against: 298accf  
+Last reviewed: 2026-01-14  
 Last updated: 2026-02-10  
 Branch: work
 

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -1,6 +1,9 @@
-# SimHub Parameter Inventory (CANONICAL)
+# SimHub Parameter Inventory
 
-Validated against commit: 9f784a9  
+**CANONICAL CONTRACT**
+
+Validated against: 9f784a9  
+Last reviewed: 2026-01-14  
 Last updated: 2026-01-14  
 Branch: work
 

--- a/Docs/Subsystems/Pit_Entry_Assist.md
+++ b/Docs/Subsystems/Pit_Entry_Assist.md
@@ -1,7 +1,10 @@
 # Pit Entry Assist & Deceleration Capture
 
+**Subsystem doc**
+
 Validated against commit: 52bd57d7c618f4df094c68c4ea6f1e11cc5e328f  
 Last updated: 2026-02-06  
+Last reviewed: 2026-01-14  
 Branch: work
 
 ## Purpose
@@ -111,4 +114,3 @@ Three structured INFO logs (edge-triggered):
   - **GT3:** decel ≈ **14 m/s²**, buffer **≈15 m**.
   - **GTP:** similar decel, slightly **higher buffer** for hybrid regen variability.
 - Defaults auto-seed on profile creation/copy; adjust per track after reviewing `LINE` logs.【F:ProfilesManagerViewModel.cs†L645-L685】【F:ProfilesManagerViewModel.cs†L503-L505】
-


### PR DESCRIPTION
### Motivation
- Make it impossible to confuse canonical contract docs with generated snapshots and reduce future doc-drift by surfacing the highest-impact intentional quirks. 
- Surface a short list of “known lies / allowed compromises” so those behaviours are not accidentally “fixed” later. 
- Standardise header blocks so canonical observability/parameter docs clearly state their authority and freshness. 

### Description
- Added a `Known Lies / Allowed Compromises` section to `Docs/Project_Index.md` with 5 concise accepted items (replay session identity, track-length deltas, DTL pit-loss semantics, fuel-planner separation, rejoin alert linger) and per-item review dates. 
- Added a `Doc Authority & Freshness` block to `Docs/Project_Index.md` that names the canonical contract docs and explicitly states that `Docs/Code_Snapshot.md` is non-authoritative/stale unless regenerated. 
- Marked `Docs/Code_Snapshot.md` with a prominent banner `SNAPSHOT / GENERATED / NON-CANONICAL`, added source/commit, generated date, regeneration note, and a one-line stale-warning. 
- Standardised header blocks: updated `Docs/SimHubParameterInventory.md` to include `**CANONICAL CONTRACT**` plus `Validated against` / `Last reviewed` metadata and updated `Docs/SimHubLogMessages.md` to include `**CANONICAL OBSERVABILITY MAP**` plus `Last reviewed`. 
- Clarified `Docs/RepoStatus.md` Known/accepted limitations into a small intentional section and added a footer directing maintainers to mirror top items into `Project_Index.md`. 
- Added a short `**Subsystem doc**` header and `Last reviewed` timestamp to `Docs/Subsystems/Pit_Entry_Assist.md`. 
- Files changed: `Docs/Project_Index.md`, `Docs/Code_Snapshot.md`, `Docs/RepoStatus.md`, `Docs/SimHubParameterInventory.md`, `Docs/SimHubLogMessages.md`, `Docs/Subsystems/Pit_Entry_Assist.md`. 
- No code changes were made and no new technical behaviour was invented; nothing was marked as needing confirmation. 

### Testing
- This is a docs-only change; no automated tests were run and no runtime behaviour was modified. 
- Changes were validated by a repository text inspection to confirm header/section presence and consistent wording across the edited files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696770dc6270832fb35af2f181bdca42)