### PR TITLE
Refresh CarSA documentation and repo status for PRs 310–320

### DIFF
--- a/Docs/Code_Snapshot.md
+++ b/Docs/Code_Snapshot.md
@@ -2,16 +2,16 @@
 
 # Code Snapshot
 
-- Source commit/PR: a5f6580 (current HEAD; CarSA PR312 follow-ups)
-- Generated date: 2026-02-01 (updated)
+- Source commit/PR: f4cd1fe (current HEAD; PRs 310–320 CarSA status + CSV/identity updates)
+- Generated date: 2026-02-03 (updated)
 - Regeneration: manual snapshot; no regen pipeline defined
 - Branch: work
 
 If this conflicts with Project_Index.md or contract docs, treat this as stale.
 
 ## Snapshot metadata (legacy)
-- Commit: a5f6580 (current HEAD)
-- Date: 2026-02-01 (updated)
+- Commit: f4cd1fe (current HEAD)
+- Date: 2026-02-03 (updated)
 
 ## Architectural notes (profiles, storage, fuel persistence)
 - **Standardized JSON storage** now resolves all plugin JSON data into `PluginsData/Common/LalaPlugin/` via `PluginStorage`, with built-in legacy migration helpers. Car profiles, race presets, message definitions, global settings, and track markers all use this storage helper for consistent locations and one-time migrations.【F:PluginStorage.cs†L1-L76】【F:ProfilesManagerViewModel.cs†L545-L936】【F:RacePresetStore.cs†L11-L140】【F:Messaging/MessageDefinitionStore.cs†L10-L120】【F:LalaLaunch.cs†L3469-L3510】
@@ -23,13 +23,14 @@ If this conflicts with Project_Index.md or contract docs, treat this as stale.
 - **Fuel planner max-fuel override** is clamped to the profile base tank in Profile mode; switching into Live Snapshot captures the prior override and uses the live cap (or 0 if missing), while switching back restores the profile value and re-applies any selected preset.【F:FuelCalcs.cs†L300-L405】【F:FuelCalcs.cs†L1821-L1884】
 - **Live Snapshot resets** clear live fuel/pace summaries when the car/track changes, ensuring the Live Session panel never shows profile fallback values during a new live session startup.【F:FuelCalcs.cs†L3270-L3703】
 - **Messaging signals** include `MSG.OtherClassBehindGap` (seconds behind a faster-class car) alongside `MSG.OvertakeApproachLine`, for use in message catalog evaluators.【F:MessagingSystem.cs†L13-L214】【F:LalaLaunch.cs†L3123-L3129】
-- **CarSA SA-Core v2** now computes distance-based gaps and player-centric closing rates from car-centric LapDistPct deltas, with a 0.5s grace window to avoid resets on brief telemetry blips. Slot gaps mirror this model; checkpoint-based RealGap no longer drives SA outputs.【F:CarSAEngine.cs†L70-L590】
-- **CarSA CSV debug cleanup** removes legacy gap columns and adds raw cross-check fields from DahlDesign and iRacing extras for Ahead01/Behind01 while preserving sign conventions as reported.【F:LalaLaunch.cs†L4366-L5321】
+- **CarSA SA-Core v2** uses car-centric LapDistPct deltas for distance-based gaps/closing with a 0.5s grace window, car-centric status memory for out-lap/compromised/penalty detection, and replay-safe identity refreshes for slot names/classes.【F:CarSAEngine.cs†L70-L590】【F:LalaLaunch.cs†L5485-L5692】
+- **CarSA StatusE + class rank** now distinguishes penalty vs off-track compromises, uses pit-surface classification, and prefers class-rank (CarClassRelSpeed/CarClassEstLapTime) for Faster/Slower class labels with a safe fallback when rank data is missing.【F:CarSAEngine.cs†L930-L1372】【F:LalaLaunch.cs†L4943-L5039】
+- **CarSA CSV debug export** adds StatusE reason + class-rank metadata and normalizes cross-check gap columns, with alignment fixes to keep headers and rows consistent.【F:LalaLaunch.cs†L4814-L5440】
 
 ## Included .cs Files
 - CarProfiles.cs — last modified 2026-02-08T00:00:00+00:00
-- CarSAEngine.cs — last modified 2026-02-01 (updated)
-- CarSASlot.cs — last modified 2026-02-01 (updated)
+- CarSAEngine.cs — last modified 2026-02-03 (updated)
+- CarSASlot.cs — last modified 2026-02-03 (updated)
 - CopyProfileDialog.xaml.cs — last modified 2025-09-14T19:32:49+01:00
 - DashesTabView.xaml.cs — last modified 2025-09-14T19:32:49+01:00
 - EnumEqualsConverter.cs — last modified 2025-11-04T19:13:41-06:00
@@ -37,7 +38,7 @@ If this conflicts with Project_Index.md or contract docs, treat this as stale.
 - FuelCalculatorView.xaml.cs — last modified 2025-11-27T07:30:04-06:00
 - FuelProjectionMath.cs — last modified 2025-12-27T12:32:10+00:00
 - InvertBooleanConverter.cs — last modified 2025-09-14T19:32:49+01:00
-- LalaLaunch.cs — last modified 2026-02-01
+- LalaLaunch.cs — last modified 2026-02-03
 - LapTimeValidationRule.cs — last modified 2025-09-14T19:32:49+01:00
 - LaunchAnalysisControl.xaml.cs — last modified 2025-11-27T11:49:07-06:00
 - LaunchPluginCombinedSettingsControl.xaml.cs — last modified 2025-11-04T19:13:41-06:00

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
-Validated against commit: a5f6580  
-Last updated: 2026-02-01  
+Validated against commit: f4cd1fe  
+Last updated: 2026-02-03  
 Branch: work
 
 ## What this repo is
