### PR TITLE
CarSAEngine: fallback to legacy heuristic when other-class rank unknown

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -941,7 +941,10 @@ namespace LaunchPlugin
                 }
                 else
                 {
-                    statusE = (int)CarSAStatusE.Unknown;
+                    // Fallback to legacy heuristic when rank is unknown/missing.
+                    statusE = isAhead
+                        ? (int)CarSAStatusE.SlowerClass
+                        : (int)CarSAStatusE.FasterClass;
                     statusEReason = StatusEReasonOtherClassUnknownRank;
                 }
             }


### PR DESCRIPTION
### Motivation
- Keep prior behaviour when the class-rank map is missing/partial by not downgrading other-class entries to `Unknown`; instead fall back to the legacy ahead/behind heuristic while still tagging the reason as `otherclass_unknownrank`.

### Description
- Replace the final `else` branch in `UpdateStatusE(...)` (other-class handling) to set `statusE = isAhead ? (int)CarSAStatusE.SlowerClass : (int)CarSAStatusE.FasterClass` and keep `statusEReason = StatusEReasonOtherClassUnknownRank`.
- Confirmed `using System.Linq;` is already present in `LalaLaunch.cs`, so no import change was required.

### Testing
- Attempted `dotnet build /workspace/LalaLaunchPlugin/LaunchPlugin.sln` to validate the solution, but the build could not be run because `dotnet` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b18574dc832f8393264399f7cc18)