### PR TITLE
Update docs for PRs 282–309: CarSA Phase 2.2, SimHub inventory, and repo status

### DIFF
--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
-Validated against commit: 708af0f  
-Last updated: 2026-01-27  
+Validated against commit: 7c6262b  
+Last updated: 2026-02-01  
 Branch: work
 
 ## What this repo is
@@ -40,7 +40,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - **Truth docs:** `SimHubParameterInventory.md`, `SimHubLogMessages.md`, `FuelProperties_Spec.md`, `FuelTab_SourceFlowNotes.md`, `Reset_And_Session_Identity.md`, `TimerZeroBehavior.md`, `CarProfiles-Legacy-Map.md` (schema + storage).
 - **Subsystem notes:** `Message_Catalog_v5_Signal_Mapping_Report.md`, `FuelTab_LeaderPaceFlow.md`, `FuelTabActionPlanOptions.md`, `FuelTabAnalysis.md`, `LALA-036-extra-time-sanity.md`, `LalaLaunch_Handover_Summary-20251130.docx`, `Subsystems/Pit_Entry_Assist.md`, `Subsystems/Track_Markers.md`, `Subsystems/Dash_Integration.md`, `Subsystems/MessageEngineV1_Notes.md`, `Subsystems/Profiles_And_PB.md`.
 - **Workflow/process:** `BranchWorkflow.md`, `ConflictResolution.md`, `RepoStatus.md`.
-- **Legacy / reference-only:** `SimHub_Parameter_Inventory.xlsx`, `FuelProperties_Spec.xlsx`, `FuelProperties_Spec (version 1).xlsx`, `Message_Catalog_v5.xlsx`, `Message_Catalog_v5_MessageToSignal_Map.csv`, `Message_Catalog_v5_Signals.csv`, `CarInfo_AllCars.xlsx`, `Codex_Task_Backlog-20251215.xlsx`, `Dahl Design → Lala Launch Mapping (lala Dash).docx`, `Dahl Design → Lala Launch Message Properties Mapping.docx`, `Dash Design.pptx`, `Dual Clutch Logic.docx`, `Phase 1 and 2 Test Script-20251202.docx`, `SessionResetIssues.docx`, `SimHub_DualClutch_Paddle_Guide.docx`, `TestingData.djson`, `UI Work.pptx`. Keep for reference; they are superseded by the canonical files above unless explicitly cited.
+- **Legacy / reference-only:** `FuelProperties_Spec.xlsx`, `FuelProperties_Spec (version 1).xlsx`, `Message_Catalog_v5.xlsx`, `Message_Catalog_v5_MessageToSignal_Map.csv`, `Message_Catalog_v5_Signals.csv`, `CarInfo_AllCars.xlsx`, `Codex_Task_Backlog-20251215.xlsx`, `Dahl Design → Lala Launch Mapping (lala Dash).docx`, `Dahl Design → Lala Launch Message Properties Mapping.docx`, `Dash Design.pptx`, `Dual Clutch Logic.docx`, `Phase 1 and 2 Test Script-20251202.docx`, `SessionResetIssues.docx`, `SimHub_DualClutch_Paddle_Guide.docx`, `TestingData.djson`, `UI Work.pptx`. Keep for reference; they are superseded by the canonical files above unless explicitly cited.
 - **Archived:** leave everything under `/Docs/Archived` untouched.
 
 ## Subsystem map
@@ -63,7 +63,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 ## Canonical docs map
 | Topic | Canonical file | Notes |
 | --- | --- | --- |
-| SimHub exports | [SimHubParameterInventory.md](SimHubParameterInventory.md) | `SimHub_Parameter_Inventory.xlsx` is **LEGACY/REFERENCE ONLY**. |
+| SimHub exports | [SimHubParameterInventory.md](SimHubParameterInventory.md) | Legacy spreadsheet removed; use this file only. |
 | SimHub log catalogue | [SimHubLogMessages.md](SimHubLogMessages.md) | Use this list; no parallel copies. |
 | Fuel model & pit rules | [FuelProperties_Spec.md](FuelProperties_Spec.md) | `FuelProperties_Spec.xlsx` and `FuelProperties_Spec (version 1).xlsx` are **LEGACY/REFERENCE ONLY**. |
 | Fuel tab data flow | [FuelTab_SourceFlowNotes.md](FuelTab_SourceFlowNotes.md) | Earlier analysis docs remain for context only. |