@@ -17,7 +17,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) — dash consumption and visualisation contracts (Pit Entry Assist + overlay visibility included).
 - [Subsystems/Track_Markers.md](Subsystems/Track_Markers.md) — pit entry/exit marker auto-learn, storage, locking, and MSGV1 notifications.
 - [Subsystems/Opponents.md](Subsystems/Opponents.md) — nearby pace/fight and pit-exit prediction (Race-only gate, lap ≥1).
-- [Subsystems/CarSA.md](Subsystems/CarSA.md) — car-based spatial awareness (SA-Core v2 distance gaps, car-centric state, slot views, debug export).
+- [Subsystems/CarSA.md](Subsystems/CarSA.md) — car-based spatial awareness (SA-Core v2 distance gaps, car-centric status memory, StatusE/class-rank handling, debug export).
 - [Subsystems/Message_System_V1.md](Subsystems/Message_System_V1.md) — notification layer for pit markers and other signals (definition-driven, no legacy messages).
 - [Subsystems/MessageEngineV1_Notes.md](Subsystems/MessageEngineV1_Notes.md) — SimHub export list + migration notes for MSGV1 and legacy MSG lanes.
 - [Subsystems/Trace_Logging.md](Subsystems/Trace_Logging.md) — session summary CSV + per-lap trace schema and lifecycle.
@@ -57,7 +57,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 | Pit Entry Assist | Pit entry braking cues, margin/cue maths, decel capture instrumentation | [Subsystems/Pit_Entry_Assist.md](Subsystems/Pit_Entry_Assist.md) (driver/dash/engine) |
 | Track markers | Auto-learned pit entry/exit markers (per track), locking, track-length change detection, MSGV1 notifications | [Subsystems/Track_Markers.md](Subsystems/Track_Markers.md) |
 | Opponents | Nearby pace/fight prediction and pit-exit class position forecasting (Race-only, lap gate ≥1, gaps absolute) | [Subsystems/Opponents.md](Subsystems/Opponents.md) |
