### PR TITLE
Clarify fuel tooltips, fix pit-loss wording, and add tooltip catalog

### DIFF
--- a/CopyProfileDialog.xaml
+++ b/CopyProfileDialog.xaml
@@ -13,23 +13,31 @@
         ResizeMode="NoResize">
     <Border BorderBrush="#555" BorderThickness="1" Padding="15">
         <StackPanel MinWidth="350">
-            <TextBlock Text="Source Profile:" Margin="0,0,0,2"/>
+            <TextBlock Text="Source Profile:" Margin="0,0,0,2"
+                       ToolTip="Profile you are copying from."/>
             <TextBlock x:Name="SourceProfileNameTextBlock" FontWeight="Bold" FontSize="14" Margin="0,0,0,15" Text="[Source Profile]"/>
 
-            <TextBlock Text="Select Destination Option:" FontWeight="Bold" Margin="0,0,0,10"/>
+            <TextBlock Text="Select Destination Option:" FontWeight="Bold" Margin="0,0,0,10"
+                       ToolTip="Choose whether to create a new profile or overwrite an existing one."/>
 
-            <RadioButton x:Name="CreateNewRadioButton" Content="Create a new profile from source" IsChecked="True" GroupName="Destination" Margin="0,0,0,5"/>
+            <RadioButton x:Name="CreateNewRadioButton" Content="Create a new profile from source" IsChecked="True" GroupName="Destination" Margin="0,0,0,5"
+                         ToolTip="Create a new profile using the source settings."/>
             <TextBox x:Name="NewProfileNameTextBox" Margin="20,0,0,15"
-                     IsEnabled="{Binding IsChecked, ElementName=CreateNewRadioButton}"/>
+                     IsEnabled="{Binding IsChecked, ElementName=CreateNewRadioButton}"
+                     ToolTip="Name for the new profile."/>
 
-            <RadioButton x:Name="CopyToExistingRadioButton" Content="Copy settings to an existing profile" GroupName="Destination" Margin="0,0,0,5"/>
+            <RadioButton x:Name="CopyToExistingRadioButton" Content="Copy settings to an existing profile" GroupName="Destination" Margin="0,0,0,5"
+                         ToolTip="Overwrite the selected existing profile with the source settings."/>
             <ComboBox x:Name="ExistingProfilesComboBox" Margin="20,0,0,20"
                       DisplayMemberPath="ProfileName"
-                      IsEnabled="{Binding IsChecked, ElementName=CopyToExistingRadioButton}"/>
+                      IsEnabled="{Binding IsChecked, ElementName=CopyToExistingRadioButton}"
+                      ToolTip="Choose which existing profile to overwrite."/>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <styles:SHButtonPrimary Content="OK" Width="80" Height="30" Margin="0,0,10,0" Click="OkButton_Click"/>
-                <styles:SHButtonSecondary Content="Cancel" Width="80" Height="30" IsCancel="True"/>
+                <styles:SHButtonPrimary Content="OK" Width="80" Height="30" Margin="0,0,10,0" Click="OkButton_Click"
+                                        ToolTip="Confirm the copy action."/>
+                <styles:SHButtonSecondary Content="Cancel" Width="80" Height="30" IsCancel="True"
+                                          ToolTip="Close without copying."/>
             </StackPanel>
         </StackPanel>
     </Border>

--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -23,15 +23,15 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="0,0,10,0">
-                        <ui:ControlsEditor ActionName="LalaLaunch.MsgCx" FriendlyName="Cancel Msg Button" />
-                        <ui:ControlsEditor ActionName="LalaLaunch.TogglePitScreen" FriendlyName="Toggle Pit Screen Popup" />
+                        <ui:ControlsEditor ActionName="LalaLaunch.MsgCx" FriendlyName="Cancel Msg Button" ToolTip="Assign a button to cancel the current popup message." />
+                        <ui:ControlsEditor ActionName="LalaLaunch.TogglePitScreen" FriendlyName="Toggle Pit Screen Popup" ToolTip="Assign a button to show or hide the pit screen popup." />
                         <ui:ControlsEditor ActionName="LalaLaunch.LaunchMode"
                        FriendlyName="Launch Mode" ToolTip="Manual prime/abort launch mode (useful for testing and non-standing-start sessions)." />
 
                     </StackPanel>
                     <StackPanel Grid.Column="1" Margin="0,0,0,0">
-                        <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode" FriendlyName="Change Primary Dash Mode" ToolTip="Used for Main Dash Functions like switching mode displays."/>
-                        <ui:ControlsEditor ActionName="LalaLaunch.SecondaryDashMode" FriendlyName="Change Secondary Dash Mode" ToolTip="Used for Sub Dash Functions like switching a widget display."/>
+                        <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode" FriendlyName="Change Primary Dash Mode" ToolTip="Assign a button to cycle primary dash modes (main screen views)." />
+                        <ui:ControlsEditor ActionName="LalaLaunch.SecondaryDashMode" FriendlyName="Change Secondary Dash Mode" ToolTip="Assign a button to cycle secondary dash modes (widgets/aux views)." />
                     </StackPanel>
                 </Grid>
                 <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" />
@@ -44,9 +44,12 @@
 
                     <StackPanel Grid.Column="0">
                         <TextBlock Text="GLOBAL DASH FUNCTIONS" FontSize="16" FontWeight="Bold" Margin="0,0,0,5"/>
-                        <styles:SHToggleCheckbox Content="Auto screen selection at session start" IsChecked="{Binding Settings.EnableAutoDashSwitch, Mode=TwoWay}" />
-                        <ui:TitledSlider Title="Post-Launch Results Display Time: " Minimum="0" Maximum="30" Value="{Binding Settings.ResultsDisplayTime, Mode=TwoWay}"/>
-                        <ui:TitledSlider Title="Fuel Ready Confidence: " Minimum="0" Maximum="100" Value="{Binding Settings.FuelReadyConfidence, Mode=TwoWay}"/>
+                        <styles:SHToggleCheckbox Content="Auto screen selection at session start" IsChecked="{Binding Settings.EnableAutoDashSwitch, Mode=TwoWay}"
+                                                 ToolTip="Automatically switch dash screens when a session starts based on context." />
+                        <ui:TitledSlider Title="Post-Launch Results Display Time: " Minimum="0" Maximum="30" Value="{Binding Settings.ResultsDisplayTime, Mode=TwoWay}"
+                                         ToolTip="How long the post-launch results screen stays visible (sec)." />
+                        <ui:TitledSlider Title="Fuel Ready Confidence: " Minimum="0" Maximum="100" Value="{Binding Settings.FuelReadyConfidence, Mode=TwoWay}"
+                                         ToolTip="Minimum confidence (%) before pit strategy uses live fuel. Below this, profile estimates may be used." />
                         <TextBlock
                             Text="Below 20%, profile fuel may be used for early estimates. Above 20%, pit strategy waits for live fuel data."
                             FontSize="11"
@@ -77,37 +80,61 @@
                         <TextBlock Text="MAIN DASH" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="1" />
                         <TextBlock Text="MESSAGE DASH" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="2" />
 
-                        <TextBlock Text="Show Launch Screen" Margin="0,5,0,0" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="2" />
+                        <TextBlock Text="Show Launch Screen" Margin="0,5,0,0" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable the Launch screen for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="1"
+                                                 ToolTip="Show the Launch screen on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="2"
+                                                 ToolTip="Show the Launch screen on the Message Dash." />
 
-                        <TextBlock Text="Show Pit Limiter Screen" Margin="0,5,0,0" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="2" />
+                        <TextBlock Text="Show Pit Limiter Screen" Margin="0,5,0,0" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable the Pit Limiter screen for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="1"
+                                                 ToolTip="Show the Pit Limiter screen on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="2"
+                                                 ToolTip="Show the Pit Limiter screen on the Message Dash." />
 
-                        <TextBlock Text="Show Automatic Pit Screen" Margin="0,5,0,0" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="2" />
+                        <TextBlock Text="Show Automatic Pit Screen" Margin="0,5,0,0" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable the automatic pit screen for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="1"
+                                                 ToolTip="Show the automatic pit screen on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="2"
+                                                 ToolTip="Show the automatic pit screen on the Message Dash." />
 
-                        <TextBlock Text="Show Track Rejoin Assist" Margin="0,5,0,0" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="2" />
+                        <TextBlock Text="Show Track Rejoin Assist" Margin="0,5,0,0" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable track rejoin assist for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="1"
+                                                 ToolTip="Show track rejoin assist on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="2"
+                                                 ToolTip="Show track rejoin assist on the Message Dash." />
 
-                        <TextBlock Text="Show Verbose Race Messages" Margin="0,5,0,0" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="2" />
+                        <TextBlock Text="Show Verbose Race Messages" Margin="0,5,0,0" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable detailed race messages for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="1"
+                                                 ToolTip="Show verbose race messages on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="2"
+                                                 ToolTip="Show verbose race messages on the Message Dash." />
 
-                        <TextBlock Text="Show Race Flags" Margin="0,5,0,0" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="2" />
+                        <TextBlock Text="Show Race Flags" Margin="0,5,0,0" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable race flag notifications for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="1"
+                                                 ToolTip="Show race flags on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="2"
+                                                 ToolTip="Show race flags on the Message Dash." />
 
-                        <TextBlock Text="Show Radio Messages" Margin="0,5,0,0" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="2" />
+                        <TextBlock Text="Show Radio Messages" Margin="0,5,0,0" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable radio message popups for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="1"
+                                                 ToolTip="Show radio messages on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="2"
+                                                 ToolTip="Show radio messages on the Message Dash." />
 
-                        <TextBlock Text="Show Traffic Alerts" Margin="0,5,0,0" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="1" />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="2" />
+                        <TextBlock Text="Show Traffic Alerts" Margin="0,5,0,0" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"
+                                   ToolTip="Enable traffic alert warnings for this dash type." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="1"
+                                                 ToolTip="Show traffic alerts on the Main Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="2"
+                                                 ToolTip="Show traffic alerts on the Message Dash." />
                     </Grid>
                 </Grid>
 
@@ -120,6 +147,7 @@
 
                     <styles:SHButtonPrimary Content="Save to Profile" Margin="15,0,0,0"
                                             Command="{Binding SaveActiveProfileCommand}"
+                                            ToolTip="Save the current dash user variables to this profile."
                                             Visibility="{Binding IsActiveProfileDirty, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                     <styles:SHButtonPrimary Content="Return to Defaults" Margin="5,0,0,0"
@@ -134,12 +162,18 @@
                     </Grid.ColumnDefinitions>
 
                     <StackPanel Grid.Column="0">
