### PR TITLE
Add session gating and offtrack debounce for CarSA

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4360,6 +4360,10 @@ namespace LaunchPlugin
             double trackPct = SafeReadDouble(pluginManager, "IRacingExtraProperties.iRacing_Player_LapDistPct", double.NaN);
             double sessionTimeSec = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.Telemetry.SessionTime", 0.0);
             double sessionTimeRemainingSec = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.Telemetry.SessionTimeRemain", double.NaN);
+            int sessionState = SafeReadInt(pluginManager, "DataCorePlugin.GameRawData.Telemetry.SessionState", 0);
+            string sessionTypeName = !string.IsNullOrWhiteSpace(currentSessionTypeForConfidence)
+                ? currentSessionTypeForConfidence
+                : (data.NewData?.SessionTypeName ?? string.Empty);
             bool debugEnabled = Settings?.EnableDebugLogging == true;
             _opponentsEngine?.Update(data, pluginManager, isRaceSessionNow, completedLaps, myPaceSec, pitLossSec, pitTripActive, inLane, trackPct, sessionTimeSec, sessionTimeRemainingSec, debugEnabled);
 
@@ -4384,7 +4388,7 @@ namespace LaunchPlugin
             {
                 notRelevantGapSec = CarSANotRelevantGapSecDefault;
             }
-            _carSaEngine?.Update(sessionTimeSec, playerCarIdx, carIdxLapDistPct, carIdxLap, carIdxTrackSurface, carIdxOnPitRoad, carIdxSessionFlags, null, lapTimeEstimateSec, notRelevantGapSec, debugEnabled);
+            _carSaEngine?.Update(sessionTimeSec, sessionState, sessionTypeName, playerCarIdx, carIdxLapDistPct, carIdxLap, carIdxTrackSurface, carIdxOnPitRoad, carIdxSessionFlags, null, lapTimeEstimateSec, notRelevantGapSec, debugEnabled);
             if (_carSaEngine != null)
             {
                 for (int i = 0; i < CarSaDebugExportSlotCount; i++)


### PR DESCRIPTION
### Motivation
- Prevent noisy/incorrect `StatusE` labels and latch carry-over during grid/formation and immediately-after-session-start periods, and avoid single-tick `TrackSurfaceRaw==0` glitches from latching an entire lap.
- Preserve existing slot assignment and live penalty flags while only gating `StatusE` and latch mutations until the session is stable.

### Description
- Pass session metadata into `CarSAEngine.Update` by adding `int sessionState` and `string sessionTypeName` and reading them in `LalaLaunch.DataUpdate` with `SafeReadInt(... "Telemetry.SessionState" ...)` and the existing session-type logic.
- Add session tracking fields to `CarSAEngine`: `_lastSessionState`, `_lastSessionTypeName`, `_sessionTypeStartTimeSec`, `_lastSessionTimeSec`, and `_allowStatusEThisTick` and reset them in `Reset()`.
- Implement session gating rules in `Update(...)`: detect race vs practice/qual sessions with helpers `IsRaceSessionType(...)` and `IsPracticeOrQualSessionType(...)`, set `allowStatusE`/`allowLatches` accordingly, perform a clean-slate latch reset on the race green-edge via `ResetCarLatchesOnly()`, and enforce a 30s settle window for Practice/Qual.
- Gate `StatusE` rendering by short-circuiting `RefreshStatusE` when `_allowStatusEThisTick` is false and forcing slot `StatusE` to `Unknown` with reason "gated" using `ApplyGatedStatusE(...)`, while leaving slot identities intact.
- Add offtrack debounce state to `CarSA_CarState` (`OffTrackStreak`, `OffTrackFirstSeenTimeSec`) and change `UpdateCarStates(...)` to accept `bool allowLatches`; when latches are allowed only set `CompromisedUntilLap` after either 3 consecutive offtrack ticks or >= 0.20s elapsed since first offtrack evidence, and only set `OutLapUntilLap` when `allowLatches` is true.
- Mirror latch-clears into slot fields via `ClearSlotLatchStates(...)` inside `ResetCarLatchesOnly()` so dashboards see the clean slate immediately.
- Keep penalty-live tracking unchanged (`CompromisedPenaltyActive` still updates from session flags) but ensure penalties do not drive `StatusE` while gated.

### Testing
- No automated tests were run against these changes (no CI/unit tests executed as part of this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698203a0a000832f89d3dd364f0d52ee)