### PR TITLE
Add Track vs Race gap outputs for CarSA Phase 1

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -33,6 +33,8 @@ namespace LaunchPlugin
         public bool IsOnPitRoad { get; set; }
         public bool IsValid { get; set; }
         public int LapDelta { get; set; }
+        public double GapTrackSec { get; set; } = double.NaN;
+        public double GapRaceSec { get; set; } = double.NaN;
         public double GapRealSec { get; set; } = double.NaN;
         public double ClosingRateSecPerSec { get; set; } = double.NaN;
         public int Status { get; set; } = (int)CarSAStatus.Unknown;
@@ -82,6 +84,8 @@ namespace LaunchPlugin
             IsOnPitRoad = false;
             IsValid = false;
             LapDelta = 0;
+            GapTrackSec = double.NaN;
+            GapRaceSec = double.NaN;
             GapRealSec = double.NaN;
             ClosingRateSecPerSec = double.NaN;
             Status = (int)CarSAStatus.Unknown;

--- a/Docs/Subsystems/CarSA.md
+++ b/Docs/Subsystems/CarSA.md
@@ -83,7 +83,7 @@ CarSA now publishes a Traffic SA “E-number” ladder per slot for dash filteri
 **Phase 2.1 logic (per slot, priority order):**
 1. If the slot is not valid **or** not on track ⇒ `NotRelevant` (190).
 2. If `IsOnPitRoad` ⇒ `InPits` (110).
-3. If `abs(GapRealSec) > NotRelevantGapSec` ⇒ `NotRelevant` (190).
+3. If `abs(GapTrackSec) > NotRelevantGapSec` ⇒ `NotRelevant` (190).
 4. Else ⇒ `Unknown` (0) for Phase 2.1 (OutLap/Faster/Slower/Racing/Lapping/BeingLapped remain inactive).
 
 **Configuration:**
@@ -102,7 +102,7 @@ System:
 Slots (Ahead01..Ahead05, Behind01..Behind05):
 - Identity: `CarIdx`, `Name`, `CarNumber`, `ClassColor`
 - State: `IsOnTrack`, `IsOnPitRoad`, `IsValid`
-- Spatial: `LapDelta`, `Gap.RealSec`
+- Spatial: `LapDelta`, `Gap.RealSec`, `Gap.TrackSec`, `Gap.RaceSec`
 - Derived: `ClosingRateSecPerSec`, `Status`, `StatusE`, `StatusShort`, `StatusLong`
 
 Debug (`Car.Debug.*`):

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3442,6 +3442,8 @@ namespace LaunchPlugin
                 AttachCore($"Car.Ahead{label}.IsValid", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].IsValid ?? false);
                 AttachCore($"Car.Ahead{label}.LapDelta", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].LapDelta ?? 0);
                 AttachCore($"Car.Ahead{label}.Gap.RealSec", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].GapRealSec ?? double.NaN);
+                AttachCore($"Car.Ahead{label}.Gap.TrackSec", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].GapTrackSec ?? double.NaN);
+                AttachCore($"Car.Ahead{label}.Gap.RaceSec", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].GapRaceSec ?? double.NaN);
                 AttachCore($"Car.Ahead{label}.ClosingRateSecPerSec", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].ClosingRateSecPerSec ?? double.NaN);
                 AttachCore($"Car.Ahead{label}.Status", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].Status ?? 0);
                 AttachCore($"Car.Ahead{label}.StatusE", () => _carSaEngine?.Outputs.AheadSlots[slotIndex].StatusE ?? 0);
@@ -3464,6 +3466,8 @@ namespace LaunchPlugin
                 AttachCore($"Car.Behind{label}.IsValid", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].IsValid ?? false);
                 AttachCore($"Car.Behind{label}.LapDelta", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].LapDelta ?? 0);
                 AttachCore($"Car.Behind{label}.Gap.RealSec", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].GapRealSec ?? double.NaN);
+                AttachCore($"Car.Behind{label}.Gap.TrackSec", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].GapTrackSec ?? double.NaN);
+                AttachCore($"Car.Behind{label}.Gap.RaceSec", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].GapRaceSec ?? double.NaN);
                 AttachCore($"Car.Behind{label}.ClosingRateSecPerSec", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].ClosingRateSecPerSec ?? double.NaN);
                 AttachCore($"Car.Behind{label}.Status", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].Status ?? 0);
                 AttachCore($"Car.Behind{label}.StatusE", () => _carSaEngine?.Outputs.BehindSlots[slotIndex].StatusE ?? 0);
@@ -5112,6 +5116,8 @@ namespace LaunchPlugin
                 buffer.Append("NaN,");
                 buffer.Append("NaN,");
                 buffer.Append("NaN,");
+                buffer.Append("NaN,");
+                buffer.Append("NaN,");
                 buffer.Append("0,");
                 buffer.Append("0,");
                 buffer.Append("0,");
