### PR TITLE
Harden CarSA S/F gating, rebind settle, behind-wrap, labels and raw telemetry

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -49,6 +49,7 @@ namespace LaunchPlugin
         public double RealGapAdjSec { get; set; } = double.NaN;
         public double LastSeenCheckpointTimeSec { get; set; } = 0.0;
         public bool JustRebound { get; set; }
+        public double ReboundTimeSec { get; set; } = 0.0;
 
         internal double LastGapUpdateTimeSec { get; set; } = 0.0;
         internal double LastGapSec { get; set; } = double.NaN;
@@ -97,6 +98,7 @@ namespace LaunchPlugin
             RealGapAdjSec = double.NaN;
             LastSeenCheckpointTimeSec = 0.0;
             JustRebound = false;
+            ReboundTimeSec = 0.0;
             LastGapUpdateTimeSec = 0.0;
             LastGapSec = double.NaN;
             HasGap = false;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4914,6 +4914,11 @@ namespace LaunchPlugin
                 UpdateCarSaRawSlots(outputs.AheadSlots, paceFlags, sessionFlags, trackSurfaceMaterial, hasPaceFlags, hasSessionFlags, hasTrackSurfaceMaterial);
                 UpdateCarSaRawSlots(outputs.BehindSlots, paceFlags, sessionFlags, trackSurfaceMaterial, hasPaceFlags, hasSessionFlags, hasTrackSurfaceMaterial);
             }
+            else
+            {
+                ClearCarSaRawSlots(outputs.AheadSlots);
+                ClearCarSaRawSlots(outputs.BehindSlots);
+            }
 
             if (includeSlots && debugEnabled)
             {
@@ -4972,6 +4977,7 @@ namespace LaunchPlugin
                 slot.PaceFlagsRaw = -1;
                 slot.SessionFlagsRaw = -1;
                 slot.TrackSurfaceMaterialRaw = -1;
+                slot.TrackSurfaceRaw = int.MinValue;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Reduce Start/Finish (S/F) false suppression by tightening the lap-delta edge guard and requiring real proximity evidence before suppressing lap-delta corrections.
- Make slot rebind settling robust to out-of-order packets by extending the one-tick rebound guard to a short time window.
- Prevent behind-wrap misfires when a car is legitimately half-a-lap behind and tidy up StatusE label strings and raw telemetry bookkeeping for clearer CSV debug output.

### Description
- Tightened S/F edge guard by changing `LapDeltaWrapEdgePct` from `0.15` to `0.05` and added a proximity gate that requires the absolute checkpoint time gap to be within `5.0` seconds before treating a lap-delta as a wrap-straddle; the exact constants used are `LapDeltaWrapEdgePct = 0.05`, proximity threshold = `5.0` seconds, and rebind settle duration = `0.10` seconds.
- Added a per-slot `ReboundTimeSec` field and set it when a slot is assigned so rebind settling now suppresses lap-delta/behind-wrap corrections until `(sessionTimeSec - ReboundTimeSec) > 0.10`.
- Modernized the real-gap logic to only suppress lap-delta corrections when both players are near the wrap edge, are physically close in lap-pct, and the checkpoint time gap is within `5.0`s, and prevented clearing the `JustRebound` flag until the settle window elapses.
- Kept behind-wrap time adjustment behavior but blocked it during the rebind settle window and preserved the rule that behind-wrap time adjustment only applies when `LapDelta == 0`.
- Updated other-class StatusE display strings without changing numeric values so `200` now shows short `"OC"` / long `"Other class"` and `210` now shows short `"OC2"` / long `"Other class (reserved)"`.
- Hardened raw-telemetry plumbing by clearing per-slot raw fields when slot inclusion is disabled and explicitly clearing `TrackSurfaceRaw` to `int.MinValue` to avoid stale raw telemetry latching CMP evidence.

### Testing
- No automated tests were executed for this change set.
- Changes were limited and local to `CarSAEngine.cs`, `CarSASlot.cs`, and `LalaLaunch.cs` to keep impacts minimal and focused on the described hardening behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9b2dbb80832f82ae4cb5507ce90c)