-                        <ui:TitledSlider Title="Rejoin Assist Linger Time (sec): " Minimum="1" Maximum="30" Value="{Binding ActiveProfile.RejoinWarningLingerTime, Mode=TwoWay}" />
-                        <ui:TitledSlider Title="Rejoin Assist Clear Speed (kph): " Minimum="10" Maximum="250" Value="{Binding ActiveProfile.RejoinWarningMinSpeed, Mode=TwoWay}" />
-                        <ui:TitledSlider Title="Spin Yaw Rate Threshold: " Minimum="10" Maximum="100" Value="{Binding ActiveProfile.SpinYawRateThreshold, Mode=TwoWay}" />
-                        <ui:TitledSlider Title="Overtake Alert activation (sec): " Minimum="1" Maximum="20" Value="{Binding ActiveProfile.TrafficApproachWarnSeconds, Mode=TwoWay}" />
-                        <ui:TitledSlider Title="Pit Entry Decel (m/s²): " Minimum="8" Maximum="22" Value="{Binding ActiveProfile.PitEntryDecelMps2, Mode=TwoWay}" />
-                        <ui:TitledSlider Title="Pit Entry Buffer (m): " Minimum="0" Maximum="40" Value="{Binding ActiveProfile.PitEntryBufferM, Mode=TwoWay}" />
+                        <ui:TitledSlider Title="Rejoin Assist Linger Time (sec): " Minimum="1" Maximum="30" Value="{Binding ActiveProfile.RejoinWarningLingerTime, Mode=TwoWay}"
+                                         ToolTip="How long the rejoin warning remains after you return to the track (sec)." />
+                        <ui:TitledSlider Title="Rejoin Assist Clear Speed (kph): " Minimum="10" Maximum="250" Value="{Binding ActiveProfile.RejoinWarningMinSpeed, Mode=TwoWay}"
+                                         ToolTip="Speed (kph) above which the rejoin warning clears automatically." />
+                        <ui:TitledSlider Title="Spin Yaw Rate Threshold: " Minimum="10" Maximum="100" Value="{Binding ActiveProfile.SpinYawRateThreshold, Mode=TwoWay}"
+                                         ToolTip="Yaw rate (deg/s) above which a spin is detected." />
+                        <ui:TitledSlider Title="Overtake Alert activation (sec): " Minimum="1" Maximum="20" Value="{Binding ActiveProfile.TrafficApproachWarnSeconds, Mode=TwoWay}"
+                                         ToolTip="Seconds to impact for an approaching car before an overtake alert triggers." />
+                        <ui:TitledSlider Title="Pit Entry Decel (m/s²): " Minimum="8" Maximum="22" Value="{Binding ActiveProfile.PitEntryDecelMps2, Mode=TwoWay}"
+                                         ToolTip="Target braking deceleration for pit entry assist (m/s²)." />
+                        <ui:TitledSlider Title="Pit Entry Buffer (m): " Minimum="0" Maximum="40" Value="{Binding ActiveProfile.PitEntryBufferM, Mode=TwoWay}"
+                                         ToolTip="Distance before pit entry to start the braking assist (m)." />
                     </StackPanel>
                 </Grid>
                 <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" />

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -1,0 +1,255 @@
+# Plugin UI Tooltips
+
+## CopyProfileDialog.xaml
+- L17: Profile you are copying from.
+- L21: Choose whether to create a new profile or overwrite an existing one.
+- L24: Create a new profile using the source settings.
+- L27: Name for the new profile.
+- L30: Overwrite the selected existing profile with the source settings.
+- L34: Choose which existing profile to overwrite.
+- L38: Confirm the copy action.
+- L40: Close without copying.
+
+## DashesTabView.xaml
+- L26: Assign a button to cancel the current popup message.
+- L27: Assign a button to show or hide the pit screen popup.
+- L29: Manual prime/abort launch mode (useful for testing and non-standing-start sessions).
+- L33: Assign a button to cycle primary dash modes (main screen views).
+- L34: Assign a button to cycle secondary dash modes (widgets/aux views).
+- L48: Automatically switch dash screens when a session starts based on context.
+- L50: How long the post-launch results screen stays visible (sec).
+- L52: Minimum confidence (%) before pit strategy uses live fuel. Below this, profile estimates may be used.
+- L84: Enable the Launch screen for this dash type.
+- L86: Show the Launch screen on the Main Dash.
+- L88: Show the Launch screen on the Message Dash.
+- L91: Enable the Pit Limiter screen for this dash type.
+- L93: Show the Pit Limiter screen on the Main Dash.
+- L95: Show the Pit Limiter screen on the Message Dash.
+- L98: Enable the automatic pit screen for this dash type.
+- L100: Show the automatic pit screen on the Main Dash.
+- L102: Show the automatic pit screen on the Message Dash.
+- L105: Enable track rejoin assist for this dash type.
+- L107: Show track rejoin assist on the Main Dash.
+- L109: Show track rejoin assist on the Message Dash.
+- L112: Enable detailed race messages for this dash type.
+- L114: Show verbose race messages on the Main Dash.
+- L116: Show verbose race messages on the Message Dash.
+- L119: Enable race flag notifications for this dash type.
+- L121: Show race flags on the Main Dash.
+- L123: Show race flags on the Message Dash.
+- L126: Enable radio message popups for this dash type.
+- L128: Show radio messages on the Main Dash.
+- L130: Show radio messages on the Message Dash.
+- L133: Enable traffic alert warnings for this dash type.
+- L135: Show traffic alerts on the Main Dash.
+- L137: Show traffic alerts on the Message Dash.
+- L150: Save the current dash user variables to this profile.
+- L155: Resets the view to the 'Default Settings' profile.
+- L166: How long the rejoin warning remains after you return to the track (sec).
+- L168: Speed (kph) above which the rejoin warning clears automatically.
+- L170: Yaw rate (deg/s) above which a spin is detected.
+- L172: Seconds to impact for an approaching car before an overtake alert triggers.
+- L174: Target braking deceleration for pit entry assist (m/s²).
+- L176: Distance before pit entry to start the braking assist (m).
+
+## FuelCalculatorView.xaml
+- L114: Inputs used to calculate the pre-race fuel plan.
+- L125: Use saved profile/track data for planning.
+- L130: Use live session data once confidence builds (may take a few laps).
+- L138: Live session snapshot used for planning when available. Confidence improves with more laps.
+- L190: Confidence in the live fuel/pace data. Low confidence may use profile estimates.
+- L195: Confidence builds with more clean laps; some fields stay locked until confident.
+- L247: Choose which car profile to use for planning.
+- L252: Select a car profile to plan a strategy for.
+- L255: Choose the track and layout for planning.
+- L260: Select the track and layout.
+- L268: Select dry or wet planning mode for this track.
+- L270: Plan using dry track data.
+- L272: Plan using wet track data and the wet factor.
+- L276: Scale fuel burn for wet running (%). Higher = higher burn.
+- L280: Apply the suggested wet factor from saved or live data.
+- L293: Average lap time used for strategy (m:ss.fff).
+- L296: Edit average lap time in m:ss.fff (used for strategy calculations).
+- L307: Data source hint for the lap time estimate.
+- L314: Live rolling average lap time.
+- L321: Saved average lap time from profile (condition aware).
+- L337: How many seconds slower your average lap time is compared to the race leader.
+- L359: Adjust the pace delta to the leader (sec) used in the plan.
+- L372: Replace the manual pace delta with the current live average.
+- L382: Limit the usable tank size for restricted fuel races (L).
+- L385: Limit the car's tank size for races with restricted fuel.
+- L414: Fuel burn per lap used for strategy (L/lap).
+- L417: Fuel burn per lap (L/lap). Edit to override the suggested value.
+- L452: Use the average fuel per lap saved in the selected profile.
+- L453: Use the most fuel-efficient lap stored in the selected profile.
+- L454: Use the highest recorded fuel per lap stored in the selected profile.
+- L474: Use the live rolling average fuel per lap.
+- L475: Use the most fuel-efficient lap observed in the current live session.
+- L476: Use the highest valid fuel per lap observed in the current live session.
+- L485: Live rolling average fuel per lap.
+- L486: Most efficient lap recorded in this session.
+- L487: Highest valid fuel per lap recorded in this session.
+- L513: Select a preset to apply.
+- L533: Choose whether the race is limited by laps or time.
+- L535: Plan for a fixed number of laps.
+- L537: Plan for a fixed race duration (minutes).
+- L541: Total race distance in laps.
+- L543: Total race duration in minutes.
+- L546: Fuel to reserve for formation or pace laps (L).
+- L551: Choose whether contingency is in laps or litres.
+- L553: Add extra laps of fuel as a safety margin.
+- L555: Add extra litres as a safety margin.
+- L558: Number of extra laps of fuel to add.
+- L560: Extra fuel to add as a safety margin (L).
+- L569: Force at least one pit stop. Stop time = Drive-Through Loss + Tyre Change Time (if any).
+- L580: Estimated pit lane loss per stop. Auto selection uses: drive-through loss, then direct pit entry-to-exit time, then the default.
+- L592: Additional stationary time if tyres are changed. Set to 0s for a drive-through-only stop.
+- L606: Reload the planner from the active profile and live session without clearing live samples.
+- L612: Save the current Race and Strategy parameters to the selected car/track profile.
+- L697: Fuel to save per lap (L/lap) for the simulator.
+- L702: Estimated time lost per lap when saving fuel (m:ss.fff).
+
+## LaunchAnalysisControl.xaml
+- L27: Select a launch trace file to review in this tab.
+- L33: Pick a trace file captured from a launch session.
+- L37: Reloads the list of files from the path specified in the Settings tab.
+- L41: Temporarily browse a different folder for launch trace files.
+- L46: WARNING: Permanently deletes the selected trace file from your disk.
+- L55: Auto-generated summary for the selected trace file.
+- L60: Raw telemetry samples for the selected trace file.
+- L78: Pick telemetry channels to plot below.
+- L89: Select the first telemetry channel to plot.
+- L94: Pick the telemetry channel for Plot 1.
+- L99: Select the second telemetry channel to plot.
+- L104: Pick the telemetry channel for Plot 2.
+- L114: When checked, scales each graph's Y-axis from its own min to max value (or 0-Max for RPM), making it easier to see the shape of the data. Uncheck to see the true values.
+- L154: Zoom the time window (sec) shown in the graphs.
+
+## LaunchPluginSettingsUI.xaml
+- L26: Save the current launch settings to this profile.
+- L31: Resets the view to the 'Default Settings' profile.
+- L34: Set your ideal engine speed for the moment the clutch bites.
+- L36: Allowed deviation (±RPM) from the target launch RPM before it is flagged.
+- L37: Set your ideal throttle for the moment the clutch bites.
+- L39: Allowed deviation (±%) from the target launch throttle before it is flagged.
+- L40: Set this to match your wheel setting for bite point.
+- L42: Allowed deviation (±%) around the bite point target.
+- L43: If the engine RPM drops below this percentage of the initial Launch RPM, the run will be flagged as 'Bogged'.
+- L44: Sets the sensitivity for detecting game-assisted anti-stall. % is delta between paddle and in game clutch.
+- L51: Location for the one-line launch summary CSV. Leave blank to use the default path shown.
+- L66: Enable or disable writing the one-line summary of each launch.
+- L70: Custom path for the summary CSV. Leave blank to use the default path.
+- L73: Browse for a summary CSV location.
+- L76: Location for detailed launch trace files used by the Launch Analysis tab. Leave blank to use the default path shown.
+- L91: Enable or disable creating detailed trace files for the 'LAUNCH ANALYSIS' tab.
+- L95: Custom path for launch trace files. Leave blank to use the default path.
+- L98: Browse for a launch trace folder.
+- L102: Enables verbose logging for troubleshooting the plugin.
+- L105: Adds PitExit math audit details to pit-in snapshots for troubleshooting.
+
+## PresetsManagerView.xaml
+- L34: Manage reusable race strategy presets.
+- L42: Create a new preset with default values.
+- L48: Delete the selected preset from disk.
+- L55: Select a preset to edit.
+- L112: Name shown in the preset list.
+- L137: Choose whether the race is limited by laps or time.
+- L143: Plan for a fixed number of laps.
+- L149: Plan for a fixed race duration (minutes).
+- L156: Total race duration in minutes.
+- L176: Total race distance in laps.
+- L199: Include at least one pit stop in the plan.
+- L206: Additional stop time when changing tyres (sec).
+- L212: Limit usable tank size for the preset (L).
+- L218: Choose whether contingency is in laps or litres.
+- L222: Add extra laps of fuel as a safety margin.
+- L226: Add extra litres as a safety margin.
+- L233: Number of extra laps of fuel to add.
+- L250: Extra fuel to add as a safety margin (L).
+- L276: Enter a preset name: use for Save Current or Rename
+- L283: Save current Fuel tab settings into a new preset name.
+- L289: Rename the selected preset using the name box.
+- L301: Revert edits to the last saved preset values.
+- L303: Save edits to the selected preset.
+
+## ProfilesManagerView.xaml
+- L22: Manage car profiles stored on disk.
+- L25: Create a new empty car profile.
+- L27: Copy the selected profile into another profile.
+- L29: Delete the selected profile from disk.
+- L32: Select the car profile to edit.
+- L38: Edit settings for the selected car profile.
+- L42: Rename the selected profile.
+- L46: Instantly copies these settings to the active car for this session.
+- L48: Saves all profiles to the JSON file.
+- L60: How long the rejoin warning remains visible after returning to the track (in seconds).
+- L70: The minimum speed (in km/h) above which the rejoin warning automatically clears.
+- L80: Yaw rate (degrees per second) above which a spin event is detected and triggers rejoin assist.
+- L90: How many seconds behind an approaching car must be projected to trigger the overtake alert.
+- L100: Target deceleration for pit entry braking assist (m/s²).
+- L110: Distance before the pit entry trigger point to start the braking assist.
+- L128: The target engine RPM to hold during launch control activation.
+- L138: Allowed deviation (±RPM) from the target launch RPM before the system flags it as out of range.
+- L148: Throttle percentage to apply when holding the launch RPM target.
+- L158: Accepted throttle percentage deviation from target before launch control gives a warning.
+- L168: Clutch engagement percentage considered the ideal bite point for launch.
+- L178: Allowed deviation (±%) around the target bite point during launch setup.
+- L188: Launch performance reduction factor to simulate clutch bog or wheel slip.
+- L198: Throttle or clutch percentage threshold below which an anti-stall warning is triggered.
+- L211: Default contingency amount added to fuel plans.
+- L213: Toggle whether the contingency value represents laps or litres.
+- L215: Fuel burn multiplier for wet conditions (%).
+- L222: How many seconds slower your average race pace is compared to your personal best lap (e.g., 1.2).
+- L229: Adjust the race pace delta used for planning (sec).
+- L242: Average refuel rate (L/s). Updates after a live refuel event if available.
+- L249: Set the refuel rate (L/s). Live refuel events can update this value.
+- L255: Base tank capacity for this car. Use Learn from Live to pull from live max fuel.
+- L265: Base tank size (L). Leave blank to use the default.
+- L270: Capture the current live max fuel as the base tank size.
+- L287: Tracks with saved data for this profile.
+- L290: Delete the selected track data from this profile.
+- L293: Select a track to edit its saved data.
+- L299: Edit saved data for the selected track.
+- L307: Pit lane loss and pit entry/exit markers for this track.
+- L342: Estimated pit lane loss per stop (sec). Updates from live pits when unlocked.
+- L348: Manual override for pit lane loss (sec).
+- L355: Lock to prevent live pit samples from overwriting this value.
+- L407: Saved pit entry marker as % of lap distance.
+- L417: Lock to prevent live marker updates from overwriting pit entry/exit values.
+- L423: Saved pit exit marker as % of lap distance.
+- L434: Last time these pit markers were updated.
+- L451: Reload LalaLaunch.TrackMarkers.json from disk (for manual edits).
+- L455: Clear pit markers and relearn them from the next live pit cycle.
+- L466: Dry-condition pace and fuel data for this track.
+- L493: Best dry lap time stored for this track.
+- L497: Manual override for best dry lap time (m:ss.fff).
+- L511: Average dry lap time used for planning (m:ss.fff).
+- L516: Manual override for average dry lap time (m:ss.fff).
+- L540: Dry fuel burn values used for planning (L/lap).
+- L548: Lowest observed dry fuel burn (L/lap).
+- L553: Manual override for dry ECO fuel burn (L/lap).
+- L561: Average observed dry fuel burn (L/lap).
+- L565: Manual override for dry AVG fuel burn (L/lap).
+- L573: Highest observed dry fuel burn (L/lap).
+- L577: Manual override for dry MAX fuel burn (L/lap).
+- L590: Number of dry fuel samples collected for this track.
+- L597: Last time dry fuel data was updated.
+- L608: Lock to prevent live dry data from overwriting these values.
+- L613: Clear dry data and relearn from new live laps (while unlocked).
+- L621: Wet-condition pace and fuel data for this track.
+- L648: Best wet lap time stored for this track.
+- L652: Manual override for best wet lap time (m:ss.fff).
+- L666: Average wet lap time used for planning (m:ss.fff).
+- L671: Manual override for average wet lap time (m:ss.fff).
+- L695: Wet fuel burn values used for planning (L/lap).
+- L703: Lowest observed wet fuel burn (L/lap).
+- L708: Manual override for wet ECO fuel burn (L/lap).
+- L716: Average observed wet fuel burn (L/lap).
+- L720: Manual override for wet AVG fuel burn (L/lap).
+- L728: Highest observed wet fuel burn (L/lap).
+- L732: Manual override for wet MAX fuel burn (L/lap).
+- L745: Number of wet fuel samples collected for this track.
+- L752: Last time wet fuel data was updated.
+- L763: Lock to prevent live wet data from overwriting these values.
+- L768: Clear wet data and relearn from new live laps (while unlocked).
+- L775: Computed deltas between wet and dry averages for this track.

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -110,7 +110,8 @@
 
                                 <TextBlock Grid.Column="0"
                                    Text="Car and Track Parameters"