@@ -80,6 +80,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - Fuel tab/UI source or planner changes → update `FuelTab_SourceFlowNotes.md`.
 
 ## Freshness
-- Validated against commit: 708af0f  
-- Date: 2026-01-27  
+- Validated against commit: 7c6262b  
+- Date: 2026-02-01  
 - Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -3,7 +3,7 @@
 ## What exists in this checkout right now
 - Only one local branch is present: `work`.
 - There is no Git remote configured, so nothing in this checkout is currently linked to GitHub.
-- The latest commit on `work` is the current HEAD with PRs #241–#281 (session summary v2 mapping, profile schema upgrades, JSON storage standardization, live max-fuel handling, preset/live snapshot fixes, messaging signals, dash overlay visibility controls, pit-entry assist manual mode, pit-entry debrief/time-loss outputs, stint burn targets, wet/dry stat gating, and wet-surface detection). Use `git log --oneline -n 22` to see the recent merges if you want to double-check.
+- The latest commit on `work` is the current HEAD with PRs #282–#309 (Fuel planner max-fuel percent/preset handling, live snapshot max-tank sync, predictor outputs, Opponents/CarSA documentation, extensive CarSA Phase 2.2 updates including status ladder expansions, raw telemetry flags, debug export improvements, identity refresh hardening, and new track vs race gap outputs). Use `git log --oneline -n 22` to see the recent merges if you want to double-check.
 
 ## How to connect this checkout to your GitHub repo
 1. Add your GitHub remote (replace the URL with your actual repository clone URL):
@@ -61,13 +61,14 @@
 - **Pit loss locking:** **COMPLETE** — per-track pit loss values can be locked to block auto-updates; blocked candidates are captured and surfaced in the Profiles UI for review before manual unlock.
 - **Pit-exit prediction audit + settled logging:** **COMPLETE** — pit-exit predictor now locks pit-loss and gap inputs at pit entry to avoid drift, logs richer pit-in/out snapshots plus math audit, and emits a one-lap-delayed “pit-out settled” confirmation.
 - **Opponents subsystem:** **COMPLETE** — race-only opponent pace/fight and pit-exit prediction exports with lap gate ≥1, summary strings, and log support.
+- **CarSA Phase 2.2:** **COMPLETE** — slot identity refresh hardening, StatusE ladder (out-lap, compromised, lapping, racing, other-class), raw telemetry flag ingest, track vs race gap outputs, and expanded debug export columns.
 - **Dry/Wet condition lock UI:** **COMPLETE** — per-track dry/wet condition lock toggles persist immediately in profiles (no save prompt).
 - **Session summary + trace v2:** **COMPLETE** — session summary CSV v2, lap trace rows with pit-stop index/phase, corrected pit-stop counting semantics, and explicit CSV column mapping for summary exports.
 - **Profile storage & schema:** **COMPLETE** — car profiles now save in a schema-v2 wrapper with opt-in track stats serialization, normalized track keys, and legacy JSON migration from older filenames/locations.
 - **Fuel + pace live persistence:** **COMPLETE** — dry/wet fuel burn windows and average lap times persist into track profiles once sample thresholds are met, with condition-specific “last updated” metadata.
 - **Profiles UI controls:** **COMPLETE** — base tank litres field with “learn from live” action, plus “relearn” buttons for pit data and dry/wet condition resets.
 - **Pit cycle guards:** **COMPLETE** — pit loss persistence now skips NaN/invalid candidates; PitLite entry arming is gated to avoid false triggers in pit stalls.
