### PR TITLE
Add Overlay dash visibility toggles and update dash setting labels

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -63,6 +63,7 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -79,20 +80,25 @@
                         <TextBlock Text="" Grid.Row="0" Grid.Column="0" />
                         <TextBlock Text="MAIN DASH" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="1" />
                         <TextBlock Text="MESSAGE DASH" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="2" />
+                        <TextBlock Text="OVERLAY" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="3" />
 
-                        <TextBlock Text="Show Launch Screen" Margin="0,5,0,0" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Launch Assist" Margin="0,5,0,0" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable the Launch screen for this dash type." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="1"
                                                  ToolTip="Show the Launch screen on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="2"
                                                  ToolTip="Show the Launch screen on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="3"
+                                                 ToolTip="Show the Launch screen on the Overlay." />
 
-                        <TextBlock Text="Show Pit Limiter Screen" Margin="0,5,0,0" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Pit Assists" Margin="0,5,0,0" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable the Pit Limiter screen for this dash type." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="1"
                                                  ToolTip="Show the Pit Limiter screen on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="2"
                                                  ToolTip="Show the Pit Limiter screen on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="3"
+                                                 ToolTip="Show the Pit Limiter screen on the Overlay." />
 
                         <TextBlock Text="Show Automatic Pit Screen" Margin="0,5,0,0" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable the automatic pit screen for this dash type." />
@@ -100,34 +106,44 @@
                                                  ToolTip="Show the automatic pit screen on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="2"
                                                  ToolTip="Show the automatic pit screen on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="3"
+                                                 ToolTip="Show the automatic pit screen on the Overlay." />
 
-                        <TextBlock Text="Show Track Rejoin Assist" Margin="0,5,0,0" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Rejoin Assist" Margin="0,5,0,0" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable track rejoin assist for this dash type." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="1"
                                                  ToolTip="Show track rejoin assist on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="2"
                                                  ToolTip="Show track rejoin assist on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="3"
+                                                 ToolTip="Show track rejoin assist on the Overlay." />
 
-                        <TextBlock Text="Show Verbose Race Messages" Margin="0,5,0,0" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Verbose Race Messages" Margin="0,5,0,0" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable detailed race messages for this dash type." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="1"
                                                  ToolTip="Show verbose race messages on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="2"
                                                  ToolTip="Show verbose race messages on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="3"
+                                                 ToolTip="Show verbose race messages on the Overlay." />
 
-                        <TextBlock Text="Show Race Flags" Margin="0,5,0,0" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Race Flags" Margin="0,5,0,0" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable race flag notifications for this dash type." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="1"
                                                  ToolTip="Show race flags on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="2"
                                                  ToolTip="Show race flags on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="3"
+                                                 ToolTip="Show race flags on the Overlay." />
 
-                        <TextBlock Text="Show Radio Messages" Margin="0,5,0,0" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Radio Messages" Margin="0,5,0,0" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable radio message popups for this dash type." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="1"
                                                  ToolTip="Show radio messages on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="2"
                                                  ToolTip="Show radio messages on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="3"
+                                                 ToolTip="Show radio messages on the Overlay." />
 
                         <TextBlock Text="Show Traffic Alerts" Margin="0,5,0,0" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"
                                    ToolTip="Enable traffic alert warnings for this dash type." />
@@ -135,6 +151,8 @@
                                                  ToolTip="Show traffic alerts on the Main Dash." />
                         <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="2"
                                                  ToolTip="Show traffic alerts on the Message Dash." />
+                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="3"
+                                                 ToolTip="Show traffic alerts on the Overlay." />
                     </Grid>
                 </Grid>
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3067,6 +3067,16 @@ namespace LaunchPlugin
             AttachCore("MsgDashShowRadioMessages", () => Settings.MsgDashShowRadioMessages);
             AttachCore("MsgDashShowTraffic", () => Settings.MsgDashShowTraffic);
 
