### PR TITLE
Apply behind-wrap to TrackGap regardless of LapDelta and expose BehindWrapApplied for debugging

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -50,6 +50,7 @@ namespace LaunchPlugin
         public double RealGapRawSec { get; set; } = double.NaN;
         public double RealGapAdjSec { get; set; } = double.NaN;
         public double LastSeenCheckpointTimeSec { get; set; } = 0.0;
+        public bool BehindWrapApplied { get; set; }
         public bool JustRebound { get; set; }
         public double ReboundTimeSec { get; set; } = 0.0;
 
@@ -101,6 +102,7 @@ namespace LaunchPlugin
             RealGapRawSec = double.NaN;
             RealGapAdjSec = double.NaN;
             LastSeenCheckpointTimeSec = 0.0;
+            BehindWrapApplied = false;
             JustRebound = false;
             ReboundTimeSec = 0.0;
             LastGapUpdateTimeSec = 0.0;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5119,6 +5119,8 @@ namespace LaunchPlugin
                 buffer.Append("NaN,");
                 buffer.Append("NaN,");
                 buffer.Append("0,");
+                buffer.Append("NaN,");
+                buffer.Append("0,");
                 buffer.Append("0,");
                 buffer.Append("0,");
                 buffer.Append("0,");
@@ -5153,6 +5155,8 @@ namespace LaunchPlugin
             buffer.Append(slot.GapRealSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
             buffer.Append(slot.GapTrackSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
             buffer.Append(slot.GapRaceSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
+            buffer.Append(slot.RealGapRawSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
+            buffer.Append(slot.BehindWrapApplied ? 1 : 0).Append(',');
             buffer.Append(slot.ClosingRateSecPerSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
             buffer.Append(slot.LapDelta).Append(',');
             buffer.Append(slot.IsOnTrack ? 1 : 0).Append(',');
@@ -5292,14 +5296,14 @@ namespace LaunchPlugin
         private static string GetCarSaDebugExportHeader()
         {
             return "SessionTimeSec,PlayerLap,PlayerLapPct,CheckpointIndexNow,CheckpointIndexCrossed,NotRelevantGapSec," +
-                   "Ahead01.CarIdx,Ahead01.ForwardDistPct,Ahead01.GapRealSec,Ahead01.GapTrackSec,Ahead01.GapRaceSec,Ahead01.ClosingRateSecPerSec,Ahead01.LapDelta,Ahead01.IsOnTrack,Ahead01.IsOnPitRoad," +
+                   "Ahead01.CarIdx,Ahead01.ForwardDistPct,Ahead01.GapRealSec,Ahead01.GapTrackSec,Ahead01.GapRaceSec,Ahead01.RealGapRawSec,Ahead01.BehindWrapApplied,Ahead01.ClosingRateSecPerSec,Ahead01.LapDelta,Ahead01.IsOnTrack,Ahead01.IsOnPitRoad," +
                    "Ahead01.StatusE,Ahead01.StatusShort,Ahead01.StatusLong,Ahead01.OutLapLatched,Ahead01.CompromisedThisLapLatched," +
                    "Ahead01.CurrentLap,Ahead01.LastLap,Ahead01.OutLapActive,Ahead01.OutLapLap,Ahead01.WasOnPitRoad,Ahead01.CompromisedLap," +
                    "Ahead01.CmpFlag_Black,Ahead01.CmpFlag_Furled,Ahead01.CmpFlag_Repair,Ahead01.CmpFlag_Disqualify," +
                    "Ahead01.TrackSurfaceRaw,Ahead01.TrackSurfaceMaterialRaw,Ahead01.SessionFlagsRaw," +
                    "Ahead01.CmpEvidence_OffTrack,Ahead01.CmpEvidence_Material,Ahead01.CmpEvidence_SessionFlags," +
                    "Ahead01.StatusEReason,Ahead01.StatusEChanged,Ahead01.CarIdxChanged," +
-                   "Behind01.CarIdx,Behind01.BackwardDistPct,Behind01.GapRealSec,Behind01.GapTrackSec,Behind01.GapRaceSec,Behind01.ClosingRateSecPerSec,Behind01.LapDelta,Behind01.IsOnTrack,Behind01.IsOnPitRoad," +
+                   "Behind01.CarIdx,Behind01.BackwardDistPct,Behind01.GapRealSec,Behind01.GapTrackSec,Behind01.GapRaceSec,Behind01.RealGapRawSec,Behind01.BehindWrapApplied,Behind01.ClosingRateSecPerSec,Behind01.LapDelta,Behind01.IsOnTrack,Behind01.IsOnPitRoad," +
                    "Behind01.StatusE,Behind01.StatusShort,Behind01.StatusLong,Behind01.OutLapLatched,Behind01.CompromisedThisLapLatched," +
                    "Behind01.CurrentLap,Behind01.LastLap,Behind01.OutLapActive,Behind01.OutLapLap,Behind01.WasOnPitRoad,Behind01.CompromisedLap," +
                    "Behind01.CmpFlag_Black,Behind01.CmpFlag_Furled,Behind01.CmpFlag_Repair,Behind01.CmpFlag_Disqualify," +


### PR DESCRIPTION
### Motivation
- Fix an issue where `Gap.TrackSec` could erroneously show ~one lap time when `LapDelta != 0` because behind-wrap was only applied in the `lapDelta == 0` branch.
- `TrackGap` must represent on-track proximity independent of lap counts while `RaceGap` keeps lap-context, and the existing S/F suppression and rebind-settle guards must be preserved.
- Add debug visibility so wrap corrections can be audited in logs/CSV to help diagnose edge cases.

### Description
- Apply behind-wrap to compute `trackGap` from `rawGap` before applying any lap-delta adjustment and run that behind-wrap logic regardless of `lapDelta`, still honoring `inRebindSettle` via `allowBehindWrap` and `suppressLapDeltaCorrection` (changes in `UpdateRealGaps` in `CarSAEngine.cs`).
- Derive `raceGap` from the finalized `trackGap` and only add `lapDelta * lapTimeEstimateSec` when `lapDelta != 0` and `allowLapDeltaAdjust` is true (keeps S/F suppression behavior intact).`
- Add a per-slot boolean `BehindWrapApplied` on `CarSASlot` and reset/set it when slots are rebound or when behind-wrap is applied, and clamp gaps as before (`MaxRealGapSec`).
- Extend the CarSA debug CSV export (`LalaLaunch.cs`) to include `RealGapRawSec` and `BehindWrapApplied` columns for Ahead/Behind rows to aid debugging.

### Testing
- No automated tests were executed as part of this change (no CI/test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb2ff4838832fbec874f62a842e95)