### PR TITLE
Expand CarSA debug export slots

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5587,6 +5587,23 @@ namespace LaunchPlugin
             _carSaDebugExportPath = null;
             _carSaDebugExportToken = null;
             _carSaDebugExportPendingLines = 0;
+            ResetCarSaDebugGapArray(_carSaDebugAheadDahlRelativeGapSec);
+            ResetCarSaDebugGapArray(_carSaDebugBehindDahlRelativeGapSec);
+            ResetCarSaDebugGapArray(_carSaDebugAheadIRacingRelativeGapSec);
+            ResetCarSaDebugGapArray(_carSaDebugBehindIRacingRelativeGapSec);
+        }
+
+        private static void ResetCarSaDebugGapArray(double[] values)
+        {
+            if (values == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = double.NaN;
+            }
         }
 
         private void ResetCarSaIdentityState()


### PR DESCRIPTION
### Motivation
- Extend the CarSA debug CSV export from a single ahead/behind slot to the full 5-slot window so replay testing can validate slot-jumping and the car-centric cache behavior across the pack.

### Description
- Add `CarSaDebugExportSlotCount = 5`, arrays of property names for Dahl and iRacing sources, and four preallocated `double[]` fields `_carSaDebugAheadDahlRelativeGapSec`, `_carSaDebugBehindDahlRelativeGapSec`, `_carSaDebugAheadIRacingRelativeGapSec`, and `_carSaDebugBehindIRacingRelativeGapSec` to avoid per-tick allocations.
- Read all five Dahl and IRXP properties once per update inside a `for` loop using `SafeReadDouble(...)` and store them into the preallocated arrays.
- Replace the hard-coded header with `GetCarSaDebugExportHeader()` that constructs the CSV header via a `StringBuilder` and helper methods (`AppendCarSaDebugHeaderColumn` / `AppendCarSaDebugSlotHeader`) in loops for `Ahead01..Ahead05` and `Behind01..Behind05` (C# 7.3 compatible).
- Update `WriteCarSaDebugExport()` to loop `i = 0..4` for ahead and behind slots and call `AppendSlotDebugRow(buffer, slot, isAhead, dahl[i], irxp[i])`, while safely handling fewer-than-5 slots by passing `null` (preserving existing formatting and `AppendSlotDebugRow` semantics).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ca5c710c832f920ec52537bc671e)