-                                   FontWeight="Bold"/>
+                                   FontWeight="Bold"
+                                   ToolTip="Inputs used to calculate the pre-race fuel plan."/>
 
                                 <!-- Planning source selector (Profile / Live) -->
                                 <StackPanel Grid.Column="1"
@@ -120,18 +121,21 @@
                                     <RadioButton Content="Profile"
                                          IsChecked="{Binding IsPlanningSourceProfile, Mode=TwoWay}"
                                          GroupName="PlanningSourceMode"
-                                         Margin="0,0,8,0"/>
+                                         Margin="0,0,8,0"
+                                         ToolTip="Use saved profile/track data for planning."/>
                                     <RadioButton Content="Live snapshot"
                                          IsChecked="{Binding IsPlanningSourceLiveSnapshot, Mode=TwoWay}"
                                          GroupName="PlanningSourceMode"
-                                         IsEnabled="{Binding CanSelectLiveSnapshot}"/>
+                                         IsEnabled="{Binding CanSelectLiveSnapshot}"
+                                         ToolTip="Use live session data once confidence builds (may take a few laps)."/>
                                 </StackPanel>
                             </Grid>
                             <!-- Live session telemetry, styled like LAUNCH SUMMARY on Post-Launch tab -->
                             <styles:SHExpander Grid.Row="1"
                                Header="{Binding LiveSessionHeader}"
                                IsExpanded="{Binding IsLiveSessionSnapshotExpanded}"
-                               Margin="0,0,0,10">
+                               Margin="0,0,0,10"
+                               ToolTip="Live session snapshot used for planning when available. Confidence improves with more laps.">
 
                                 <Grid Margin="5">
                                     <Grid.ColumnDefinitions>
@@ -182,11 +186,13 @@
                                        Style="{StaticResource SnapshotValueStyle}" />
                                     <TextBlock Grid.Row="5" Grid.Column="0"
                                        Text="Data Confidence"
-                                       Style="{StaticResource SnapshotLabelStyle}" />
+                                       Style="{StaticResource SnapshotLabelStyle}"
+                                       ToolTip="Confidence in the live fuel/pace data. Low confidence may use profile estimates." />
                                     <TextBlock Grid.Row="5" Grid.Column="1"
                                        Text="{Binding LiveConfidenceSummary}"
                                        Style="{StaticResource SnapshotValueStyle}"
-                                       TextWrapping="Wrap" />
+                                       TextWrapping="Wrap"
+                                       ToolTip="Confidence builds with more clean laps; some fields stay locked until confident." />
                                     <TextBlock Grid.Row="6" Grid.Column="0"
                                        Text="Wet Lap Times"
                                        Style="{StaticResource SnapshotLabelStyle}"
@@ -237,14 +243,16 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Car Profile:"
-                                        VerticalAlignment="Center" Margin="0,0,8,0" FontWeight="Bold"/>
+                                        VerticalAlignment="Center" Margin="0,0,8,0" FontWeight="Bold"
+                                        ToolTip="Choose which car profile to use for planning."/>
                                     <ComboBox  Grid.Row="0" Grid.Column="1" Width="300" Margin="0,0,0,6"
                                          ItemsSource="{Binding AvailableCarProfiles}"
                                          SelectedItem="{Binding SelectedCarProfile, Mode=TwoWay}"
                                          DisplayMemberPath="ProfileName"
                                          ToolTip="Select a car profile to plan a strategy for."/>
                                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Track:"
-                                        VerticalAlignment="Center" Margin="0,0,8,0" FontWeight="Bold"/>
+                                        VerticalAlignment="Center" Margin="0,0,8,0" FontWeight="Bold"
+                                        ToolTip="Choose the track and layout for planning."/>
                                     <ComboBox  Grid.Row="1" Grid.Column="1" Width="Auto"
                                          ItemsSource="{Binding AvailableTrackStats}"
                                          DisplayMemberPath="DisplayName"
@@ -256,15 +264,20 @@
                             <!-- Track condition (Profile planning only) -->
                             <StackPanel Grid.Row="3" Margin="0,5,0,5">
                                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                                    <TextBlock Text="Track Condition:" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                    <RadioButton Content="Dry" IsChecked="{Binding IsDry, Mode=TwoWay}" GroupName="TrackCondition"/>
-                                    <RadioButton Content="Wet" IsChecked="{Binding IsWet, Mode=TwoWay}" GroupName="TrackCondition" Margin="10,0,0,0"/>
+                                    <TextBlock Text="Track Condition:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                               ToolTip="Select dry or wet planning mode for this track."/>
+                                    <RadioButton Content="Dry" IsChecked="{Binding IsDry, Mode=TwoWay}" GroupName="TrackCondition"
+                                                 ToolTip="Plan using dry track data."/>
+                                    <RadioButton Content="Wet" IsChecked="{Binding IsWet, Mode=TwoWay}" GroupName="TrackCondition" Margin="10,0,0,0"
+                                                 ToolTip="Plan using wet track data and the wet factor."/>
                                 </StackPanel>
                                 <TextBlock Text="{Binding TrackConditionModeLabel}" Style="{StaticResource UnitHint}" Margin="2,2,0,0" />
