### PR TITLE
Prefer Drivers table CarNumber string when available

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5096,14 +5096,14 @@ namespace LaunchPlugin
                     name = GetString(pluginManager, $"{basePath}.AbbrevName") ?? string.Empty;
                 }
 
-                int numberRaw = GetInt(pluginManager, $"{basePath}.CarNumberRaw", int.MinValue);
-                if (numberRaw != int.MinValue)
+                carNumber = GetString(pluginManager, $"{basePath}.CarNumber") ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(carNumber))
                 {
-                    carNumber = numberRaw.ToString(CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    carNumber = GetString(pluginManager, $"{basePath}.CarNumber") ?? string.Empty;
+                    int numberRaw = GetInt(pluginManager, $"{basePath}.CarNumberRaw", int.MinValue);
+                    if (numberRaw != int.MinValue)
+                    {
+                        carNumber = numberRaw.ToString(CultureInfo.InvariantCulture);
+                    }
                 }
 
                 int colorRaw = GetInt(pluginManager, $"{basePath}.CarClassColor", int.MinValue);


### PR DESCRIPTION
### Motivation
- Avoid display regressions where leading zeros (e.g., `007`) are lost because `CarNumberRaw` is numeric; prefer the `DriversXX.CarNumber` string when present.

### Description
- Update `TryGetCarIdentityFromDriversTable` in `LalaLaunch.cs` to read `DataCorePlugin.GameRawData.SessionData.DriverInfo.DriversXX.CarNumber` first and only fall back to `CarNumberRaw` when the string is empty, preserving prior fallbacks and formatting via `FormatCarClassColor`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cff680ab8832f861243bc103f9b09)