### PR TITLE
Avoid treating unknown session flags/material as compromised evidence

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -780,8 +780,9 @@ namespace LaunchPlugin
             }
 
             bool offTrackEvidence = !slot.IsOnTrack && !slot.IsOnPitRoad && slot.TrackSurfaceRaw != TrackSurfaceUnknown;
-            bool materialOffTrack = slot.TrackSurfaceMaterialRaw >= 15;
-            bool sessionFlagged = (unchecked((uint)slot.SessionFlagsRaw) & (uint)SessionFlagMaskCompromised) != 0;
+            bool materialOffTrack = slot.TrackSurfaceMaterialRaw >= 0 && slot.TrackSurfaceMaterialRaw >= 15;
+            bool sessionFlagged = slot.SessionFlagsRaw >= 0
+                && (unchecked((uint)slot.SessionFlagsRaw) & (uint)SessionFlagMaskCompromised) != 0;
             return offTrackEvidence || materialOffTrack || sessionFlagged;
         }
 


### PR DESCRIPTION
### Motivation
- CarSA Phase 2.2 showed StatusE stuck on CMP because `SessionFlagsRaw` defaulted to -1 and the existing bitmask treated it as `0xFFFFFFFF`, always indicating compromised. 
- Apply a minimal, C# 7.3-compatible fix that does not change Phase 1 slotting/wrap math or the existing StatusE ladder and evaluation order.

### Description
- In `IsCompromisedEvidence(CarSASlot)` guard material evidence so `TrackSurfaceMaterialRaw` only counts when it is a valid non-negative value and `>= 15` by using `slot.TrackSurfaceMaterialRaw >= 0 && slot.TrackSurfaceMaterialRaw >= 15`. 
- In `IsCompromisedEvidence(CarSASlot)` guard session-flag evidence so `SessionFlagsRaw` is only interpreted when it is a valid non-negative value by using `slot.SessionFlagsRaw >= 0 && (unchecked((uint)slot.SessionFlagsRaw) & (uint)SessionFlagMaskCompromised) != 0`. 
- Leave the existing `offTrackEvidence` and pit-road exclusion logic unchanged to avoid introducing CMP on pit road and to keep StatusE ordering intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f8cc2a13c832f953705852e7e0e35)