### PR TITLE
Mask CarIdx bitfield arrays to 32 bits

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5766,10 +5766,11 @@ namespace LaunchPlugin
                     values = Array.ConvertAll(sbytes, v => (int)v);
                     return true;
                 case long[] longs:
-                    values = Array.ConvertAll(longs, v => unchecked((int)v));
+                    // CarIdx bitfield arrays only define the lower 32 bits; mask intentionally.
+                    values = Array.ConvertAll(longs, v => unchecked((int)(v & 0xFFFFFFFF)));
                     return true;
                 case ulong[] ulongs:
-                    values = Array.ConvertAll(ulongs, v => unchecked((int)v));
+                    values = Array.ConvertAll(ulongs, v => unchecked((int)(v & 0xFFFFFFFF)));
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
### Motivation
- Fix incorrect values produced when converting `long[]`/`ulong[]` CarIdx bitfield arrays to `int[]` by ensuring only the lower 32 bits are used.

### Description
- Update `TryConvertToIntArray` in `LalaLaunch.cs` to mask `long`/`ulong` elements with `v & 0xFFFFFFFF` and cast via `unchecked((int)(...))`, and add a comment documenting the intentional 32-bit bitfield handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7b3ed254832f8c120c7886487c8f)