-                                <ui:TitledSlider Title="Wet Factor (%):" Minimum="70" Maximum="130" Value="{Binding WetFactorPercent, Mode=TwoWay}" Visibility="{Binding IsWet, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" Margin="0,5,0,0"/>
+                                <ui:TitledSlider Title="Wet Factor (%):" Minimum="70" Maximum="130" Value="{Binding WetFactorPercent, Mode=TwoWay}" Visibility="{Binding IsWet, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" Margin="0,5,0,0"
+                                                 ToolTip="Scale fuel burn for wet running (%). Higher = higher burn."/>
                                 <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Visibility="{Binding IsWet, Converter={StaticResource BooleanToVisibilityConverter}}">
                                     <TextBlock Text="{Binding SourceWetFactorDisplay}" Style="{StaticResource UnitHint}" VerticalAlignment="Center" Visibility="{Binding HasSourceWetFactor, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                    <Button Content="Use source" Command="{Binding ApplySourceWetFactorCommand}" Margin="10,0,0,0" Visibility="{Binding HasSourceWetFactor, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                    <Button Content="Use source" Command="{Binding ApplySourceWetFactorCommand}" Margin="10,0,0,0" Visibility="{Binding HasSourceWetFactor, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            ToolTip="Apply the suggested wet factor from saved or live data."/>
                                 </StackPanel>
                             </StackPanel>
 
@@ -276,9 +289,11 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
 
-                                <TextBlock Grid.Column="0" Text="Avg Lap Time:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                <TextBlock Grid.Column="0" Text="Avg Lap Time:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                           ToolTip="Average lap time used for strategy (m:ss.fff)." />
 
-                                <TextBox Grid.Column="1" VerticalAlignment="Center" Width="60" HorizontalAlignment="Left">
+                                <TextBox Grid.Column="1" VerticalAlignment="Center" Width="60" HorizontalAlignment="Left"
+                                         ToolTip="Edit average lap time in m:ss.fff (used for strategy calculations).">
                                     <TextBox.Text>
                                         <Binding Path="EstimatedLapTime" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                             <Binding.ValidationRules>
@@ -288,7 +303,8 @@
                                     </TextBox.Text>
                                 </TextBox>
 
-                                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0">
+                                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0"
+                                            ToolTip="Data source hint for the lap time estimate.">
                                     <TextBlock Text="{Binding LapTimeSourceInfo}" VerticalAlignment="Center"/>
                                     <TextBlock Text="{Binding LiveLapPaceInfo, StringFormat=Live avg: {0}}"
                                        Foreground="Gray"
@@ -339,7 +355,8 @@
               Margin="0,2,0,0"
               Minimum="0" Maximum="5"
               SmallChange="0.1" TickFrequency="0.1"
-              IsSnapToTickEnabled="True" />
+              IsSnapToTickEnabled="True"
+              ToolTip="Adjust the pace delta to the leader (sec) used in the plan." />
 
                                     <TextBlock Grid.Column="1"
                 Text="{Binding LeaderDeltaSeconds, StringFormat=N1}"
@@ -352,6 +369,7 @@
                         Content="Reset to live"
                         Command="{Binding ResetLeaderDeltaToLiveCommand}"
                         Margin="8,0,0,0"
+                        ToolTip="Replace the manual pace delta with the current live average."
                         Visibility="{Binding IsLeaderDeltaManual, Converter={StaticResource BoolToVisibilityConverter}}" />
                                 </Grid>
                             </Grid>
@@ -360,7 +378,8 @@
 
                         <StackPanel Grid.Row="6" Margin="0,15,0,0">
                             <Grid Margin="0,0,0,4">
-                                <TextBlock Text="Max Fuel Override (litres):" VerticalAlignment="Center"/>
+                                <TextBlock Text="Max Fuel Override (litres):" VerticalAlignment="Center"
+                                           ToolTip="Limit the usable tank size for restricted fuel races (L)." />
                             </Grid>
 
                             <ui:TitledSlider Title="" Minimum="0" Maximum="{Binding MaxFuelOverrideMaximum}" Value="{Binding MaxFuelOverride, Mode=TwoWay}" ToolTip="Limit the car's tank size for races with restricted fuel." IsEnabled="{Binding IsPlanningSourceProfile}">
@@ -391,9 +410,11 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Fuel per Lap:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Fuel per Lap:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                       ToolTip="Fuel burn per lap used for strategy (L/lap)." />
 
-                            <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Width="50" HorizontalAlignment="Left" Text="{Binding FuelPerLapText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Width="50" HorizontalAlignment="Left" Text="{Binding FuelPerLapText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     ToolTip="Fuel burn per lap (L/lap). Edit to override the suggested value." />
 
                             <TextBlock Grid.Row="0" Grid.Column="2" Margin="10,0,0,0" VerticalAlignment="Center">
                                 <TextBlock.Style>
@@ -508,24 +529,35 @@
 
 
                         <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
-                            <TextBlock Text="Race Type:" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                            <RadioButton Content="Lap-Limited" IsChecked="{Binding IsLapLimitedRace, Mode=TwoWay}" GroupName="RaceType"/>
-                            <RadioButton Content="Time-Limited" IsChecked="{Binding IsTimeLimitedRace, Mode=TwoWay}" GroupName="RaceType" Margin="10,0,0,0"/>
+                            <TextBlock Text="Race Type:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                       ToolTip="Choose whether the race is limited by laps or time."/>
+                            <RadioButton Content="Lap-Limited" IsChecked="{Binding IsLapLimitedRace, Mode=TwoWay}" GroupName="RaceType"
+                                         ToolTip="Plan for a fixed number of laps."/>
+                            <RadioButton Content="Time-Limited" IsChecked="{Binding IsTimeLimitedRace, Mode=TwoWay}" GroupName="RaceType" Margin="10,0,0,0"
+                                         ToolTip="Plan for a fixed race duration (minutes)."/>
                         </StackPanel>
 
-                        <ui:TitledSlider Title="Race Laps:" Minimum="1" Maximum="500" Value="{Binding RaceLaps, Mode=TwoWay}" Visibility="{Binding IsLapLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
-                        <ui:TitledSlider Title="Race Minutes:" Minimum="10" Maximum="1440" Value="{Binding RaceMinutes, Mode=TwoWay}" Visibility="{Binding IsTimeLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
+                        <ui:TitledSlider Title="Race Laps:" Minimum="1" Maximum="500" Value="{Binding RaceLaps, Mode=TwoWay}" Visibility="{Binding IsLapLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                                         ToolTip="Total race distance in laps."/>
+                        <ui:TitledSlider Title="Race Minutes:" Minimum="10" Maximum="1440" Value="{Binding RaceMinutes, Mode=TwoWay}" Visibility="{Binding IsTimeLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                                         ToolTip="Total race duration in minutes."/>
 
-                        <ui:TitledSlider Title="Formation Lap Fuel (liters):" Minimum="0" Maximum="10" Value="{Binding FormationLapFuelLiters, Mode=TwoWay}" Margin="0,10,0,0"/>
+                        <ui:TitledSlider Title="Formation Lap Fuel (liters):" Minimum="0" Maximum="10" Value="{Binding FormationLapFuelLiters, Mode=TwoWay}" Margin="0,10,0,0"
+                                         ToolTip="Fuel to reserve for formation or pace laps (L)." />
 
                         <StackPanel Margin="0,10,0,0">
                             <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
-                                <TextBlock Text="Contingency Type:" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                <RadioButton Content="Extra Laps" IsChecked="{Binding IsContingencyInLaps, Mode=TwoWay}" GroupName="ContingencyType"/>
-                                <RadioButton Content="Extra Litres" IsChecked="{Binding IsContingencyLitres, Mode=TwoWay}" GroupName="ContingencyType" Margin="10,0,0,0"/>
+                                <TextBlock Text="Contingency Type:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                           ToolTip="Choose whether contingency is in laps or litres."/>
+                                <RadioButton Content="Extra Laps" IsChecked="{Binding IsContingencyInLaps, Mode=TwoWay}" GroupName="ContingencyType"
+                                             ToolTip="Add extra laps of fuel as a safety margin."/>
+                                <RadioButton Content="Extra Litres" IsChecked="{Binding IsContingencyLitres, Mode=TwoWay}" GroupName="ContingencyType" Margin="10,0,0,0"
+                                             ToolTip="Add extra litres as a safety margin."/>
                             </StackPanel>
-                            <ui:TitledSlider Title="Contingency Laps:" Minimum="0" Maximum="5" Value="{Binding ContingencyValue, Mode=TwoWay}" Visibility="{Binding IsContingencyInLaps, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
-                            <ui:TitledSlider Title="Contingency Litres:" Minimum="0" Maximum="20" Value="{Binding ContingencyValue, Mode=TwoWay}" Visibility="{Binding IsContingencyLitres, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
+                            <ui:TitledSlider Title="Contingency Laps:" Minimum="0" Maximum="5" Value="{Binding ContingencyValue, Mode=TwoWay}" Visibility="{Binding IsContingencyInLaps, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                                             ToolTip="Number of extra laps of fuel to add."/>
+                            <ui:TitledSlider Title="Contingency Litres:" Minimum="0" Maximum="20" Value="{Binding ContingencyValue, Mode=TwoWay}" Visibility="{Binding IsContingencyLitres, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                                             ToolTip="Extra fuel to add as a safety margin (L)." />
                         </StackPanel>
                         <!-- Pit Strategy: header + checkbox on one line -->
                         <StackPanel Orientation="Horizontal" Margin="0,10,0,6">
@@ -545,7 +577,7 @@
                             Margin="0,0,0,6">
                             <ui:TitledSlider.ToolTip>
                                 <ToolTip>
-                                    <TextBlock Text="Total pit lane delta per stop (In Lap and Out Lap deltas to Average Lap.)."
+                                    <TextBlock Text="Estimated pit lane loss per stop. Auto selection uses: drive-through loss, then direct pit entry-to-exit time, then the default."
                                         TextWrapping="Wrap" Width="260"/>
                                 </ToolTip>
                             </ui:TitledSlider.ToolTip>
@@ -557,7 +589,7 @@
                             Value="{Binding TireChangeTime, Mode=TwoWay}">
                             <ui:TitledSlider.ToolTip>
                                 <ToolTip>
-                                    <TextBlock Text="Additional time if tyres are changed. Set to 0s for a drive-through-only stop."
+                                    <TextBlock Text="Additional stationary time if tyres are changed. Set to 0s for a drive-through-only stop."
                                         TextWrapping="Wrap" Width="260"/>
                                 </ToolTip>
                             </ui:TitledSlider.ToolTip>
@@ -661,11 +693,13 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Fuel Save Target (L/Lap):" VerticalAlignment="Center" Margin="0,0,10,0" Grid.Column="0"/>
-                                <Slider Grid.Column="1" VerticalAlignment="Center" Value="{Binding FuelSaveTarget, Mode=TwoWay}" Minimum="0" Maximum="1.0" SmallChange="0.05" TickFrequency="0.05" IsSnapToTickEnabled="True" />
+                                <Slider Grid.Column="1" VerticalAlignment="Center" Value="{Binding FuelSaveTarget, Mode=TwoWay}" Minimum="0" Maximum="1.0" SmallChange="0.05" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                        ToolTip="Fuel to save per lap (L/lap) for the simulator." />
                                 <TextBlock Grid.Column="2" Text="{Binding FuelSaveTarget, StringFormat=N2}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
                             </Grid>
                             <TextBlock Text="Est. Time Loss per Lap (m:ss.fff):" Margin="0,10,0,2"/>
-                            <TextBox Text="{Binding TimeLossPerLapOfFuelSave, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBox Text="{Binding TimeLossPerLapOfFuelSave, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     ToolTip="Estimated time lost per lap when saving fuel (m:ss.fff)." />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Margin="15,0,0,0" VerticalAlignment="Center">
                             <TextBlock FontSize="14" Margin="0,0,0,5"><Run Text="Pit Stops Saved: "/><Run Text="{Binding StopsSaved, Mode=OneWay}" FontWeight="Bold"/></TextBlock>

--- a/LaunchAnalysisControl.xaml
+++ b/LaunchAnalysisControl.xaml
@@ -23,12 +23,14 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock Grid.Column="0" Text="TRACE FILE SELECTION" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <TextBlock Grid.Column="0" Text="TRACE FILE SELECTION" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
+                               ToolTip="Select a launch trace file to review in this tab."/>
 
                     <ComboBox Grid.Column="1" x:Name="FileComboBox" 
                       VerticalAlignment="Center"
                       ItemsSource="{Binding AvailableTraceFiles}"
-                      SelectedItem="{Binding SelectedFilePath, Mode=TwoWay}" />
+                      SelectedItem="{Binding SelectedFilePath, Mode=TwoWay}"
+                      ToolTip="Pick a trace file captured from a launch session." />
 
                     <styles:SHButtonPrimary Grid.Column="2" x:Name="RefreshButton"
                                 Content="Refresh File List" Width="120" Margin="10,0,0,0" 
@@ -49,11 +51,13 @@
             </StackPanel>
 
             <!-- Summary + Raw Telemetry -->
-            <styles:SHExpander Header="LAUNCH SUMMARY" IsExpanded="True">
+            <styles:SHExpander Header="LAUNCH SUMMARY" IsExpanded="True"
+                               ToolTip="Auto-generated summary for the selected trace file.">
                 <Grid x:Name="SummaryGrid" Margin="10" />
             </styles:SHExpander>
 
-            <styles:SHExpander Header="RAW TELEMETRY DATA" IsExpanded="False">
+            <styles:SHExpander Header="RAW TELEMETRY DATA" IsExpanded="False"
+                               ToolTip="Raw telemetry samples for the selected trace file.">
                 <DataGrid x:Name="RawTelemetryGrid"
                           ItemsSource="{Binding RawTelemetryData}"
                           AutoGenerateColumns="True"
@@ -70,7 +74,8 @@
                    DockPanel.Dock="Left" 
                    FontWeight="Bold" 
                    VerticalAlignment="Center" 
-                   Margin="0,0,15,0"/>
+                   Margin="0,0,15,0"
+                   ToolTip="Pick telemetry channels to plot below."/>
 
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -80,19 +85,23 @@
 
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
 
-                            <TextBlock Text="Plot 1:" VerticalAlignment="Center" Margin="0,0,5,0" />
+                            <TextBlock Text="Plot 1:" VerticalAlignment="Center" Margin="0,0,5,0"
+                                       ToolTip="Select the first telemetry channel to plot." />
                             <Grid Width="200">
                                 <ComboBox ItemsSource="{Binding PlottableProperties}"
                                           SelectedItem="{Binding SelectedPlotProperty, Mode=TwoWay}"
-                                          VerticalAlignment="Center" />
+                                          VerticalAlignment="Center"
+                                          ToolTip="Pick the telemetry channel for Plot 1." />
                                 <Border Height="3" Background="LightBlue" VerticalAlignment="Bottom" Margin="0,2,0,0" CornerRadius="1.5" />
                             </Grid>
 
-                            <TextBlock Text="Plot 2:" VerticalAlignment="Center" Margin="20,0,5,0" />
+                            <TextBlock Text="Plot 2:" VerticalAlignment="Center" Margin="20,0,5,0"
+                                       ToolTip="Select the second telemetry channel to plot." />
                             <Grid Width="200">
                                 <ComboBox ItemsSource="{Binding PlottableProperties}"
                                           SelectedItem="{Binding SelectedPlotProperty2, Mode=TwoWay}"
-                                          VerticalAlignment="Center" />
+                                          VerticalAlignment="Center"
+                                          ToolTip="Pick the telemetry channel for Plot 2." />
                                 <Border Height="3" Background="OrangeRed" VerticalAlignment="Bottom" Margin="0,2,0,0" CornerRadius="1.5" />
                             </Grid>
 
@@ -141,7 +150,8 @@
                       Maximum="{Binding SliderMaximum}"
                       LowerValue="{Binding SliderMinTime, Mode=TwoWay}"
                       UpperValue="{Binding SliderMaxTime, Mode=TwoWay}"
-                      Margin="0,15,0,0"/>
+                      Margin="0,15,0,0"
+                      ToolTip="Zoom the time window (sec) shown in the graphs."/>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -23,6 +23,7 @@
 
                         <styles:SHButtonPrimary Content="Save to Profile" Margin="15,0,0,0"
                                                 Command="{Binding SaveActiveProfileCommand}"
+                                                ToolTip="Save the current launch settings to this profile."
                                                 Visibility="{Binding IsActiveProfileDirty, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                         <styles:SHButtonPrimary Content="Return to Defaults" Margin="5,0,0,0"
@@ -31,11 +32,14 @@
                                                 Visibility="{Binding CanReturnToDefaults, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                     </StackPanel>
                     <ui:TitledSlider Title="Target Launch RPM" Minimum="1000" Maximum="10000" Value="{Binding ActiveProfile.TargetLaunchRPM, Mode=TwoWay}" ToolTip="Set your ideal engine speed for the moment the clutch bites."/>
-                    <ui:TitledSlider Title="Optimal RPM Tolerance" Minimum="100" Maximum="2000" Value="{Binding ActiveProfile.OptimalRPMTolerance, Mode=TwoWay}" />
+                    <ui:TitledSlider Title="Optimal RPM Tolerance" Minimum="100" Maximum="2000" Value="{Binding ActiveProfile.OptimalRPMTolerance, Mode=TwoWay}"
+                                     ToolTip="Allowed deviation (±RPM) from the target launch RPM before it is flagged." />
                     <ui:TitledSlider Title="Target Launch Throttle (%)" Minimum="1" Maximum="100" Value="{Binding ActiveProfile.TargetLaunchThrottle, Mode=TwoWay}" ToolTip="Set your ideal throttle for the moment the clutch bites."/>
-                    <ui:TitledSlider Title="Optimal Throttle Tolerance (%)" Minimum="0" Maximum="20" Value="{Binding ActiveProfile.OptimalThrottleTolerance, Mode=TwoWay}" />
+                    <ui:TitledSlider Title="Optimal Throttle Tolerance (%)" Minimum="0" Maximum="20" Value="{Binding ActiveProfile.OptimalThrottleTolerance, Mode=TwoWay}"
+                                     ToolTip="Allowed deviation (±%) from the target launch throttle before it is flagged." />
                     <ui:TitledSlider Title="Target Bite Point (%)" Minimum="0" Maximum="100" Value="{Binding ActiveProfile.TargetBitePoint, Mode=TwoWay}" ToolTip="Set this to match your wheel setting for bite point."/>
-                    <ui:TitledSlider Title="Bite Point Tolerance (%)" Minimum="1" Maximum="10" Value="{Binding ActiveProfile.BitePointTolerance, Mode=TwoWay}" />
+                    <ui:TitledSlider Title="Bite Point Tolerance (%)" Minimum="1" Maximum="10" Value="{Binding ActiveProfile.BitePointTolerance, Mode=TwoWay}"
+                                     ToolTip="Allowed deviation (±%) around the bite point target." />
                     <ui:TitledSlider Title="Bog Down Factor (%)" Minimum="0" Maximum="100" Value="{Binding ActiveProfile.BogDownFactorPercent, Mode=TwoWay}" ToolTip="If the engine RPM drops below this percentage of the initial Launch RPM, the run will be flagged as 'Bogged'."/>
                     <ui:TitledSlider Title="Anti-Stall Alert Threshold (%)" Minimum="0" Maximum="100" Value="{Binding ActiveProfile.AntiStallThreshold, Mode=TwoWay}" ToolTip="Sets the sensitivity for detecting game-assisted anti-stall. % is delta between paddle and in game clutch."/>
                 </StackPanel>
@@ -43,7 +47,8 @@
 
             <styles:SHSection Title="TELEMETRY LOGGING SETTINGS" ShowSeparator="True">
                 <StackPanel>
-                    <TextBlock Margin="0,5,0,2" Foreground="LightGray">
+                    <TextBlock Margin="0,5,0,2" Foreground="LightGray"
+                               ToolTip="Location for the one-line launch summary CSV. Leave blank to use the default path shown.">
                         <TextBlock.Text>
                             <MultiBinding StringFormat="{}Main Summary CSV Path (Leave blank for default: {0})">
                                 <Binding ElementName="SettingsPage" Path="DefaultSummaryLogPath" Mode="OneWay"/>
@@ -61,11 +66,14 @@
                                                  ToolTip="Enable or disable writing the one-line summary of each launch."/>
                         <TextBox Grid.Column="1" x:Name="CsvPathTextBox" 
                                  Text="{Binding Settings.CsvLogPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                 VerticalAlignment="Center" />
+                                 VerticalAlignment="Center"
+                                 ToolTip="Custom path for the summary CSV. Leave blank to use the default path." />
                         <styles:SHButtonPrimary Grid.Column="2" Content="Browse..." Margin="5,0,0,0"
-                                                Tag="{Binding ElementName=CsvPathTextBox}" Click="BrowseButton_Click"/>
+                                                Tag="{Binding ElementName=CsvPathTextBox}" Click="BrowseButton_Click"
+                                                ToolTip="Browse for a summary CSV location."/>
                     </Grid>
-                    <TextBlock Margin="0,15,0,2" Foreground="LightGray">
+                    <TextBlock Margin="0,15,0,2" Foreground="LightGray"
+                               ToolTip="Location for detailed launch trace files used by the Launch Analysis tab. Leave blank to use the default path shown.">
                         <TextBlock.Text>
                             <MultiBinding StringFormat="{}Detailed Trace Files Path (Leave blank for default: {0})">
                                 <Binding ElementName="SettingsPage" Path="DefaultTraceLogPath" Mode="OneWay"/>
@@ -83,9 +91,11 @@
                                                  ToolTip="Enable or disable creating detailed trace files for the 'LAUNCH ANALYSIS' tab."/>
                         <TextBox Grid.Column="1" x:Name="TracePathTextBox" 
                                  Text="{Binding Settings.TraceLogPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                 VerticalAlignment="Center" />
+                                 VerticalAlignment="Center"
+                                 ToolTip="Custom path for launch trace files. Leave blank to use the default path." />
                         <styles:SHButtonPrimary Grid.Column="2" Content="Browse..." Margin="5,0,0,0" 
-                                                Tag="{Binding ElementName=TracePathTextBox}" Click="BrowseButton_Click"/>
+                                                Tag="{Binding ElementName=TracePathTextBox}" Click="BrowseButton_Click"
+                                                ToolTip="Browse for a launch trace folder."/>
                     </Grid>
                     <styles:SHToggleCheckbox Content="Enable Debug Logging" Margin="0,20,0,0"
                                              IsChecked="{Binding Settings.EnableDebugLogging, Mode=TwoWay}" 

--- a/PresetsManagerView.xaml
+++ b/PresetsManagerView.xaml
@@ -30,25 +30,29 @@
             <TextBlock DockPanel.Dock="Top"
              Text="Race Presets"
              FontSize="16" FontWeight="Bold"
-             Margin="0,0,0,10"/>
+             Margin="0,0,0,10"
+             ToolTip="Manage reusable race strategy presets."/>
 
             <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">
                 <styles:SHButtonPrimary Content="Create New Preset"
                             Height="30"
                             Click="OnCreateNewPreset"
                             Background="#28A745" Foreground="White"
-                            HorizontalAlignment="Stretch" Margin="0,0,0,6"/>
+                            HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                            ToolTip="Create a new preset with default values."/>
                 <styles:SHButtonSecondary Content="Delete Current Preset"
                               Height="30"
                               Click="OnDeletePreset"
                               Background="#C82333" Foreground="White"
-                              HorizontalAlignment="Stretch"/>
+                              HorizontalAlignment="Stretch"
+                              ToolTip="Delete the selected preset from disk."/>
             </StackPanel>
 
             <ListBox ItemsSource="{Binding AvailablePresets}"
                  SelectedItem="{Binding EditorSelection, ElementName=Root, Mode=TwoWay}"
                  DisplayMemberPath="Name"
-                 BorderThickness="1" BorderBrush="Gray"/>
+                 BorderThickness="1" BorderBrush="Gray"
+                 ToolTip="Select a preset to edit."/>
         </DockPanel>
 
         <!-- RIGHT: split into scrollable editor (row 0) and sticky footer (row 1) -->
@@ -104,7 +108,8 @@
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="Preset Name:" VerticalAlignment="Center" FontWeight="Bold"/>
                         <TextBox Grid.Column="1"
-                     Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                     Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     ToolTip="Name shown in the preset list."/>
                         <TextBlock Grid.Column="2"
                                    Text="{Binding ActivePresetHelperText, ElementName=Root}"
                                    VerticalAlignment="Center"
@@ -128,23 +133,27 @@
 
                     <!-- Race Type -->
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                        <TextBlock Text="Race Type:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                        <TextBlock Text="Race Type:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                   ToolTip="Choose whether the race is limited by laps or time."/>
                         <RadioButton Content="Lap-Limited"
                          IsChecked="{Binding EditingPreset.Type, ElementName=Root,
                                              Converter={StaticResource EnumEqualsConverter},
                                              ConverterParameter=LapLimited, Mode=TwoWay}"
-                         GroupName="RaceType"/>
+                         GroupName="RaceType"
+                         ToolTip="Plan for a fixed number of laps."/>
                         <RadioButton Content="Time-Limited" Margin="10,0,0,0"
                          IsChecked="{Binding EditingPreset.Type, ElementName=Root,
                                              Converter={StaticResource EnumEqualsConverter},
                                              ConverterParameter=TimeLimited, Mode=TwoWay}"
-                         GroupName="RaceType"/>
+                         GroupName="RaceType"
+                         ToolTip="Plan for a fixed race duration (minutes)."/>
                     </StackPanel>
 
                     <!-- Race Minutes (only when Time-Limited) -->
                     <ui:TitledSlider Title="Race Minutes:"
                            Minimum="1" Maximum="1440"
-                           Value="{Binding RaceMinutes, Mode=TwoWay}">
+                           Value="{Binding RaceMinutes, Mode=TwoWay}"
+                           ToolTip="Total race duration in minutes.">
                         <ui:TitledSlider.Style>
                             <Style TargetType="{x:Type ui:TitledSlider}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -163,7 +172,8 @@
                     <!-- Race Laps (only when Lap-Limited) -->
                     <ui:TitledSlider Title="Race Laps:"
                            Minimum="1" Maximum="1000"
-                           Value="{Binding RaceLaps, Mode=TwoWay}">
+                           Value="{Binding RaceLaps, Mode=TwoWay}"
+                           ToolTip="Total race distance in laps.">
                         <ui:TitledSlider.Style>
                             <Style TargetType="{x:Type ui:TitledSlider}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -185,35 +195,42 @@
                         <CheckBox Content="Mandatory pit stop required"
                       Margin="16,0,0,0"
                       VerticalAlignment="Center"
-                      IsChecked="{Binding MandatoryStopRequired, Mode=TwoWay}"/>
+                      IsChecked="{Binding MandatoryStopRequired, Mode=TwoWay}"
+                      ToolTip="Include at least one pit stop in the plan."/>
                     </StackPanel>
 
                     <!-- Tyre Change Time (s) -->
                     <ui:TitledSlider Title="Tyre Change Time (s):"
                            Minimum="0" Maximum="60"
-                           Value="{Binding TireChangeTimeSec, Mode=TwoWay}"/>
+                           Value="{Binding TireChangeTimeSec, Mode=TwoWay}"
+                           ToolTip="Additional stop time when changing tyres (sec)."/>
 
                     <!-- Max Fuel Override (litres) -->
                     <ui:TitledSlider Title="Max Fuel Override (litres):"
                            Minimum="0" Maximum="150"
-                           Value="{Binding MaxFuelLitres, Mode=TwoWay}"/>
+                           Value="{Binding MaxFuelLitres, Mode=TwoWay}"
+                           ToolTip="Limit usable tank size for the preset (L)."/>
 
                     <!-- Contingency -->
                     <StackPanel Margin="0,10,0,0">
                         <StackPanel Orientation="Horizontal" Margin="0,5,0,6">
-                            <TextBlock Text="Contingency Type:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Text="Contingency Type:" VerticalAlignment="Center" Margin="0,0,10,0"
+                                       ToolTip="Choose whether contingency is in laps or litres."/>
                             <RadioButton Content="Extra Laps"
                            IsChecked="{Binding ContingencyInLaps, Mode=TwoWay}"
-                           GroupName="ContingencyType"/>
+                           GroupName="ContingencyType"
+                           ToolTip="Add extra laps of fuel as a safety margin."/>
                             <RadioButton Content="Extra Litres" Margin="10,0,0,0"
                            IsChecked="{Binding ContingencyInLaps, Converter={StaticResource NotBoolConverter}, Mode=TwoWay}"
-                           GroupName="ContingencyType"/>
+                           GroupName="ContingencyType"
+                           ToolTip="Add extra litres as a safety margin."/>
                         </StackPanel>
 
                         <!-- Laps variant -->
                         <ui:TitledSlider Title="Contingency Laps:"
                              Minimum="0" Maximum="5"
-                             Value="{Binding ContingencyValue, Mode=TwoWay}">
+                             Value="{Binding ContingencyValue, Mode=TwoWay}"
+                             ToolTip="Number of extra laps of fuel to add.">
                             <ui:TitledSlider.Style>
                                 <Style TargetType="{x:Type ui:TitledSlider}">
                                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -229,7 +246,8 @@
                         <!-- Litres variant -->
                         <ui:TitledSlider Title="Contingency Litres:"
                              Minimum="0" Maximum="20"
-                             Value="{Binding ContingencyValue, Mode=TwoWay}">
+                             Value="{Binding ContingencyValue, Mode=TwoWay}"
+                             ToolTip="Extra fuel to add as a safety margin (L).">
                             <ui:TitledSlider.Style>
                                 <Style TargetType="{x:Type ui:TitledSlider}">
                                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -261,12 +279,14 @@
                         <styles:SHButtonPrimary Grid.Column="1"
                                     Content="Save Fuel Tab Data as Preset"
                                     Width="220" Height="30" Margin="8,0,0,0"
-                                    Click="OnSaveCurrentAsPreset"/>
+                                    Click="OnSaveCurrentAsPreset"
+                                    ToolTip="Save current Fuel tab settings into a new preset name."/>
 
                         <styles:SHButtonSecondary Grid.Column="2"
                                       Content="Rename Selected"
                                       Width="150" Height="30" Margin="8,0,0,0"
-                                      Click="OnRenamePreset"/>
+                                      Click="OnRenamePreset"
+                                      ToolTip="Rename the selected preset using the name box."/>
                     </Grid>
 
                 </StackPanel>
@@ -277,8 +297,10 @@
                   Orientation="Horizontal"
                   HorizontalAlignment="Right"
                   Margin="0,10,0,0">
-                <styles:SHButtonSecondary Content="Discard Changes" Width="140" Height="30" Click="OnDiscardChanges"/>
-                <styles:SHButtonPrimary   Content="Save Changes"    Width="140" Height="30" Click="OnSaveEdits"/>
+                <styles:SHButtonSecondary Content="Discard Changes" Width="140" Height="30" Click="OnDiscardChanges"
+                                          ToolTip="Revert edits to the last saved preset values."/>
+                <styles:SHButtonPrimary   Content="Save Changes"    Width="140" Height="30" Click="OnSaveEdits"
+                                          ToolTip="Save edits to the selected preset."/>
             </StackPanel>
         </Grid>
     </Grid>

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -18,21 +18,28 @@
         </Grid.ColumnDefinitions>
 
         <DockPanel Grid.Column="0">
-            <TextBlock DockPanel.Dock="Top" Text="Car Profiles Library" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
+            <TextBlock DockPanel.Dock="Top" Text="Car Profiles Library" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"
+                       ToolTip="Manage car profiles stored on disk."/>
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <styles:SHButtonPrimary Content="New" Width="70" Margin="2" Command="{Binding NewProfileCommand}"/>
-                <styles:SHButtonPrimary Content="Copy To..." Width="80" Margin="2" Command="{Binding CopySettingsCommand}"/>
-                <styles:SHButtonSecondary Content="Delete" Width="70" Margin="2" Command="{Binding DeleteProfileCommand}" Background="#C82333" Foreground="White"/>
+                <styles:SHButtonPrimary Content="New" Width="70" Margin="2" Command="{Binding NewProfileCommand}"
+                                        ToolTip="Create a new empty car profile."/>
+                <styles:SHButtonPrimary Content="Copy To..." Width="80" Margin="2" Command="{Binding CopySettingsCommand}"
+                                        ToolTip="Copy the selected profile into another profile."/>
+                <styles:SHButtonSecondary Content="Delete" Width="70" Margin="2" Command="{Binding DeleteProfileCommand}" Background="#C82333" Foreground="White"
+                                          ToolTip="Delete the selected profile from disk."/>
             </StackPanel>
-            <ListBox ItemsSource="{Binding SortedCarProfiles}" SelectedItem="{Binding SelectedProfile, Mode=TwoWay}" DisplayMemberPath="ProfileName" BorderThickness="1" BorderBrush="Gray"/>
+            <ListBox ItemsSource="{Binding SortedCarProfiles}" SelectedItem="{Binding SelectedProfile, Mode=TwoWay}" DisplayMemberPath="ProfileName" BorderThickness="1" BorderBrush="Gray"
+                     ToolTip="Select the car profile to edit."/>
         </DockPanel>
 
         <DockPanel Grid.Column="2" IsEnabled="{Binding IsProfileSelected}">
             <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,10">
-                <TextBlock Text="Editing Profile:" FontSize="16" FontWeight="Bold" VerticalAlignment="Center"/>
+                <TextBlock Text="Editing Profile:" FontSize="16" FontWeight="Bold" VerticalAlignment="Center"
+                           ToolTip="Edit settings for the selected car profile."/>
                 <TextBox Text="{Binding SelectedProfile.ProfileName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                          FontSize="16" FontWeight="Normal" Margin="10,0,0,0" MinWidth="200"
-                         BorderThickness="0" Background="Transparent"/>
+                         BorderThickness="0" Background="Transparent"
+                         ToolTip="Rename the selected profile."/>
             </StackPanel>
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
                 <styles:SHButtonPrimary Content="Apply to Live Session" Width="150" Margin="0,0,10,0" Command="{Binding ApplyToLiveCommand}" Height="30"
@@ -200,9 +207,12 @@
 
                 <styles:SHTabItem Header="FUEL">
                     <StackPanel Margin="10" DataContext="{Binding SelectedProfile}">
-                        <ui:TitledSlider Title="Contingency Laps/Litres" Minimum="0" Maximum="10" Value="{Binding FuelContingencyValue, Mode=TwoWay}" />
-                        <styles:SHToggleCheckbox Content="Contingency is in Laps (otherwise Litres)" IsChecked="{Binding IsContingencyInLaps, Mode=TwoWay}" Margin="5,10,0,0"/>
-                        <ui:TitledSlider Title="Wet Fuel Multiplier (%)" Minimum="70" Maximum="130" Value="{Binding WetFuelMultiplier, Mode=TwoWay}" Margin="0,15,0,0"/>
+                        <ui:TitledSlider Title="Contingency Laps/Litres" Minimum="0" Maximum="10" Value="{Binding FuelContingencyValue, Mode=TwoWay}"
+                                         ToolTip="Default contingency amount added to fuel plans." />
+                        <styles:SHToggleCheckbox Content="Contingency is in Laps (otherwise Litres)" IsChecked="{Binding IsContingencyInLaps, Mode=TwoWay}" Margin="5,10,0,0"
+                                                 ToolTip="Toggle whether the contingency value represents laps or litres."/>
+                        <ui:TitledSlider Title="Wet Fuel Multiplier (%)" Minimum="70" Maximum="130" Value="{Binding WetFuelMultiplier, Mode=TwoWay}" Margin="0,15,0,0"
+                                         ToolTip="Fuel burn multiplier for wet conditions (%)."/>
 
                         <Grid Margin="0,15,0,0">
                             <Grid.RowDefinitions>
@@ -215,7 +225,8 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RacePaceDeltaSeconds, Mode=TwoWay}" Minimum="0" Maximum="5" SmallChange="0.1" TickFrequency="0.1" IsSnapToTickEnabled="True" />
+                                <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RacePaceDeltaSeconds, Mode=TwoWay}" Minimum="0" Maximum="5" SmallChange="0.1" TickFrequency="0.1" IsSnapToTickEnabled="True"
+                                        ToolTip="Adjust the race pace delta used for planning (sec)."/>
                                 <TextBlock Grid.Column="1" Text="{Binding RacePaceDeltaSeconds, StringFormat=N1}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
                             </Grid>
                         </Grid>
