### PR TITLE
Fix CarSA debug export CSV alignment

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4834,6 +4834,7 @@ namespace LaunchPlugin
                     _carSaDebugBehindDahlRelativeGapSec, _carSaDebugBehindIRacingRelativeGapSec);
 
                 AppendPlayerRawEvidence(buffer, outputs);
+                buffer.Append(',');
                 AppendCarSaClassRankDebug(buffer);
                 buffer.AppendLine();
 


### PR DESCRIPTION
### Motivation
- Ensure CSV rows from `WriteCarSaDebugExport` have the correct column separation so `PlayerPaceFlagsRaw` and `CarSA.ClassRankSource` are written as separate fields in every row without changing the CSV header or other logic.

### Description
- In `LalaLaunch.cs`, inside `WriteCarSaDebugExport`, insert a missing separator by adding `buffer.Append(',');` between `AppendPlayerRawEvidence(buffer, outputs);` and `AppendCarSaClassRankDebug(buffer);` so the two field groups are properly delimited.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811e539244832f8babab974de697ef)