### PR TITLE
Use player checkpoint timestamp for real-gap calculations

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -605,11 +605,11 @@ namespace LaunchPlugin
                 slot.RealGapAdjSec = adjustedGap;
                 slot.GapRealSec = isAhead ? Math.Abs(adjustedGap) : -Math.Abs(adjustedGap);
 
-                UpdateClosingRate(slot, sessionTimeSec);
+                UpdateClosingRate(slot, playerCheckpointTimeSec);
             }
         }
 
-        private static void UpdateClosingRate(CarSASlot slot, double sessionTimeSec)
+        private static void UpdateClosingRate(CarSASlot slot, double gapTimeSec)
         {
             if (!slot.IsValid || double.IsNaN(slot.GapRealSec))
             {
@@ -623,12 +623,12 @@ namespace LaunchPlugin
                 slot.HasGapAbs = true;
                 slot.LastGapSec = slot.GapRealSec;
                 slot.LastGapAbs = gapAbs;
-                slot.LastGapUpdateTimeSec = sessionTimeSec;
+                slot.LastGapUpdateTimeSec = gapTimeSec;
                 slot.ClosingRateSecPerSec = double.NaN;
                 return;
             }
 
-            double dt = sessionTimeSec - slot.LastGapUpdateTimeSec;
+            double dt = gapTimeSec - slot.LastGapUpdateTimeSec;
             if (dt <= 0.05)
             {
                 return;
@@ -651,7 +651,7 @@ namespace LaunchPlugin
 
             slot.LastGapSec = slot.GapRealSec;
             slot.LastGapAbs = gapAbs;
-            slot.LastGapUpdateTimeSec = sessionTimeSec;
+            slot.LastGapUpdateTimeSec = gapTimeSec;
         }
 
         private void UpdateSlotDebug(CarSASlot slot, bool isAhead)


### PR DESCRIPTION
### Motivation
- `UpdateRealGaps` was using `sessionTimeSec` each tick which lets checkpoint-based gaps drift between actual crossing and the current tick, inflating/deflating `GapRealSec` and `ClosingRateSecPerSec` between crossings. 
- The change centralises the player's checkpoint timestamp so gap calculations reflect the shared checkpoint time rather than the current tick time. 
- Ensure previously noted slot-swap behavior (stale gap history when `CarIdx` changes) is still handled. 

### Description
- Verified `ApplySlotAssignment` already clears gap-related state when a slot's `CarIdx` changes so the first fix is already present. 
- Compute `playerCheckpointTimeSec` once per tick using `_stopwatch.GetLastCheckpointTimeSec(playerCheckpointIndexNow, playerCarIdx)` and pass it into `UpdateRealGaps`. 
- Changed `UpdateRealGaps` signature to accept `playerCheckpointTimeSec` and switched the raw gap computation to `rawGap = playerCheckpointTimeSec - lastSeen`. 
- Added a guard to abort/produce `NaN` gaps when the player checkpoint timestamp is unavailable (`playerCheckpointTimeSec <= 0.0`). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a11e72518832f979643f04acdb5f7)