@@ -228,19 +239,20 @@
                             </Grid.ColumnDefinitions>
 
                             <StackPanel Grid.Column="0">
-                                <TextBlock Text="Refuel Rate (L/s):" ToolTip="The average rate at which the car refuels."/>
+                                <TextBlock Text="Refuel Rate (L/s):" ToolTip="Average refuel rate (L/s). Updates after a live refuel event if available."/>
                                 <Grid Margin="0,4,0,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RefuelRate, Mode=TwoWay}" Minimum="1" Maximum="10" SmallChange="0.05" TickFrequency="0.05" IsSnapToTickEnabled="True" />
+                                    <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RefuelRate, Mode=TwoWay}" Minimum="1" Maximum="10" SmallChange="0.05" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                            ToolTip="Set the refuel rate (L/s). Live refuel events can update this value."/>
                                     <TextBlock Grid.Column="1" Text="{Binding RefuelRate, StringFormat=N2}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
                                 </Grid>
                             </StackPanel>
 
                             <StackPanel Grid.Column="2">
-                                <TextBlock Text="Base Tank (L):" ToolTip="Unscaled base tank capacity for this car profile."/>
+                                <TextBlock Text="Base Tank (L):" ToolTip="Base tank capacity for this car. Use Learn from Live to pull from live max fuel."/>
                                 <Grid Margin="0,4,0,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -249,11 +261,13 @@
                                     <TextBox Grid.Column="0"
                                              Margin="0,0,0,0"
                                              TextAlignment="Right"
