### PR TITLE
Gate ClosingRateSecPerSec to mini-sector cadence and apply EMA smoothing

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -100,7 +100,7 @@ namespace LaunchPlugin
         internal bool OutLapLatched => OutLapActive;
         internal bool CompromisedThisLapLatched => CompromisedThisLap;
         internal int TrackSurfaceRawDebug => TrackSurfaceRaw;
-        internal double ClosingRateSmoothed { get; set; } = double.NaN;
+        internal double ClosingRateSmoothed { get; set; }
         internal bool ClosingRateHasSample { get; set; }
 
         public void Reset()
@@ -167,7 +167,7 @@ namespace LaunchPlugin
             SlotIsAhead = false;
             LastIdentityAttemptSessionTimeSec = -1.0;
             IdentityResolved = false;
-            ClosingRateSmoothed = double.NaN;
+            ClosingRateSmoothed = 0.0;
             ClosingRateHasSample = false;
         }
     }


### PR DESCRIPTION
### Motivation
- Make `ClosingRateSecPerSec` stable and meaningful by updating/publishing it only at mini-sector cadence and by smoothing the published value with an EMA while preserving the existing sign convention.

### Description
- Add `ClosingRateEmaAlpha = 0.35` and use it for EMA smoothing of per-slot `ClosingRateSmoothed` which is then published to `ClosingRateSecPerSec`.
- Change the update gate to use the existing mini-sector checkpoint logic via `ShouldUpdateMiniSectorForCar(slot.CarIdx)` so `ClosingRateSecPerSec` only changes when the slot car or player crosses a mini-sector.
- Initialize and reset per-slot smoothing state to zero (`ClosingRateSmoothed = 0.0`, `ClosingRateHasSample = false`) on slot invalidation and when a slot is rebound, instead of `double.NaN`.
- Preserve the original raw closing-rate sign and clamp behavior; no changes to the gap math or property name `ClosingRateSecPerSec`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835a781bfc832fa72ee46cfb226573)