### PR TITLE
Refine CarSA wrap guard suppression to avoid lap-delta and behind-wrap spikes

### DIFF
--- a/Docs/Subsystems/CarSA.md
+++ b/Docs/Subsystems/CarSA.md
@@ -32,8 +32,8 @@ CarSA is independent of the race-only Opponents subsystem and does not change Op
 
 ### Lap delta correction
 - `lapDelta = oppLap - myLap`
-- If `lapDelta != 0`, `RealGapAdjSec += lapDelta * LapTimeEstimateSec` is applied **only when both the player and the slot are not near S/F** (near edge = within 3% of lapPct 0/1). If either side is near the edge, the correction is skipped to avoid wrap spikes.
-- If `lapDelta == 0` and the slot is **behind**, the gap is wrapped by subtracting the lap-time estimate when the raw gap implies the previous lap.
+- If `lapDelta != 0`, `RealGapAdjSec += lapDelta * LapTimeEstimateSec` is applied **unless both the player and the slot are near S/F and physically close** (near edge = within 3% of lapPct 0/1, close = within 10% lap distance). This suppresses only the true S/F straddle spike.
+- If `lapDelta == 0` and the slot is **behind**, the gap is wrapped by subtracting the lap-time estimate when the raw gap implies the previous lap; this wrap adjustment is also suppressed when both cars are near S/F and physically close.
 - RealGap is clamped to ±600 s to guard against telemetry spikes.
 - LapDelta wrap override: if lap counters differ by ±1 at S/F but the cars are physically close (within 10% lap distance) and straddling the S/F edge (within 15% of lapPct 0/1), LapDelta is treated as `0` to prevent single-tick spikes.
 


### PR DESCRIPTION
### Motivation
- Fix a regression where lap-delta correction was being suppressed too broadly, causing ~1-lap gap errors when the player was near S/F but the opponent was mid-lap and far. 
- Prevent large negative behind-gap jumps for physically-close cars that straddle the S/F line by narrowing the suppression to the true danger zone.

### Description
- In `CarSAEngine.cs` compute `slotLapPct` and `distPct` per slot and add `const double WrapStraddleClosePct = 0.10` to detect physically-close S/F straddles. 
- Compute `playerNearEdge`, `slotNearEdge`, and `closeEnough`, and derive `suppressLapDeltaCorrection = playerNearEdge && slotNearEdge && closeEnough`. 
- Apply the lap-delta correction (`adjustedGap += lapDelta * lapTimeEstimateSec`) only when `!suppressLapDeltaCorrection`, so far/mid-lap opponents still get corrected. 
- Apply the same suppression to the behind-wrap branch (`adjustedGap = rawGap - lapTimeEstimateSec`) so close behind cars straddling S/F don’t get bogus negative jumps. 
- Update `Docs/Subsystems/CarSA.md` to document that lap-delta correction and behind-wrap adjustment are suppressed only when BOTH cars are near S/F (within 3%) AND physically close (<=10% lap distance).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5d87453c832faebe4d981b13a4a8)