-                                             Text="{Binding BaseTankLitres, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"/>
+                                             Text="{Binding BaseTankLitres, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"
+                                             ToolTip="Base tank size (L). Leave blank to use the default."/>
                                     <styles:SHButtonSecondary Grid.Column="1"
                                                               Content="Learn from Live"
                                                               Margin="8,0,0,0"
-                                                              Command="{Binding DataContext.LearnBaseTankCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                                                              Command="{Binding DataContext.LearnBaseTankCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              ToolTip="Capture the current live max fuel as the base tank size."/>
                                 </Grid>
                             </StackPanel>
                         </Grid>
@@ -269,23 +283,28 @@
                         </Grid.ColumnDefinitions>
 
                         <DockPanel Grid.Column="0">
-                            <TextBlock DockPanel.Dock="Top" Text="Recorded Tracks" FontWeight="Bold" Margin="0,0,0,10"/>
+                            <TextBlock DockPanel.Dock="Top" Text="Recorded Tracks" FontWeight="Bold" Margin="0,0,0,10"
+                                       ToolTip="Tracks with saved data for this profile."/>
                             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                                <styles:SHButtonSecondary Content="Delete" Width="80" Command="{Binding DeleteTrackCommand}" Background="#C82333" Foreground="White"/>
+                                <styles:SHButtonSecondary Content="Delete" Width="80" Command="{Binding DeleteTrackCommand}" Background="#C82333" Foreground="White"
+                                                          ToolTip="Delete the selected track data from this profile."/>
                             </StackPanel>
-                            <ListBox ItemsSource="{Binding TracksForSelectedProfile}" SelectedItem="{Binding SelectedTrack, Mode=TwoWay}" DisplayMemberPath="DisplayName" BorderThickness="1" BorderBrush="Gray"/>
+                            <ListBox ItemsSource="{Binding TracksForSelectedProfile}" SelectedItem="{Binding SelectedTrack, Mode=TwoWay}" DisplayMemberPath="DisplayName" BorderThickness="1" BorderBrush="Gray"
+                                     ToolTip="Select a track to edit its saved data."/>
                         </DockPanel>
 
                         <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                             <StackPanel DataContext="{Binding SelectedTrack}" Grid.IsSharedSizeScope="True" IsEnabled="{Binding DataContext.IsTrackSelected, RelativeSource={RelativeSource AncestorType=UserControl}}">
-                                <TextBlock FontWeight="Bold">
+                                <TextBlock FontWeight="Bold"
+                                           ToolTip="Edit saved data for the selected track.">
                                     <Run Text="Editing Data for: "/>
                                     <Run Text="{Binding DisplayName}"/>
                                 </TextBlock>
                                 <Border Height="1" Background="#444" Margin="0,5,0,10"/>
 
                                 <!-- PIT DATA (Pit Loss + Track Markers) -->
-                                <GroupBox Header="Pit Data" Margin="0,0,0,10">
+                                <GroupBox Header="Pit Data" Margin="0,0,0,10"
+                                          ToolTip="Pit lane loss and pit entry/exit markers for this track.">
                                     <Grid Margin="8,6,8,8" Grid.IsSharedSizeScope="True">
                                         <Grid.RowDefinitions>
                                             <!-- Pit loss line -->
@@ -319,18 +338,21 @@
                                         <TextBlock Grid.Row="0" Grid.Column="0"
                    Text="Pit Lane Loss (s):"
                    Margin="0,6,10,0"
-                   VerticalAlignment="Center"/>
+                   VerticalAlignment="Center"
+                   ToolTip="Estimated pit lane loss per stop (sec). Updates from live pits when unlocked."/>
 
                                         <TextBox Grid.Row="0" Grid.Column="1"
                  Margin="0,6,0,0"
                  TextAlignment="Right"
-                 Text="{Binding PitLaneLossSecondsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                 Text="{Binding PitLaneLossSecondsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 ToolTip="Manual override for pit lane loss (sec)."/>
 
                                         <CheckBox Grid.Row="0" Grid.Column="2"
                   Margin="12,6,0,0"
                   VerticalAlignment="Center"
                   Content="Locked"
-                  IsChecked="{Binding PitLaneLossLocked, Mode=TwoWay}"/>
+                  IsChecked="{Binding PitLaneLossLocked, Mode=TwoWay}"
+                  ToolTip="Lock to prevent live pit samples from overwriting this value."/>
 
                                         <!-- Pit loss info lines -->
                                         <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,6,0,0">
@@ -381,7 +403,8 @@
 
                                             <TextBlock Grid.Row="0" Grid.Column="0"
                                                Text="Stored Pit Entry %:"
-                                               VerticalAlignment="Center"/>
+                                               VerticalAlignment="Center"
+                                               ToolTip="Saved pit entry marker as % of lap distance."/>
                                             <TextBlock Grid.Row="0" Grid.Column="1"
                                                Text="{Binding StoredPitEntryPctText}"
                                                TextAlignment="Right"
@@ -390,12 +413,14 @@
                                               Margin="12,0,0,0"
                                               VerticalAlignment="Center"
                                               Content="Locked"
-                                              IsChecked="{Binding TrackMarkersLocked, Mode=TwoWay}"/>
+                                              IsChecked="{Binding TrackMarkersLocked, Mode=TwoWay}"
+                                              ToolTip="Lock to prevent live marker updates from overwriting pit entry/exit values."/>
 
                                             <TextBlock Grid.Row="1" Grid.Column="0"
                                                Margin="0,6,0,0"
                                                Text="Stored Pit Exit %:"
-                                               VerticalAlignment="Center"/>
+                                               VerticalAlignment="Center"
+                                               ToolTip="Saved pit exit marker as % of lap distance."/>
                                             <TextBlock Grid.Row="1" Grid.Column="1"
                                                Margin="0,6,0,0"
                                                Text="{Binding StoredPitExitPctText}"
@@ -405,7 +430,8 @@
                                             <TextBlock Grid.Row="2" Grid.Column="0"
                                                Margin="0,6,0,0" FontStyle="Italic" Foreground="#FF9AA0A6"
                                                Text="Last Updated (UTC):"
-                                               VerticalAlignment="Center"/>
+                                               VerticalAlignment="Center"
+                                               ToolTip="Last time these pit markers were updated."/>
                                             <TextBlock Grid.Row="2" Grid.Column="1"
                                                Margin="0,6,0,0" FontStyle="Italic" Foreground="#FF9AA0A6"
                                                Text="{Binding TrackMarkersLastUpdatedText}"
@@ -425,7 +451,8 @@
                                                     ToolTip="Reload LalaLaunch.TrackMarkers.json from disk (for manual edits)."/>
                                                 <styles:SHButtonPrimary
                                                     Content="Zero and Relearn"
-                                                    Command="{Binding RelearnPitDataCommand}" Click="SHButtonPrimary_Click"/>
+                                                    Command="{Binding RelearnPitDataCommand}" Click="SHButtonPrimary_Click"
+                                                    ToolTip="Clear pit markers and relearn them from the next live pit cycle."/>
                                             </StackPanel>
 
 
@@ -435,7 +462,8 @@
                                 </GroupBox>
 
                                 <!-- DRY CONDITIONS -->
-                                <GroupBox Header="Dry Conditions Data" Margin="0,0,0,10">
+                                <GroupBox Header="Dry Conditions Data" Margin="0,0,0,10"
+                                          ToolTip="Dry-condition pace and fuel data for this track.">
                                     <Grid Margin="8,6,8,8" Grid.IsSharedSizeScope="True">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
@@ -461,10 +489,12 @@
                                         <TextBlock Grid.Row="0" Grid.Column="0"
                                            Text="Best Lap Time (m:ss.fff):"
                                            Margin="0,0,10,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Best dry lap time stored for this track."/>
                                         <TextBox Grid.Row="0" Grid.Column="1"
                                              TextAlignment="Right"
-                                             Text="{Binding BestLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding BestLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for best dry lap time (m:ss.fff)."/>
                                         <TextBlock Grid.Row="0" Grid.Column="2"
                                                Margin="12,0,0,0"
                                                VerticalAlignment="Center"
@@ -477,11 +507,13 @@
                                         <TextBlock Grid.Row="1" Grid.Column="0"
                                            Text="Avg Lap Time (m:ss.fff):"
                                            Margin="0,6,10,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Average dry lap time used for planning (m:ss.fff)."/>
                                         <TextBox Grid.Row="1" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
-                                             Text="{Binding AvgLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding AvgLapTimeDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for average dry lap time (m:ss.fff)."/>
                                         <StackPanel
                                             Grid.Row="1"
                                             Grid.Column="2"
@@ -504,38 +536,45 @@
                                         <TextBlock Grid.Row="2" Grid.Column="0"
                                            Text="Fuel Burn (L/lap):"
                                            Margin="0,6,10,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Dry fuel burn values used for planning (L/lap)."/>
 
                                         <!-- ECO -->
                                         <TextBlock Grid.Row="2" Grid.Column="0"
                                            Margin="120,6,10,0"
                                            Text="ECO"
                                            FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Lowest observed dry fuel burn (L/lap)."/>
                                         <TextBox Grid.Row="2" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
-                                             Text="{Binding MinFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding MinFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for dry ECO fuel burn (L/lap)."/>
 
                                         <!-- AVG -->
                                         <TextBlock Grid.Row="3" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="AVG"
                                            FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Average observed dry fuel burn (L/lap)."/>
                                         <TextBox Grid.Row="3" Grid.Column="1"
                                              TextAlignment="Right"
-                                             Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding AvgFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for dry AVG fuel burn (L/lap)."/>
 
                                         <!-- MAX -->
                                         <TextBlock Grid.Row="4" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="MAX"
                                            FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Highest observed dry fuel burn (L/lap)."/>
                                         <TextBox Grid.Row="4" Grid.Column="1"
                                              TextAlignment="Right"
-                                             Text="{Binding MaxFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding MaxFuelPerLapDryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for dry MAX fuel burn (L/lap)."/>
 
                                         <!-- Fuel sample / updated -->
                                         <StackPanel
@@ -547,13 +586,15 @@
 
                                             <TextBlock
                                                 Text="{Binding DryFuelSampleCount, StringFormat=Sample: {0}}"
-                                                Margin="0,0,10,0"/>
+                                                Margin="0,0,10,0"
+                                                ToolTip="Number of dry fuel samples collected for this track."/>
 
                                             <TextBlock
                                                 Text="{Binding DryFuelLastUpdatedText, Mode=OneWay}"
                                                 FontStyle="Italic"
                                                 Foreground="#FF9AA0A6"
-                                                TextWrapping="Wrap"/>
+                                                TextWrapping="Wrap"
+                                                ToolTip="Last time dry fuel data was updated."/>
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
@@ -563,18 +604,21 @@
                                             HorizontalAlignment="Left">
                                             <CheckBox
                                                 Content="Locked"
-                                                IsChecked="{Binding DryConditionsLocked, Mode=TwoWay}"/>
+                                                IsChecked="{Binding DryConditionsLocked, Mode=TwoWay}"
+                                                ToolTip="Lock to prevent live dry data from overwriting these values."/>
                                             <styles:SHButtonPrimary
                                                 Content="Zero and Relearn"
                                                 Command="{Binding DataContext.RelearnDryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                Margin="10,0,0,0"/>
+                                                Margin="10,0,0,0"
+                                                ToolTip="Clear dry data and relearn from new live laps (while unlocked)."/>
                                         </StackPanel>
                                     </Grid>
                                 </GroupBox>
 
 
                                 <!-- WET CONDITIONS -->
-                                <GroupBox Header="Wet Conditions Data" Margin="0,0,0,10">
+                                <GroupBox Header="Wet Conditions Data" Margin="0,0,0,10"
+                                          ToolTip="Wet-condition pace and fuel data for this track.">
                                     <Grid Margin="8,6,8,8" Grid.IsSharedSizeScope="True">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
@@ -600,10 +644,12 @@
                                         <TextBlock Grid.Row="0" Grid.Column="0"
                                            Text="Best Lap Time (m:ss.fff):"
                                            Margin="0,0,10,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Best wet lap time stored for this track."/>
                                         <TextBox Grid.Row="0" Grid.Column="1"
                                              TextAlignment="Right"
-                                             Text="{Binding BestLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding BestLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for best wet lap time (m:ss.fff)."/>
                                         <TextBlock Grid.Row="0" Grid.Column="2"
                                            Margin="12,0,0,0"
                                            VerticalAlignment="Center"
@@ -616,11 +662,13 @@
                                         <TextBlock Grid.Row="1" Grid.Column="0"
                                            Text="Avg Lap Time (m:ss.fff):"
                                            Margin="0,6,10,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Average wet lap time used for planning (m:ss.fff)."/>
                                         <TextBox Grid.Row="1" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
-                                             Text="{Binding AvgLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding AvgLapTimeWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for average wet lap time (m:ss.fff)."/>
                                         <StackPanel
                                             Grid.Row="1"
                                             Grid.Column="2"
@@ -643,38 +691,45 @@
                                         <TextBlock Grid.Row="2" Grid.Column="0"
                                            Text="Fuel Burn (L/lap):"
                                            Margin="0,6,10,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Wet fuel burn values used for planning (L/lap)."/>
 
                                         <!-- ECO -->
                                         <TextBlock Grid.Row="2" Grid.Column="0"
                                            Margin="120,6,10,0"
                                            Text="ECO"
                                            FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Lowest observed wet fuel burn (L/lap)."/>
                                         <TextBox Grid.Row="2" Grid.Column="1"
                                              Margin="0,6,0,0"
                                              TextAlignment="Right"
-                                             Text="{Binding MinFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding MinFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for wet ECO fuel burn (L/lap)."/>
 
                                         <!-- AVG -->
                                         <TextBlock Grid.Row="3" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="AVG"
                                            FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Average observed wet fuel burn (L/lap)."/>
                                         <TextBox Grid.Row="3" Grid.Column="1"
                                              TextAlignment="Right"
-                                             Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding AvgFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for wet AVG fuel burn (L/lap)."/>
 
                                         <!-- MAX -->
                                         <TextBlock Grid.Row="4" Grid.Column="0"
                                            Margin="120,0,10,0"
                                            Text="MAX"
                                            FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center"
+                                           ToolTip="Highest observed wet fuel burn (L/lap)."/>
                                         <TextBox Grid.Row="4" Grid.Column="1"
                                              TextAlignment="Right"
-                                             Text="{Binding MaxFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                             Text="{Binding MaxFuelPerLapWetText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             ToolTip="Manual override for wet MAX fuel burn (L/lap)."/>
 
                                         <!-- Fuel sample / updated -->
                                         <StackPanel
@@ -686,13 +741,15 @@
 
                                             <TextBlock
                                                 Text="{Binding WetFuelSampleCount, StringFormat=Sample: {0}}"
-                                                Margin="0,0,10,0"/>
+                                                Margin="0,0,10,0"
+                                                ToolTip="Number of wet fuel samples collected for this track."/>
 
                                             <TextBlock
                                                 Text="{Binding WetFuelLastUpdatedText, Mode=OneWay}"
                                                 FontStyle="Italic"
                                                 Foreground="#FF9AA0A6"
-                                                TextWrapping="Wrap"/>
+                                                TextWrapping="Wrap"
+                                                ToolTip="Last time wet fuel data was updated."/>
                                         </StackPanel>
 
                                         <!-- Placeholder lock -->
@@ -702,17 +759,20 @@
                                             HorizontalAlignment="Left">
                                             <CheckBox
                                                 Content="Locked"
-                                                IsChecked="{Binding WetConditionsLocked, Mode=TwoWay}"/>
+                                                IsChecked="{Binding WetConditionsLocked, Mode=TwoWay}"
+                                                ToolTip="Lock to prevent live wet data from overwriting these values."/>
                                             <styles:SHButtonPrimary
                                                 Content="Zero and Relearn"
                                                 Command="{Binding DataContext.RelearnWetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                Margin="10,0,0,0"/>
+                                                Margin="10,0,0,0"
+                                                ToolTip="Clear wet data and relearn from new live laps (while unlocked)."/>
                                         </StackPanel>
                                     </Grid>
                                 </GroupBox>
 
                                 <!-- WET VS DRY AVG DELTAS -->
-                                <GroupBox Header="Wet vs Dry Avg Deltas" Margin="0,0,0,10">
+                                <GroupBox Header="Wet vs Dry Avg Deltas" Margin="0,0,0,10"
+                                          ToolTip="Computed deltas between wet and dry averages for this track.">
                                     <Grid Margin="8,6,8,8">
                                         <TextBlock TextWrapping="Wrap">
                                             <Run Text="{Binding WetVsDryAvgLapDeltaText, Mode=OneWay}" />


### PR DESCRIPTION
### Motivation
- Make fuel-related UI clearer by specifying that the `Wet Factor` affects fuel burn only and by explaining the `Pit Drive-Through Loss` auto-selection order. 
- Provide a single reference for all UI tooltip text so reviewers can iterate on wording without scanning XAML files. 
- Improve tester guidance and consistency by adding or standardizing `ToolTip` text across plugin UI controls.

### Description
- Updated `FuelCalculatorView.xaml` to change the `Wet Factor` tooltip to "Scale fuel burn for wet running (%)" and to reword the `Pit Drive-Through Loss` tooltip to describe the auto-selection order: drive-through loss, then direct pit entry-to-exit time, then the default. 
- Added or standardized `ToolTip` text across multiple XAML views including `CopyProfileDialog.xaml`, `DashesTabView.xaml`, `LaunchAnalysisControl.xaml`, `LaunchPluginSettingsUI.xaml`, `PresetsManagerView.xaml`, and `ProfilesManagerView.xaml` to clarify behavior, units, and lock/source semantics. 
- Generated `Docs/Plugin_UI_Tooltips.md` as a catalog of current tooltip messages extracted from the XAML for review and future updates. 
- Made no functional changes to logic or calculations; edits are XAML-only and focused on user-facing help text.

### Testing
- Automated tests: none run because the changes are UI-only `XAML` text updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a6e48b98832fa3f2e465daa7c5b4)