@@ -5145,6 +5151,8 @@ namespace LaunchPlugin
             buffer.Append(slot.CarIdx).Append(',');
             buffer.Append((isAhead ? slot.ForwardDistPct : slot.BackwardDistPct).ToString("F6", CultureInfo.InvariantCulture)).Append(',');
             buffer.Append(slot.GapRealSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
+            buffer.Append(slot.GapTrackSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
+            buffer.Append(slot.GapRaceSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
             buffer.Append(slot.ClosingRateSecPerSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
             buffer.Append(slot.LapDelta).Append(',');
             buffer.Append(slot.IsOnTrack ? 1 : 0).Append(',');
@@ -5284,14 +5292,14 @@ namespace LaunchPlugin
         private static string GetCarSaDebugExportHeader()
         {
             return "SessionTimeSec,PlayerLap,PlayerLapPct,CheckpointIndexNow,CheckpointIndexCrossed,NotRelevantGapSec," +
-                   "Ahead01.CarIdx,Ahead01.ForwardDistPct,Ahead01.GapRealSec,Ahead01.ClosingRateSecPerSec,Ahead01.LapDelta,Ahead01.IsOnTrack,Ahead01.IsOnPitRoad," +
+                   "Ahead01.CarIdx,Ahead01.ForwardDistPct,Ahead01.GapRealSec,Ahead01.GapTrackSec,Ahead01.GapRaceSec,Ahead01.ClosingRateSecPerSec,Ahead01.LapDelta,Ahead01.IsOnTrack,Ahead01.IsOnPitRoad," +
                    "Ahead01.StatusE,Ahead01.StatusShort,Ahead01.StatusLong,Ahead01.OutLapLatched,Ahead01.CompromisedThisLapLatched," +
                    "Ahead01.CurrentLap,Ahead01.LastLap,Ahead01.OutLapActive,Ahead01.OutLapLap,Ahead01.WasOnPitRoad,Ahead01.CompromisedLap," +
                    "Ahead01.CmpFlag_Black,Ahead01.CmpFlag_Furled,Ahead01.CmpFlag_Repair,Ahead01.CmpFlag_Disqualify," +
                    "Ahead01.TrackSurfaceRaw,Ahead01.TrackSurfaceMaterialRaw,Ahead01.SessionFlagsRaw," +
                    "Ahead01.CmpEvidence_OffTrack,Ahead01.CmpEvidence_Material,Ahead01.CmpEvidence_SessionFlags," +
                    "Ahead01.StatusEReason,Ahead01.StatusEChanged,Ahead01.CarIdxChanged," +
-                   "Behind01.CarIdx,Behind01.BackwardDistPct,Behind01.GapRealSec,Behind01.ClosingRateSecPerSec,Behind01.LapDelta,Behind01.IsOnTrack,Behind01.IsOnPitRoad," +
+                   "Behind01.CarIdx,Behind01.BackwardDistPct,Behind01.GapRealSec,Behind01.GapTrackSec,Behind01.GapRaceSec,Behind01.ClosingRateSecPerSec,Behind01.LapDelta,Behind01.IsOnTrack,Behind01.IsOnPitRoad," +
                    "Behind01.StatusE,Behind01.StatusShort,Behind01.StatusLong,Behind01.OutLapLatched,Behind01.CompromisedThisLapLatched," +
                    "Behind01.CurrentLap,Behind01.LastLap,Behind01.OutLapActive,Behind01.OutLapLap,Behind01.WasOnPitRoad,Behind01.CompromisedLap," +
                    "Behind01.CmpFlag_Black,Behind01.CmpFlag_Furled,Behind01.CmpFlag_Repair,Behind01.CmpFlag_Disqualify," +


### PR DESCRIPTION
### Motivation

- Fix semantic mismatch where the published gap used by SA included a lap-delta term, making proximity and relevance decisions incorrect when `LapDelta != 0`.
- Provide both a physical on-track proximity gap and a race-style gap so dashboards and SA logic can choose the correct metric.

### Description

- Added `GapTrackSec` and `GapRaceSec` fields to `CarSASlot` and initialize/reset them to `NaN` in `CarSASlot.cs`.
- Compute both gaps in `CarSAEngine.UpdateRealGaps`: `TrackGapSec` (physical on-track proximity, no `lapDelta` term) and `RaceGapSec` (existing behavior: includes `lapDelta * lapTimeEstimateSec` and existing S/F suppression rules), and kept `GapRealSec` aligned to the race-style gap for backward compatibility; code comments explicitly document each meaning.
- Switched NotRelevant gating to use `GapTrackSec` (`abs(GapTrackSec) > NotRelevantGapSec` → `NotRelevant`) and changed closing-rate calculations to derive from `GapTrackSec` so proximity/closing reflect on-track distance.
- Exported new SimHub properties in `LalaLaunch.cs`: `Car.AheadXX.Gap.TrackSec` and `Car.AheadXX.Gap.RaceSec` (and corresponding `Car.BehindXX.*`), while keeping `Car.AheadXX.Gap.RealSec` / `Car.BehindXX.Gap.RealSec` unchanged.
- Extended debug CSV (`CarSA_Debug_*.csv`) header and row output to include `Ahead01.GapTrackSec`, `Ahead01.GapRaceSec`, `Behind01.GapTrackSec`, and `Behind01.GapRaceSec` (without removing existing columns).
- Updated docs (`Docs/Subsystems/CarSA.md`) to reflect that NotRelevant gating and exports now include `Gap.TrackSec`/`Gap.RaceSec` and that `Gap.RealSec` remains the race-style gap.

Files changed: `CarSASlot.cs`, `CarSAEngine.cs`, `LalaLaunch.cs`, `Docs/Subsystems/CarSA.md`.

Key explicit notes:
- `Gap.RealSec` remains the race-style gap (includes lap-delta) for backward compatibility.
- New exported properties: `Car.AheadXX.Gap.TrackSec`, `Car.BehindXX.Gap.TrackSec`, `Car.AheadXX.Gap.RaceSec`, `Car.BehindXX.Gap.RaceSec`.
- `NotRelevant` gating and `ClosingRateSecPerSec` now use `GapTrackSec` (physical on-track proximity).

### Testing

- No automated tests were executed as part of this change.
- Changes include conservative, additive exports and keep existing `Gap.RealSec` behavior to minimize integration risk; manual/runtime validation recommended in a live session to verify behavior when `LapDelta != 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fabf5c148832f912ba5d58d72b2ff)