-| CarSA | Car-based spatial awareness using SA-Core v2 distance gaps, car-centric state, half-lap filtering, and debug export | [Subsystems/CarSA.md](Subsystems/CarSA.md) |
+| CarSA | Car-based spatial awareness using SA-Core v2 distance gaps, car-centric status memory, class-rank StatusE labeling, and debug export | [Subsystems/CarSA.md](Subsystems/CarSA.md) |
 | Dash integration | Screen manager modes, pit screen, dash visibility toggles (main/message/overlay), and Pit Entry Assist visual guidance | [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## Canonical docs map
@@ -80,6 +80,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch control ins
 - Fuel tab/UI source or planner changes → update `FuelTab_SourceFlowNotes.md`.
 
 ## Freshness
-- Validated against commit: a5f6580  
-- Date: 2026-02-01  
+- Validated against commit: f4cd1fe  
+- Date: 2026-02-03  
 - Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -3,7 +3,7 @@
 ## What exists in this checkout right now
 - Only one local branch is present: `work`.
 - There is no Git remote configured, so nothing in this checkout is currently linked to GitHub.
-- The latest commit on `work` is the current HEAD with PRs #282–#312 (Fuel planner max-fuel percent/preset handling, live snapshot max-tank sync, predictor outputs, Opponents/CarSA documentation, extensive CarSA Phase 2.2 updates, and SA-Core v2 distance-based car-centric CarSA gaps with closing-rate sign/grace fixes plus CSV cross-check logging cleanup). Use `git log --oneline -n 22` to see the recent merges if you want to double-check.
+- The latest commit on `work` is the current HEAD with PRs #310–#320 (documentation refresh, track-gap wrap fix for lapped cars, SA-Core v2 gap cleanup, StatusE redesign, replay identity retry, CarSA CSV instrumentation + alignment fixes, pit-surface status corrections, class-rank-based StatusE for multi-class, and car-centric status memory fed by session flags). Use `git log --oneline -n 22` to see the recent merges if you want to double-check.
 
 ## How to connect this checkout to your GitHub repo
 1. Add your GitHub remote (replace the URL with your actual repository clone URL):
@@ -61,7 +61,7 @@
 - **Pit loss locking:** **COMPLETE** — per-track pit loss values can be locked to block auto-updates; blocked candidates are captured and surfaced in the Profiles UI for review before manual unlock.
 - **Pit-exit prediction audit + settled logging:** **COMPLETE** — pit-exit predictor now locks pit-loss and gap inputs at pit entry to avoid drift, logs richer pit-in/out snapshots plus math audit, and emits a one-lap-delayed “pit-out settled” confirmation.
 - **Opponents subsystem:** **COMPLETE** — race-only opponent pace/fight and pit-exit prediction exports with lap gate ≥1, summary strings, and log support.
-- **CarSA SA-Core v2:** **INTEGRATED** — distance-based, car-centric gap/closing model with player-centric closing sign, grace window for telemetry blips, and trimmed CSV debug columns plus raw external gap cross-checks.
+- **CarSA SA-Core v2:** **INTEGRATED** — distance-based car-centric gaps/closing with telemetry grace windows, StatusE redesign (penalty/off-track splits, lapping text, pit-area handling), class-rank-aware other-class labeling, replay-safe identity retries, and debug CSV instrumentation alignment/cross-checks.
 - **Dry/Wet condition lock UI:** **COMPLETE** — per-track dry/wet condition lock toggles persist immediately in profiles (no save prompt).
 - **Session summary + trace v2:** **COMPLETE** — session summary CSV v2, lap trace rows with pit-stop index/phase, corrected pit-stop counting semantics, and explicit CSV column mapping for summary exports.
 - **Profile storage & schema:** **COMPLETE** — car profiles now save in a schema-v2 wrapper with opt-in track stats serialization, normalized track keys, and legacy JSON migration from older filenames/locations.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -2,9 +2,9 @@
 
 **CANONICAL OBSERVABILITY MAP**
 
-Validated against: b45bc8f  
-Last reviewed: 2026-02-12  
-Last updated: 2026-02-12  
+Validated against: f4cd1fe  
+Last reviewed: 2026-02-03  
+Last updated: 2026-02-03  
 Branch: work
 
 Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
@@ -60,7 +60,8 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 ## Opponents and pit-exit prediction
 - **`[LalaPlugin:Opponents] Opponents subsystem active (Race session + lap gate met).`** — Gate opened (Race + CompletedLaps ≥1); outputs now live.【F:Opponents.cs†L72-L88】
 - **`[LalaPlugin:Opponents] Slot <slot> rebound -> <identity> (<name>)`** — Nearby slot (Ahead1/2, Behind1/2) re-bound to a new identity; pace cache persists per identity (logs gated to lap ≥1 and debug toggle).【F:Opponents.cs†L252-L361】
-- **`[LalaPlugin:CarSA] CarSA enabled (source=CarIdxTruth, checkpoints=60, slots=5/5)`** — CarSA subsystem became valid for the session (CarIdx truth, 60 checkpoints, 5/5 slots).【F:CarSAEngine.cs†L180-L186】
+- **`[LalaPlugin:CarSA] CarSA enabled (source=CarIdxTruth, slots=5/5)`** — CarSA subsystem became valid for the session (CarIdx truth, 5/5 slots).【F:CarSAEngine.cs†L387-L390】
+- **`[LalaPlugin:CarSA] Class rank map built using <source> (<count> classes)`** — Class-rank lookup initialized from session info (CarClassRelSpeed preferred, else CarClassEstLapTime). Drives Faster/Slower class StatusE labeling in multiclass sessions.【F:LalaLaunch.cs†L4930-L4987】
 - **`[LalaPlugin:PitExit] Predictor valid -> true (pitLoss=X.Xs)`** — Pit-exit predictor became valid with leaderboard/player row found.【F:Opponents.cs†L507-L566】
 - **`[LalaPlugin:PitExit] Predicted class position changed -> P# (ahead=N)`** — Predicted post-stop class position changed while valid (gated to lap ≥1 and debug toggle).【F:Opponents.cs†L532-L566】
 - **`[LalaPlugin:PitExit] Predictor valid -> false`** — Pit-exit predictor lost validity (no player row/leaderboard data).【F:Opponents.cs†L568-L579】

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -2,9 +2,9 @@
 
 **CANONICAL CONTRACT**
 
-Validated against: a5f6580  
-Last reviewed: 2026-02-01  
-Last updated: 2026-02-01  
+Validated against: f4cd1fe  
+Last reviewed: 2026-02-03  
+Last updated: 2026-02-03  
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -91,12 +91,12 @@ Branch: work
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
 | Car.Valid | bool | True when CarSA has a valid player index and CarIdx lap pct truth for the tick. | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L74-L233】【F:LalaLaunch.cs†L3414-L3418】 |
-| Car.Source | string | Source label (Phase 1: `CarIdxTruth`). | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L74-L87】【F:LalaLaunch.cs†L3414-L3418】 |
-| Car.Checkpoints / Car.SlotsAhead / Car.SlotsBehind | int | Checkpoint count (60) and slot counts (5/5). | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L7-L11】【F:LalaLaunch.cs†L3414-L3418】 |
+| Car.Source | string | Source label (`CarIdxTruth`). | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L74-L87】【F:LalaLaunch.cs†L3414-L3418】 |
+| Car.SlotsAhead / Car.SlotsBehind | int | Slot counts (5/5). | Per tick. | `CarSAEngine.cs` + `AttachCore`【F:CarSAEngine.cs†L7-L11】【F:LalaLaunch.cs†L3414-L3418】 |
 | Car.Player.PaceFlagsRaw / SessionFlagsRaw / TrackSurfaceMaterialRaw | int | Raw telemetry flags for the player CarIdx row (or -1 if missing). Only populated when raw-telemetry mode is enabled. | Per tick. | `LalaLaunch.cs` raw telemetry debug + `AttachCore`【F:LalaLaunch.cs†L3429-L3431】【F:LalaLaunch.cs†L4874-L4917】 |
-| Car.Ahead01..Ahead05.* | mixed | Slot outputs for nearest ahead cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.RealSec (legacy mirror of Gap.RaceSec), Gap.TrackSec (distance-based proximity), Gap.RaceSec (distance-based time gap), ClosingRateSecPerSec (player-centric; positive = closing), Status, StatusE, StatusShort, StatusLong, PaceFlagsRaw, SessionFlagsRaw, TrackSurfaceMaterialRaw. | Per tick; distance gaps derived from car-centric LapDistPct deltas. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3419-L3446】 |
-| Car.Behind01..Behind05.* | mixed | Slot outputs for nearest behind cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.RealSec (legacy mirror of Gap.RaceSec), Gap.TrackSec (distance-based proximity), Gap.RaceSec (distance-based time gap), ClosingRateSecPerSec (player-centric; positive = closing), Status, StatusE, StatusShort, StatusLong, PaceFlagsRaw, SessionFlagsRaw, TrackSurfaceMaterialRaw. | Per tick; distance gaps derived from car-centric LapDistPct deltas. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3448-L3470】 |
-| Car.Debug.* | mixed | Debug telemetry for player checkpoint indices (`PlayerCheckpointIndexNow`, `PlayerCheckpointIndexCrossed`, `PlayerCheckpointCrossed`), slot validation, half-lap filter counters, timestamp update counters (`TimestampUpdatesThisTick`, `TimestampUpdatesSinceLastPlayerCross`), slot swap counts (`SlotCarIdxChangedThisTick`), raw telemetry availability (`HasCarIdxPaceFlags`, `HasCarIdxSessionFlags`, `HasCarIdxTrackSurfaceMaterial`), and read diagnostics (`RawTelemetryReadMode`, `RawTelemetryFailReason`). | Per tick. | `CarSAEngine.cs` debug fields + `AttachCore`【F:CarSAEngine.cs†L85-L283】【F:LalaLaunch.cs†L3458-L3487】 |
+| Car.Ahead01..Ahead05.* | mixed | Slot outputs for nearest ahead cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.TrackSec (distance-based proximity), Gap.RealSec (legacy alias of TrackSec), ClosingRateSecPerSec (player-centric; positive = closing), Status, StatusE, StatusShort, StatusLong, StatusEReason, PaceFlagsRaw, SessionFlagsRaw, TrackSurfaceMaterialRaw. | Per tick; distance gaps derived from car-centric LapDistPct deltas. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3419-L3455】 |
+| Car.Behind01..Behind05.* | mixed | Slot outputs for nearest behind cars: CarIdx, Name, CarNumber, ClassColor, IsOnTrack, IsOnPitRoad, IsValid, LapDelta, Gap.TrackSec (distance-based proximity), Gap.RealSec (legacy alias of TrackSec), ClosingRateSecPerSec (player-centric; positive = closing), Status, StatusE, StatusShort, StatusLong, StatusEReason, PaceFlagsRaw, SessionFlagsRaw, TrackSurfaceMaterialRaw. | Per tick; distance gaps derived from car-centric LapDistPct deltas. | `CarSAEngine.cs` slot update + `AttachCore`【F:CarSAEngine.cs†L248-L709】【F:LalaLaunch.cs†L3461-L3479】 |
+| Car.Debug.* | mixed | Debug telemetry for player/slot identity, raw telemetry availability, and slot filtering: `PlayerCarIdx`, `PlayerLapPct`, `PlayerLap`, `SessionTimeSec`, `SourceFastPathUsed`, `HasCarIdxPaceFlags`, `HasCarIdxSessionFlags`, `HasCarIdxTrackSurfaceMaterial`, `RawTelemetryReadMode`, `RawTelemetryFailReason`, `Ahead01.CarIdx`, `Ahead01.ForwardDistPct`, `Behind01.CarIdx`, `Behind01.BackwardDistPct`, `InvalidLapPctCount`, `OnPitRoadCount`, `OnTrackCount`, `TimestampUpdatesThisTick`, `FilteredHalfLapCountAhead`, `FilteredHalfLapCountBehind`, `LapTimeEstimateSec`, `HysteresisReplacementsThisTick`, `SlotCarIdxChangedThisTick`. | Per tick. | `CarSAEngine.cs` debug fields + `AttachCore`【F:CarSAEngine.cs†L85-L283】【F:LalaLaunch.cs†L3482-L3510】 |
 
 ## Pit timing and PitLite
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/Subsystems/CarSA.md
+++ b/Docs/Subsystems/CarSA.md
@@ -1,67 +1,53 @@
-# CarSA (Car System) — Phase 2.2
+# CarSA (Car System) — SA-Core v2
 
 ## Scope
-CarSA provides **session-agnostic**, **class-agnostic** spatial awareness using iRacing CarIdx telemetry arrays as the source of truth. It publishes the 5 nearest cars ahead and 5 behind on track for Practice, Qualifying, and Race sessions.
+CarSA provides **session-agnostic**, **class-aware** spatial awareness using iRacing CarIdx telemetry arrays as the source of truth. It publishes the 5 nearest cars ahead and 5 behind on track for Practice, Qualifying, and Race sessions using distance-based gaps derived from car-centric LapDistPct deltas.
 
 CarSA is independent of the race-only Opponents subsystem and does not change Opponents or Rejoin Assist behavior.
 
 ## Truth source
-- **Primary:** `CarIdx*` raw telemetry arrays (CarIdxLapDistPct, CarIdxLap, CarIdxTrackSurface, CarIdxOnPitRoad).
-- **Raw flags (optional):** `CarIdxPaceFlags`, `CarIdxSessionFlags`, `CarIdxTrackSurfaceMaterial` when raw telemetry read mode is enabled (drives compromised-lap inference and debug visibility).
-- **Fast-path:** Not enabled in Phase 1 (source remains `CarIdxTruth`).
-- **Identity:** Slot Name/CarNumber/ClassColor are populated on slot rebinds/session reset from `SessionData.DriverInfo.CompetingDrivers` (UserName/CarNumber/CarClassColor).
+- **Primary:** `CarIdx*` telemetry arrays (CarIdxLapDistPct, CarIdxLap, CarIdxTrackSurface, CarIdxOnPitRoad).
+- **Raw flags (optional):** `CarIdxSessionFlags`, `CarIdxPaceFlags`, and `CarIdxTrackSurfaceMaterial` when raw telemetry read mode is enabled (drives compromised evidence and debug exports).
+- **Identity:** Slot Name/CarNumber/ClassColor are pulled from session info (`DriverInfo.DriversXX` preferred, fallback to `DriverInfo.CompetingDrivers`) with retry logic so replays can resolve identities once the session data arrives.
+- **Class rank map:** CarSA builds a per-session class rank map from `CarClassRelSpeed` (preferred) or `CarClassEstLapTime` to label Faster/Slower class statuses.
+
+## Car-centric state cache
+CarSA keeps a car-centric shadow state per `CarIdx` that is authoritative for StatusE decisions and gap/closing-rate stability:
+- **Spatial deltas:** Forward/backward distance pct, signed delta pct, and closing rate based on per-tick LapDistPct deltas.
+- **Track state:** Track surface raw, pit area detection (pit lane or pit stall), on-track flag, and session flags.
+- **Latches:**
+  - **Out-lap** latches when a car exits pit area onto track; stays active until the next lap completes.
+  - **Compromised (off-track)** latches when track surface == OffTrack; stays active until the next lap completes.
+  - **Compromised (penalty)** latches when session flags include black/furled/repair/disqualify; stays active until the next lap completes.
+- **Grace windows:**
+  - **LapPct grace:** 0.5 s grace before clearing delta/closing data on invalid LapDistPct.
+  - **Not-in-world grace:** 3.0 s before clearing latches if a car remains NotInWorld.
 
 ## Slot selection (Ahead/Behind)
-- Ordering uses CarIdx lap distance percentages (`LapDistPct`) for all cars.
+- Ordering uses car-centric forward/backward distances computed from LapDistPct.
 - Forward distance: `(oppPct - myPct + 1.0) % 1.0`
 - Backward distance: `(myPct - oppPct + 1.0) % 1.0`
-- TrackSurface semantics: `IsOnTrack` is **true only when TrackSurface == OnTrack**; OffTrack/OnPitRoad/NotInWorld are treated as not on track, and NotInWorld marks the slot invalid.
-- Default: pit-road cars are **excluded** from candidate slots to reduce practice/quali noise.
-- Slot stability: a candidate replaces the current slot only if it is **at least 10% closer** (or the current slot is invalid).
-- Slot stability: if a slot swaps to a new `CarIdx`, the gap/closing-rate history is cleared to avoid carrying stale gap data across cars.
-- Half-lap filter: candidates with `distPct` in **[0.40, 0.60]** are skipped per direction to avoid S/F wrap ambiguity (tracked by debug counters).
+- **TrackSurface semantics:** `IsOnTrack` is true only when TrackSurface == OnTrack. Pit lane/stall is treated as pit area. NotInWorld makes a slot invalid.
+- **Pit-road exclusion:** pit-road cars are excluded from candidate slots by default to reduce practice/quali noise.
+- **Half-lap filter:** candidates with `distPct` in **[0.40, 0.60]** are skipped per direction to avoid S/F wrap ambiguity (tracked by debug counters).
+- **Hysteresis:** a new candidate replaces a slot only if it is **at least 10% closer** (or the current slot is invalid).
+- **Slot reset:** when a slot swaps to a new `CarIdx`, gap and status text caches are cleared. Identity is refreshed with retry to avoid replay timing gaps.
 
-## RealGap (checkpoint stopwatch)
-- **60 checkpoints** evenly spaced around lapPct [0..1).
-- For each (checkpoint, carIdx), CarSA stores the last timestamp when that car crossed the checkpoint.
-- CarSA computes the player’s **current checkpoint index** every tick:
-  - `PlayerCheckpointIndexNow = floor(PlayerLapPct * CheckpointCount)` (clamped 0..59). It only returns `-1` when `PlayerLapPct` is invalid.
-  - `PlayerCheckpointIndexCrossed` updates **only** on the crossing tick and is `-1` otherwise.
-- RealGap is updated **every tick** using `PlayerCheckpointIndexNow`:
-  - `RealGapRawSec = playerCheckpointTimeSec - lastCheckpointTimeSec`
-  - `RealGapAdjSec` is adjusted for lap delta and wrap behavior.
-  - **Sign convention:** Ahead = **positive**, Behind = **negative**.
+## Gap & closing semantics
+- **Gap.TrackSec:** `distPct * lapTimeEstimateSec` (distance-based proximity gap).
+- **Gap.RealSec:** legacy alias of `Gap.TrackSec` for backward compatibility.
+- **ClosingRateSecPerSec:** derived from change in absolute delta pct over time; **positive values mean closing**; clamped to ±5 s/s.
+- **Lap time estimate:** player average pace, else last lap, else 120 s fallback.
+- **LapDelta:** computed from CarIdx lap counters with S/F straddle guards to avoid one-tick spikes when cars are physically close around the line.
 
-### Lap delta correction
-- `lapDelta = oppLap - myLap`
-- If `lapDelta != 0`, `RealGapAdjSec += lapDelta * LapTimeEstimateSec` is applied **unless both the player and the slot are near S/F and physically close** (near edge = within 3% of lapPct 0/1, close = within 10% lap distance). This suppresses only the true S/F straddle spike.
-- If `lapDelta == 0` and the slot is **behind**, the gap is wrapped by subtracting the lap-time estimate when the raw gap implies the previous lap; when both cars are near S/F and physically close, the wrap uses a stricter threshold (0.90 * lap time) to avoid false wraps.
-- On the **first RealGap update after a slot rebind**, lap-delta and behind-wrap corrections are suppressed (one-tick settle guard) and cleared after the first successful RealGap publish.
-- RealGap is clamped to ±600 s to guard against telemetry spikes.
-- LapDelta wrap override: if lap counters differ by ±1 at S/F but the cars are physically close (within 10% lap distance) and straddling the S/F edge (within 15% of lapPct 0/1), LapDelta is treated as `0` to prevent single-tick spikes.
-
-### Gap RealSec grace hold
-- If a slot has a valid last gap and a RealGap update is missing (no checkpoint timestamp yet), CarSA **holds the last gap for ~2 seconds** before returning `NaN`.
-- During this grace hold, `ClosingRateSecPerSec` is frozen to `0` to avoid spikes.
-
-### ClosingRate definition
-- `ClosingRateSecPerSec` uses **absolute gap magnitude** derived from `GapTrackSec`.
-- Positive values mean the gap is **shrinking** (closing), negative values mean the gap is growing (dropping back), regardless of ahead/behind sign.
-
-### Lap time estimate (used for RealGap)
-Priority order:
-1. Player’s running average pace (from existing pace model).
-2. Player’s last lap time.
-3. Fallback (120 s).
-
-## Status enum (Phase 1)
-CarSA defines a minimal, stable status enum:
+## Status enums
+CarSA publishes a minimal base status enum:
 - `Unknown = 0`
 - `Normal = 1`
 - `InPits = 2` (set whenever `CarIdxOnPitRoad` is true).
 
-## StatusE ladder (Phase 2.2)
-CarSA publishes a Traffic SA “E-number” ladder per slot for dash filtering. Values are grouped into LOW/MID/HIGH numeric ranges, and Phase 2.2 enables real status selection beyond `Unknown`.
+## StatusE ladder (SA-Core v2)
+CarSA publishes a Traffic SA “E-number” ladder per slot for dash filtering. StatusE uses car-centric latches, pit-area detection, and class rank data.
 
 **Numeric mapping (locked):**
 
@@ -70,47 +56,39 @@ CarSA publishes a Traffic SA “E-number” ladder per slot for dash filtering. 
 | LOW | 0 | Unknown | UNK | Unknown |
 | MID | 100 | OutLap | OUT | Out lap |
 | MID | 110 | InPits | PIT | In pits |
-| MID | 120 | CompromisedThisLap | CMP | Compromised |
-| MID | 190 | NotRelevant | NR | Not relevant |
-| HIGH | 200 | FasterClass | F+ | Faster class |
-| HIGH | 210 | SlowerClass | S- | Slower class |
+| MID | 121 | CompromisedOffTrack | OFF | Off track |
+| MID | 122 | CompromisedPenalty | PEN | Penalty/Flag |
+| HIGH | 200 | FasterClass | FCL | Faster class |
+| HIGH | 210 | SlowerClass | SCL | Slower class |
 | HIGH | 220 | Racing | RCE | Racing |
-| HIGH | 230 | LappingYou | LY | Lapping you |
-| HIGH | 240 | BeingLapped | BL | Being lapped |
+| HIGH | 230 | LappingYou | +nL | Ahead +n laps |
+| HIGH | 240 | BeingLapped | -nL | Behind -n laps |
 
-**Phase 2.2 logic (per slot, priority order):**
-1. If the slot is invalid or `TrackSurface == NotInWorld` ⇒ `NotRelevant` (190, reason `invalid`).
-2. If `IsOnPitRoad` ⇒ `InPits` (110, reason `pits`).
-3. If not on track ⇒ `NotRelevant` (190, reason `invalid`).
-4. If compromised evidence exists (off-track surface, track material >= 15, or session flags indicate compromised) ⇒ `CompromisedThisLap` (120, reason `cmp`).
-5. If `abs(GapTrackSec) > NotRelevantGapSec` ⇒ `NotRelevant` (190, reason `nr_gap`).
-6. If slot just exited pits and is on the out-lap ⇒ `OutLap` (100, reason `outlap`).
-7. If `LapDelta > 0` ⇒ `LappingYou` (230, reason `lapping_you`).
-8. If `LapDelta < 0` ⇒ `BeingLapped` (240, reason `you_are_lapping`).
-9. If Opponents identifies this slot as a live fight (lap ≥1, `LapsToFight > 0`, identity match) ⇒ `Racing` (220, reason `racing`).
-10. If class color mismatches the player’s class ⇒ `FasterClass` (200, reason `otherclass`). Phase 2.2 uses `FasterClass` as the placeholder for “other class”; `SlowerClass` remains reserved.
-11. Else ⇒ `Unknown` (0, reason `unknown`).
+**StatusE logic (per slot, priority order):**
+1. If the slot is on pit road or in a pit-area surface ⇒ `InPits` (reason `pits`).
+2. If car-centric compromised penalty latch is active ⇒ `CompromisedPenalty` (reason `cmp_pen`).
+3. Else if car-centric compromised off-track latch is active ⇒ `CompromisedOffTrack` (reason `cmp_off`).
+4. If slot is invalid / NotInWorld / not on track ⇒ `Unknown` (reason `unknown`).
+5. If car-centric out-lap latch is active ⇒ `OutLap` (reason `outlap`).
+6. If `LapDelta > 0` ⇒ `LappingYou` (reason `lap_ahead`).
+7. If `LapDelta < 0` ⇒ `BeingLapped` (reason `lap_behind`).
+8. If same class as player ⇒ `Racing` (reason `racing`).
+9. If other class and class ranks exist ⇒ `FasterClass` or `SlowerClass` (reason `otherclass`).
+10. If other class but rank is unavailable ⇒ fallback based on ahead/behind direction (`FasterClass` when behind, `SlowerClass` when ahead; reason `otherclass_unknownrank`).
 
-**Configuration:**
-- `NotRelevantGapSec` (double, default **10.0s**) is stored in global plugin settings and persists across sessions.
+`NotRelevant` is reserved but unused in SA-Core v2 (gap-based relevance gating is disabled).
 
-## Gap semantics (Phase 2.2)
-- **Gap.TrackSec:** proximity gap derived from checkpoint stopwatch without lap-delta adjustment (used for closing-rate).
-- **Gap.RaceSec:** race-style gap with lap-delta adjustment applied.
-- **Gap.RealSec:** current published gap mirror of `Gap.RaceSec` (signed + ahead / - behind).
-
-## Raw telemetry flags (Phase 2.2)
+## Raw telemetry flags
 - Player-level raw flags are published as `Car.Player.PaceFlagsRaw`, `Car.Player.SessionFlagsRaw`, `Car.Player.TrackSurfaceMaterialRaw`.
 - Slot-level raw flags (`PaceFlagsRaw`, `SessionFlagsRaw`, `TrackSurfaceMaterialRaw`) are populated when raw telemetry mode includes slots.
-- Debug outputs report whether each raw array was readable and the read mode/failure reason (see Debug exports below).
+- Debug outputs report whether each raw array was readable and the read mode/failure reason.
 
-## Exports (Phase 2.2)
+## Exports (SA-Core v2)
 Prefix: `Car.*`
 
 System:
 - `Car.Valid`
 - `Car.Source` (`CarIdxTruth`)
-- `Car.Checkpoints` (60)
 - `Car.SlotsAhead` (5)
 - `Car.SlotsBehind` (5)
 - `Car.Player.PaceFlagsRaw`
@@ -120,34 +98,29 @@ System:
 Slots (Ahead01..Ahead05, Behind01..Behind05):
 - Identity: `CarIdx`, `Name`, `CarNumber`, `ClassColor`
 - State: `IsOnTrack`, `IsOnPitRoad`, `IsValid`
-- Spatial: `LapDelta`, `Gap.RealSec`, `Gap.TrackSec`, `Gap.RaceSec`
-- Derived: `ClosingRateSecPerSec`, `Status`, `StatusE`, `StatusShort`, `StatusLong`
+- Spatial: `LapDelta`, `Gap.TrackSec`, `Gap.RealSec`
+- Derived: `ClosingRateSecPerSec`, `Status`, `StatusE`, `StatusShort`, `StatusLong`, `StatusEReason`
 - Raw telemetry (mode permitting): `PaceFlagsRaw`, `SessionFlagsRaw`, `TrackSurfaceMaterialRaw`
 
 Debug (`Car.Debug.*`):
-- Player: `PlayerCarIdx`, `PlayerLapPct`, `PlayerLap`, `PlayerCheckpointIndexNow`, `PlayerCheckpointIndexCrossed`, `PlayerCheckpointCrossed`, `SessionTimeSec`, `SourceFastPathUsed`
-- Raw telemetry: `HasCarIdxPaceFlags`, `HasCarIdxSessionFlags`, `HasCarIdxTrackSurfaceMaterial`, `RawTelemetryReadMode`, `RawTelemetryFailReason`
-- RealGap validation (Ahead01/Behind01 only): `CarIdx`, distance pct, raw/adjusted gap, last checkpoint time
-- Sanity: `InvalidLapPctCount`, `OnPitRoadCount`, `OnTrackCount`, `TimestampUpdatesThisTick`
-- Timestamp accumulator: `TimestampUpdatesSinceLastPlayerCross` (counts checkpoint timestamp writes since the last player checkpoint crossing).
-- Optional (debug-gated): `LapTimeEstimateSec`, `HysteresisReplacementsThisTick`, `SlotCarIdxChangedThisTick`, `RealGapClampsThisTick`
-- Candidate filter: `FilteredHalfLapCountAhead`, `FilteredHalfLapCountBehind`
+- `PlayerCarIdx`, `PlayerLapPct`, `PlayerLap`, `SessionTimeSec`, `SourceFastPathUsed`
+- Raw telemetry availability: `HasCarIdxPaceFlags`, `HasCarIdxSessionFlags`, `HasCarIdxTrackSurfaceMaterial`, `RawTelemetryReadMode`, `RawTelemetryFailReason`
+- Slot debug: `Ahead01.CarIdx`, `Ahead01.ForwardDistPct`, `Behind01.CarIdx`, `Behind01.BackwardDistPct`
+- Sanity/counters: `InvalidLapPctCount`, `OnPitRoadCount`, `OnTrackCount`, `TimestampUpdatesThisTick`, `FilteredHalfLapCountAhead`, `FilteredHalfLapCountBehind`
+- Optional (debug-gated): `LapTimeEstimateSec`, `HysteresisReplacementsThisTick`, `SlotCarIdxChangedThisTick`
 
 ## Debug export (optional)
-When `EnableCarSADebugExport` is enabled, CarSA writes a lightweight CSV snapshot on **player checkpoint crossings**:
-- Path: `SimHub/Logs/LalapluginData/CarSA_Debug_YYYY-MM-DD_HH-mm-ss_<TrackName>.csv` (UTC timestamp, sanitized track name; repeated `_` collapsed, trimmed, and clamped to 60 chars)
-- Cadence: **checkpoint crossings only** (same event that updates RealGap).
+When `EnableCarSADebugExport` is enabled, CarSA writes a lightweight CSV snapshot on **every DataUpdate tick** (buffered, flushed every 20 lines or 4 KB):
+- Path: `SimHub/Logs/LalapluginData/CarSA_Debug_YYYY-MM-DD_HH-mm-ss_<TrackName>.csv` (UTC timestamp, sanitized track name; repeated `_` collapsed, trimmed, clamped to 60 chars)
 - Columns (grouped):
-  - **Player:** `SessionTimeSec`, `PlayerLap`, `PlayerLapPct`, `CheckpointIndexNow`, `CheckpointIndexCrossed`, `NotRelevantGapSec`.
-  - **Ahead01 / Behind01:** `CarIdx`, distance pct, `GapRealSec`, `GapTrackSec`, `GapRaceSec`, `ClosingRateSecPerSec`, `LapDelta`, `IsOnTrack`, `IsOnPitRoad`, `StatusE`, `StatusShort`, `StatusLong`.
-  - **Status latches:** `OutLapLatched`, `CompromisedThisLapLatched`, `CurrentLap`, `LastLap`, `OutLapActive`, `OutLapLap`, `WasOnPitRoad`, `CompromisedLap`.
-  - **Compromised flags:** `CmpFlag_Black`, `CmpFlag_Furled`, `CmpFlag_Repair`, `CmpFlag_Disqualify`.
-  - **Raw flags:** `TrackSurfaceRaw`, `TrackSurfaceMaterialRaw`, `SessionFlagsRaw`.
-  - **Compromised evidence:** `CmpEvidence_OffTrack`, `CmpEvidence_Material`, `CmpEvidence_SessionFlags`.
-  - **Status metadata:** `StatusEReason`, `StatusEChanged`, `CarIdxChanged`.
-  - **Counters:** `TimestampUpdatesThisTick`, `RealGapClampsThisTick`, `HysteresisReplacementsThisTick`, `SlotCarIdxChangedThisTick`, `FilteredHalfLapCountAhead`, `FilteredHalfLapCountBehind`.
+  - **Player:** `SessionTimeSec`, `PlayerLap`, `PlayerLapPct`, `NotRelevantGapSec` (legacy config value).
+  - **Ahead01 / Behind01:** `CarIdx`, `DistPct`, `GapTrackSec`, `ClosingRateSecPerSec`, `LapDelta`, `IsOnTrack`, `IsOnPitRoad`, `StatusE`, `StatusEReason`.
+  - **Cross-check gaps:** DahlDesign and iRacing extra-relative gaps plus normalized cross-check columns.
+  - **Raw evidence:** Track surface raw/material, session flags, pace flags, plus track surface labels.
+  - **Player raw evidence:** Player track surface/material/session flags/pace flags.
+  - **Class rank metadata:** `CarSA.ClassRankSource`, `CarSA.ClassRankCount`.
 
 ## Performance notes
 - Single-pass candidate selection with fixed arrays (no per-tick allocations).
 - No LINQ or string formatting in per-tick loops.
-- RealGap updates every tick using `PlayerCheckpointIndexNow`.
+- Car-centric cache avoids per-slot computations for closing and status latches.

--- a/Docs/User Docs/Changelog_Since_PR240.md
+++ b/Docs/User Docs/Changelog_Since_PR240.md
@@ -10,3 +10,6 @@
 - **Fuel math updates**: stint fuel margin expressed as a percentage and refined stops-required calculations for cleaner strategy guidance.
 - **Profile storage & schema updates**: standardized JSON storage, normalized track keys, and base-tank litres stored per car profile.
 - **New predictor exports** for fuel burn and pace so dashboards can show consistent “next lap” guidance even before long stints are built up.
+- **CarSA SA-Core v2 upgrades**: car-centric distance gaps, status memory (out-lap/compromised/penalty), and replay-safe identity refresh for slots.
+- **CarSA StatusE redesign**: penalty vs off-track labels, pit-area classification, class-rank-aware Faster/Slower class tagging, and lapping text output.
+- **CarSA debug export improvements**: aligned CSV columns with cross-check gaps, StatusE reason fields, and class-rank metadata for multi-class auditing.


### PR DESCRIPTION
### Motivation
- Bring repository documentation up-to-date for the recent CarSA/related work included across PRs 310–320 so docs reflect current runtime behaviour and exports. 
- Ensure the CarSA subsystem spec, SimHub export catalogue, and log catalogue correctly describe SA-Core v2 semantics (car-centric gaps, status memory, class-rank labeling) and the improved debug CSV outputs. 
- Make the Project/Repo index and snapshot metadata authoritative for the new changes so downstream engineers and dashboards have a single source of truth.

### Description
- Updated high-level repo status and snapshot notes to reference PRs 310–320 and to summarise CarSA status/class-rank/identity/CSV improvements (`Docs/RepoStatus.md`, `Docs/Code_Snapshot.md`, `Docs/Project_Index.md`).
- Rewrote and reorganised the CarSA subsystem document to describe SA-Core v2 behaviour: car-centric state cache, latches (out-lap/compromised/penalty), gap/closing semantics, S/F guards, class-rank map, replay-safe identity refresh, and StatusE redesign (`Docs/Subsystems/CarSA.md`).
- Aligned the SimHub parameter inventory and SimHub log catalogue with the new CarSA exports and log messages, added `StatusEReason` and class-rank debug metadata, clarified `Gap.TrackSec`/`Gap.RealSec` semantics, and updated validation headers/dates (`Docs/SimHubParameterInventory.md`, `Docs/SimHubLogMessages.md`).
- Improved user-facing changelog and debug export description to call out CSV alignment, cross-check gap columns, and class-rank instrumentation for multi-class auditing (`Docs/User Docs/Changelog_Since_PR240.md`, plus smaller header/label fixes across docs).
- No source code changes were made; all edits are documentation only and focus on accuracy and export naming/semantics (SimHub keys and CSV column descriptions were normalised where needed).

### Testing
- Automated tests: none run because this is documentation-only work and no code changes were introduced. 
- Validation: the documentation was updated to match the current code patterns and SimHub export wiring found in the codebase (docs reference the actual `LalaLaunch.cs`/`CarSAEngine.cs` locations for cross-checking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c68ba23c832fae036c62c38cea07)