-- **Fuel planner max-fuel handling:** **COMPLETE** — profile-mode max fuel override is clamped to per-car base tank; Live Snapshot mode uses live session cap (MaxFuel × BoP, defaulting BoP to 1.0) and raises a clear error when live cap is unavailable. The Live Session panel clears max-fuel displays when the cap is missing.
+- **Fuel planner max-fuel handling:** **COMPLETE** — profile-mode max fuel override is clamped to per-car base tank; preset max fuel values are stored as % of base tank; Live Snapshot mode uses live session cap (MaxFuel × BoP, defaulting BoP to 1.0) and raises a clear error when live cap is unavailable. The Live Session panel clears max-fuel displays when the cap is missing.
 - **Live Snapshot + presets:** **COMPLETE** — changing car/track clears the Live Snapshot UI to avoid stale data; switching back to Profile mode restores the previous profile max-fuel override and re-applies the selected preset.
 - **Messaging signals:** **COMPLETE** — `MSG.OtherClassBehindGap` exported for multi-class approach messaging; no `MSGOtherClassBehindGap` alias remains.
 - **Stint burn targets:** **COMPLETE** — live “current tank” burn guidance exported with banding (SAVE/HOLD/PUSH/OKAY) and a configurable pit-in reserve expressed as % of one lap’s stable burn.

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -2,13 +2,13 @@
 
 **CANONICAL CONTRACT**
 
-Validated against: b45bc8f  
-Last reviewed: 2026-02-12  
-Last updated: 2026-02-12  
+Validated against: 7c6262b  
+Last reviewed: 2026-02-01  
+Last updated: 2026-02-01  
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
-- Legacy spreadsheet `SimHub_Parameter_Inventory.xlsx` is reference-only; this file is canonical.
+- Legacy spreadsheet removed; this file is canonical.
 - “Defined in” lists the class/method that computes the value before `AttachCore/AttachVerbose` publishes it.
 
 ## Fuel
@@ -93,9 +93,10 @@ Branch: work
 | Car.Valid | bool | True when CarSA has a valid player index and CarIdx lap pct truth for the tick. | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L74-L233】【F:LalaLaunch.cs†L3414-L3418】 |
 | Car.Source | string | Source label (Phase 1: `CarIdxTruth`). | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L74-L87】【F:LalaLaunch.cs†L3414-L3418】 |
 | Car.Checkpoints / Car.SlotsAhead / Car.SlotsBehind | int | Checkpoint count (60) and slot counts (5/5). | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L7-L11】【F:LalaLaunch.cs†L3414-L3418】 |
