### PR TITLE
Fix CarSA raw telemetry reads without debug gating

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -136,6 +136,8 @@ namespace LaunchPlugin
         public int PlayerPaceFlagsRaw { get; set; } = -1;
         public int PlayerSessionFlagsRaw { get; set; } = -1;
         public int PlayerTrackSurfaceMaterialRaw { get; set; } = -1;
+        public string RawTelemetryReadMode { get; set; } = string.Empty;
+        public string RawTelemetryFailReason { get; set; } = string.Empty;
 
         public void Reset()
         {
@@ -174,6 +176,8 @@ namespace LaunchPlugin
             PlayerPaceFlagsRaw = -1;
             PlayerSessionFlagsRaw = -1;
             PlayerTrackSurfaceMaterialRaw = -1;
+            RawTelemetryReadMode = string.Empty;
+            RawTelemetryFailReason = string.Empty;
         }
     }
 


### PR DESCRIPTION
### Motivation
- The previous CarSA raw telemetry outputs were never populated in normal mode because reads were gated behind `debugEnabled` and relied on fragile reflection, making testing impossible.
- The intent is to always attempt raw telemetry reads when `Settings.CarSARawTelemetryMode > 0` and provide lightweight diagnostics when reads fail.

### Description
- Removed the `debugEnabled` gating so raw telemetry arrays are attempted whenever `CarSARawTelemetryMode > 0` and kept verbose slot-change logging gated by `debugEnabled` in `LalaLaunch.cs`.
- Reworked `TryReadTelemetryIntArray` to first try direct property access via `pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.Telemetry.<propertyName>")`, then fall back to reflection `GetProperty`, and finally `GetField`, while returning `readMode` and `failReason` strings for diagnostics.
- Added lightweight diagnostics fields `RawTelemetryReadMode` and `RawTelemetryFailReason` to the CarSA debug outputs and exposed them as `Car.Debug.RawTelemetryReadMode` and `Car.Debug.RawTelemetryFailReason` via `AttachCore` (changes in `CarSASlot.cs` and `LalaLaunch.cs`).
- Extended `TryConvertToIntArray` to accept additional common array shapes (`sbyte[]`, `long[]`, `ulong[]`) and kept graceful failure for unsupported types.

### Testing
- No automated tests were executed for this change; changes were implemented and committed but no test suite or build was run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f748d8c04832f87b9f99d802a9a04)