### PR TITLE
CarSA: use Drivers table readiness to allow identity refresh in replays

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5106,11 +5106,7 @@ namespace LaunchPlugin
                     carNumber = GetString(pluginManager, $"{basePath}.CarNumber") ?? string.Empty;
                 }
 
-                int colorRaw = GetInt(pluginManager, $"{basePath}.CarClassColor", int.MinValue);
-                if (colorRaw != int.MinValue)
-                {
-                    classColor = FormatCarClassColor(colorRaw);
-                }
+                classColor = GetCarClassColorHex(pluginManager, $"{basePath}.CarClassColor");
 
                 return true;
             }
@@ -5143,11 +5139,65 @@ namespace LaunchPlugin
                     name = GetString(pluginManager, $"DataCorePlugin.GameRawData.SessionData.DriverInfo.CompetingDrivers[{i}].TeamName") ?? string.Empty;
                 }
                 carNumber = GetString(pluginManager, $"DataCorePlugin.GameRawData.SessionData.DriverInfo.CompetingDrivers[{i}].CarNumber") ?? string.Empty;
-                classColor = GetString(pluginManager, $"DataCorePlugin.GameRawData.SessionData.DriverInfo.CompetingDrivers[{i}].CarClassColor") ?? string.Empty;
+                classColor = GetCarClassColorHex(pluginManager, $"DataCorePlugin.GameRawData.SessionData.DriverInfo.CompetingDrivers[{i}].CarClassColor");
                 return true;
             }
 
             return false;
+        }
+
+        private static string GetCarClassColorHex(PluginManager pluginManager, string propertyName)
+        {
+            if (pluginManager == null || string.IsNullOrWhiteSpace(propertyName))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                var raw = pluginManager.GetPropertyValue(propertyName);
+                if (raw == null) return string.Empty;
+
+                if (raw is int intValue)
+                {
+                    return FormatCarClassColor(intValue);
+                }
+
+                if (raw is long longValue)
+                {
+                    return FormatCarClassColor((int)longValue);
+                }
+
+                if (raw is uint uintValue)
+                {
+                    return FormatCarClassColor((int)uintValue);
+                }
+
+                string rawText = Convert.ToString(raw, CultureInfo.InvariantCulture);
+                if (string.IsNullOrWhiteSpace(rawText)) return string.Empty;
+
+                rawText = rawText.Trim();
+                if (rawText.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                {
+                    rawText = rawText.Substring(2);
+                }
+
+                if (int.TryParse(rawText, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int parsedHex))
+                {
+                    return FormatCarClassColor(parsedHex);
+                }
+
+                if (int.TryParse(rawText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedInt))
+                {
+                    return FormatCarClassColor(parsedInt);
+                }
+
+                return string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
         }
 
         private static string FormatCarClassColor(int colorRaw)


### PR DESCRIPTION
### Motivation
- CarSA identity refresh could hang in replays because the previous readiness gate waited for `CompetingDrivers` even though replays typically populate `DriverInfo.Drivers01..Drivers64` but not `CompetingDrivers`.
- Make the refresh proceed when the Drivers table is available so slots get `Name`/`CarNumber`/`ClassColor` in replay sessions without adding any exported properties.

### Description
- Replace the old `IsCompetingDriversReady` check with a new `IsCarSaIdentitySourceReady` that returns true if `Drivers01.CarIdx` is available or, as a fallback, `CompetingDrivers[0].CarIdx` is available.
- Update the refresh gate in `RefreshCarSaSlotIdentities` to use `IsCarSaIdentitySourceReady` so identity refresh no longer blocks in replays.
- Add `TryGetCarIdentityFromDriversTable` and reorder `TryGetCarIdentityFromSessionInfo` to prefer the `Drivers01..Drivers64` table and fall back to `CompetingDrivers`, and add `FormatCarClassColor` to format class color as `0xRRGGBB`.
- Preserve previous behavior where possible, keep per-car lookups by `CarIdx`, and emit a debug line when an identity remains unresolved after a slot change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697caf2d514c832faa224517c57fd179)