-| Car.Ahead01..Ahead05.* | mixed | Slot outputs for nearest ahead cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.RealSec (signed +), ClosingRateSecPerSec, Status, StatusE, StatusShort, StatusLong. | Per tick; RealGap updates every tick using `PlayerCheckpointIndexNow`. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3419-L3436】 |
-| Car.Behind01..Behind05.* | mixed | Slot outputs for nearest behind cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.RealSec (signed −), ClosingRateSecPerSec, Status, StatusE, StatusShort, StatusLong. | Per tick; RealGap updates every tick using `PlayerCheckpointIndexNow`. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3438-L3455】 |
-| Car.Debug.* | mixed | Debug telemetry for player checkpoint indices (`PlayerCheckpointIndexNow`, `PlayerCheckpointIndexCrossed`, `PlayerCheckpointCrossed`), slot validation, and RealGap inspection (Ahead01/Behind01 only), including half-lap filter counters, timestamp update counters (`TimestampUpdatesThisTick`, `TimestampUpdatesSinceLastPlayerCross`), and slot swap counts (`SlotCarIdxChangedThisTick`). | Per tick. | `CarSAEngine.cs` debug fields + `AttachCore`【F:CarSAEngine.cs†L85-L283】【F:LalaLaunch.cs†L3458-L3475】 |
+| Car.Player.PaceFlagsRaw / SessionFlagsRaw / TrackSurfaceMaterialRaw | int | Raw telemetry flags for the player CarIdx row (or -1 if missing). Only populated when raw-telemetry mode is enabled. | Per tick. | `LalaLaunch.cs` raw telemetry debug + `AttachCore`【F:LalaLaunch.cs†L3429-L3431】【F:LalaLaunch.cs†L4874-L4917】 |
+| Car.Ahead01..Ahead05.* | mixed | Slot outputs for nearest ahead cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.RealSec (signed +), Gap.TrackSec (proximity), Gap.RaceSec (lap-delta adjusted), ClosingRateSecPerSec, Status, StatusE, StatusShort, StatusLong, PaceFlagsRaw, SessionFlagsRaw, TrackSurfaceMaterialRaw. | Per tick; RealGap updates every tick using `PlayerCheckpointIndexNow`. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3419-L3446】 |
+| Car.Behind01..Behind05.* | mixed | Slot outputs for nearest behind cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.RealSec (signed −), Gap.TrackSec (proximity), Gap.RaceSec (lap-delta adjusted), ClosingRateSecPerSec, Status, StatusE, StatusShort, StatusLong, PaceFlagsRaw, SessionFlagsRaw, TrackSurfaceMaterialRaw. | Per tick; RealGap updates every tick using `PlayerCheckpointIndexNow`. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3448-L3470】 |
+| Car.Debug.* | mixed | Debug telemetry for player checkpoint indices (`PlayerCheckpointIndexNow`, `PlayerCheckpointIndexCrossed`, `PlayerCheckpointCrossed`), slot validation, and RealGap inspection (Ahead01/Behind01 only), including half-lap filter counters, timestamp update counters (`TimestampUpdatesThisTick`, `TimestampUpdatesSinceLastPlayerCross`), slot swap counts (`SlotCarIdxChangedThisTick`), raw telemetry availability (`HasCarIdxPaceFlags`, `HasCarIdxSessionFlags`, `HasCarIdxTrackSurfaceMaterial`), and read diagnostics (`RawTelemetryReadMode`, `RawTelemetryFailReason`). | Per tick. | `CarSAEngine.cs` debug fields + `AttachCore`【F:CarSAEngine.cs†L85-L283】【F:LalaLaunch.cs†L3458-L3487】 |
 
 ## Pit timing and PitLite
 | Exported name | Type | Units / meaning | Update cadence | Defined in |


### PR DESCRIPTION
### Motivation
- Bring repository documentation up to date for the set of recent PRs (282–309) so canonical docs reflect new CarSA behaviour, Opponents/Planner outputs and planner max-fuel/preset handling. 
- Ensure subsystem descriptions and SimHub export inventory live under the `Docs/Subsystems` and `Docs/SimHubParameterInventory.md` boundaries and include the new raw-telemetry and gap semantics. 
- Remove or deprecate stale/legacy references (legacy parameter spreadsheet) and refresh doc freshness/validated commit metadata so readers can rely on the canonical sources.

### Description
- Expanded `Docs/Subsystems/CarSA.md` to Phase 2.2 and added `StatusE` ladder details, the Phase 2.2 per-slot priority logic, gap semantics (`Gap.TrackSec`/`Gap.RaceSec`/`Gap.RealSec`), raw telemetry flags, and a more detailed `CarSA` debug-export column specification. 
- Updated `Docs/SimHubParameterInventory.md` to document the new `Car.*` exports (player raw flag fields, slot raw flag fields, `Gap.TrackSec`/`Gap.RaceSec` distinctions, and debug diagnostics), and refreshed the file’s validated-commit and last-reviewed dates. 
- Revised `Docs/Project_Index.md` and `Docs/RepoStatus.md` to cover PRs #282–#309, remove the legacy `SimHub_Parameter_Inventory.xlsx` spreadsheet reference, note the changed canonical sources, and surface the CarSA/Planner highlights (raw flags, track vs race gap outputs, max-fuel preset percent behaviour, and CarSA identity/debug improvements). 
- No source code changes were made; modified docs only: `Docs/Subsystems/CarSA.md`, `Docs/SimHubParameterInventory.md`, `Docs/Project_Index.md`, and `Docs/RepoStatus.md`.

### Testing
- Automated tests: none executed because this is a documentation-only change. 
- Repository hygiene: changes were committed to the `work` branch and the repo metadata headers were updated to reference the current commit (`7c6262b`) and date (`2026-02-01`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697faee526bc832f891417d8a8785ea3)