+            // --- Overlay Options (CORE) ---
+            AttachCore("OverlayDashShowLaunchScreen", () => Settings.OverlayDashShowLaunchScreen);
+            AttachCore("OverlayDashShowPitLimiter", () => Settings.OverlayDashShowPitLimiter);
+            AttachCore("OverlayDashShowPitScreen", () => Settings.OverlayDashShowPitScreen);
+            AttachCore("OverlayDashShowRejoinAssist", () => Settings.OverlayDashShowRejoinAssist);
+            AttachCore("OverlayDashShowVerboseMessaging", () => Settings.OverlayDashShowVerboseMessaging);
+            AttachCore("OverlayDashShowRaceFlags", () => Settings.OverlayDashShowRaceFlags);
+            AttachCore("OverlayDashShowRadioMessages", () => Settings.OverlayDashShowRadioMessages);
+            AttachCore("OverlayDashShowTraffic", () => Settings.OverlayDashShowTraffic);
+
             // --- Manual Timeout (CORE) ---
             AttachCore("ManualTimeoutRemaining", () =>
             {
@@ -4136,7 +4146,7 @@ namespace LaunchPlugin
             {
                 _poll250ms.Restart();
                 UpdateLiveMaxFuel(pluginManager);
-                _msgSystem.Enabled = Settings.MsgDashShowTraffic || Settings.LalaDashShowTraffic;
+                _msgSystem.Enabled = Settings.MsgDashShowTraffic || Settings.LalaDashShowTraffic || Settings.OverlayDashShowTraffic;
                 double warn = ActiveProfile.TrafficApproachWarnSeconds;
                 if (!(warn > 0)) warn = 5.0;
                 _msgSystem.WarnSeconds = warn;
@@ -6378,6 +6388,16 @@ namespace LaunchPlugin
         public bool MsgDashShowRaceFlags { get; set; } = true;
         public bool MsgDashShowRadioMessages { get; set; } = true;
         public bool MsgDashShowTraffic { get; set; } = true;
+
+        // --- Overlay Toggles (Default ON) ---
+        public bool OverlayDashShowLaunchScreen { get; set; } = true;
+        public bool OverlayDashShowPitLimiter { get; set; } = true;
+        public bool OverlayDashShowPitScreen { get; set; } = true;
+        public bool OverlayDashShowRejoinAssist { get; set; } = true;
+        public bool OverlayDashShowVerboseMessaging { get; set; } = true;
+        public bool OverlayDashShowRaceFlags { get; set; } = true;
+        public bool OverlayDashShowRadioMessages { get; set; } = true;
+        public bool OverlayDashShowTraffic { get; set; } = true;
     }
     /// <summary>
     /// Helper class for continuous telemetry data logging, now specifically focused on per-launch traces.


### PR DESCRIPTION
### Motivation
- Provide a third visibility target (Overlay) in the dash settings so users can control which alerts/screens appear on an on-screen overlay separately from the main and message dashes.
- Simplify a few setting labels to group related controls (e.g. "Launch Assist", "Pit Assists") for clarity in the UI.
- Expose overlay toggles as plugin properties so the rest of the plugin can read overlay preferences at runtime (parity with `LalaDash`/`MsgDash`).

### Description
- Updated `DashesTabView.xaml` to add an "OVERLAY" column, adjust several label text values, and bind overlay toggle checkboxes to new settings named `OverlayDashShow...`.
- Added overlay toggle properties to `LaunchPluginSettings` in `LalaLaunch.cs` (e.g. `OverlayDashShowLaunchScreen`, `OverlayDashShowPitLimiter`, etc.) with default `true` values.
- Exposed the overlay toggles via `AttachCore(...)` calls (properties named `OverlayDashShow...`) so they are available to SimHub bindings and dashboards.
- Included `Settings.OverlayDashShowTraffic` in the message system enablement check (`_msgSystem.Enabled`) so overlay traffic toggle can enable/disable the message engine alongside existing main/msg toggles.

### Testing
- No automated tests were run for these changes (UI and settings additions only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696919ad53a4832fa9a3791048d38226)