### PR TITLE
Add user-facing changelog and refresh documentation for fuel/pace/planner

### DIFF
--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
-Validated against commit: b45bc8f  
-Last updated: 2026-02-12  
+Validated against commit: 708af0f  
+Last updated: 2026-01-27  
 Branch: work
 
 ## What this repo is
@@ -78,6 +78,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - Fuel tab/UI source or planner changes → update `FuelTab_SourceFlowNotes.md`.
 
 ## Freshness
-- Validated against commit: b45bc8f  
-- Date: 2026-02-12  
+- Validated against commit: 708af0f  
+- Date: 2026-01-27  
 - Branch: work

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -1,7 +1,7 @@
 # Fuel Model
 
-Validated against commit: b45bc8f  
-Last updated: 2026-02-12  
+Validated against commit: 708af0f  
+Last updated: 2026-01-27  
 Branch: work
 
 ## Purpose

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -1,7 +1,7 @@
 # Fuel Planner Tab
 
-Validated against commit: b45bc8f  
-Last updated: 2026-02-12  
+Validated against commit: 708af0f  
+Last updated: 2026-01-27  
 Branch: work
 
 ## Purpose
@@ -93,7 +93,9 @@ The planner tracks *what source is currently active* for each input:
 
 ### Max fuel override handling (profile vs live)
 - **Profile mode:** `MaxFuelOverride` is clamped to the profile base tank (`BaseTankLitres`), and the UI shows a percent-of-base-tank badge.
+- **Preset max fuel input:** Preset max fuel is expressed as a **percentage of base tank** (default 100%), making presets portable across cars with different base tanks.
 - **Live Snapshot mode:** `MaxFuelOverride` is set from the live session cap (MaxFuel × BoP), or `0` if the live cap is unavailable.
+- **Preset visibility in Live Snapshot:** Preset max-fuel values remain visible (read-only) so drivers can compare preset intent against live caps.
 - **Mode transitions:** switching into Live Snapshot stores the previous profile override; switching back to Profile restores it and re-applies the selected preset (if any).
 - **Validation:** if the live cap is missing in Live Snapshot mode, the planner surfaces an explicit “Live max fuel cap unavailable” error and blocks strategy outputs.
 

--- a/Docs/Subsystems/Pace_And_Projection.md
+++ b/Docs/Subsystems/Pace_And_Projection.md
@@ -1,7 +1,7 @@
 # Pace and Projection
 
-Validated against commit: b45bc8f  
-Last updated: 2026-02-12  
+Validated against commit: 708af0f  
+Last updated: 2026-01-27  
 Branch: work
 
 ## Purpose
@@ -101,7 +101,7 @@ On each lap completion:
 
 Accepted laps feed pace windows; rejected laps do not affect averages.
 
-Wet/dry mode does **not** change pace validity rules; it only influences how the resulting lap stats are persisted to dry vs wet profile fields.
+Wet/dry mode follows tyre-compound telemetry and uses the **same** lap validity rules; it only routes accepted laps into dry vs wet profile fields.
 
 Acceptance rules mirror fuel-lap acceptance where possible.
 

--- a/Docs/User Docs/Changelog_Since_PR240.md
+++ b/Docs/User Docs/Changelog_Since_PR240.md
@@ -1,0 +1,12 @@
+# LalaLaunch Plugin Changelog (since PR240)
+
+- Auto-learned **pit entry/exit markers** per track with lock/reload controls, plus **manual pit entry assist arming** and on-track cue/debrief outputs to help nail the entry line.
+- **Pit timing & loss accuracy** improvements (direct vs DTL calculations), including pit-entry time-loss capture and more reliable pit lane loss reporting in strategy screens.
+- **Session summary & trace logging**: CSV/trace outputs for post-session review and trend analysis.
+- **Opponents race tools**: nearby car summaries, pace deltas, “laps to fight,” and **pit-exit position prediction** for class battles.
+- **Dry vs wet tracking**: separate dry/wet fuel + pace stats, condition locks, wet mode detection from tyre compound, and track wetness labels for dashboards.
+- **Fuel planner/live snapshot upgrades**: live snapshot resets on car/track changes, clearer readiness gates, safer max-tank handling, and preset max fuel defined as a **percentage of base tank** with visible preset values even in Live Snapshot mode.
+- **Fuel strategy UI polish**: standardized tooltips, clearer toggle labels, overlay visibility column, and compact “last updated” labels.
+- **Fuel math updates**: stint fuel margin expressed as a percentage and refined stops-required calculations for cleaner strategy guidance.
+- **Profile storage & schema updates**: standardized JSON storage, normalized track keys, and base-tank litres stored per car profile.
+- **New predictor exports** for fuel burn and pace so dashboards can show consistent “next lap” guidance even before long stints are built up.


### PR DESCRIPTION
### Motivation
- Provide an end-user friendly changelog summarising user-relevant changes since PR240. 
- Ensure canonical docs reflect recent behavior and renames introduced in recent PRs (wet/dry handling, max-fuel preset behaviour, predictor exports). 
- Keep the `Docs` inventory consistent with the validated code snapshot and freshen the metadata dates so downstream readers see the correct reference point.

### Description
- Add a new user-facing changelog at `Docs/User Docs/Changelog_Since_PR240.md` listing the high-level user-visible changes (pit markers & assist, pit timing, session traces, opponents tools, dry/wet tracking, planner/live snapshot and preset max-fuel notes, UI polish, fuel math, profile schema, and new predictor exports). 
- Update `Docs/Project_Index.md`, `Docs/Subsystems/Fuel_Model.md`, `Docs/Subsystems/Fuel_Planner_Tab.md`, and `Docs/Subsystems/Pace_And_Projection.md` to refresh the validated commit/date metadata and to clarify behaviour for preset max-fuel visibility and wet/dry handling. 
- Documentation changes only; no runtime code or exports were modified in this PR.

### Testing
- No automated tests were run because this is a documentation-only change. 
- The docs were reviewed locally and committed; file additions and edits were validated by a local commit operation without runtime verification. 
- No runtime behaviour was exercised and therefore no unit/integration tests were executed or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69788c7deb80832fb8b80f8cbc43115c)