### PR TITLE
Hold last smoothed ClosingRate when raw is invalid to avoid NaN blips

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -923,9 +923,16 @@ namespace LaunchPlugin
                         double rawClosing = state.ClosingRateSecPerSec;
                         if (double.IsNaN(rawClosing) || double.IsInfinity(rawClosing))
                         {
-                            slot.ClosingRateSmoothed = 0.0;
-                            slot.ClosingRateHasSample = false;
-                            slot.ClosingRateSecPerSec = double.NaN;
+                            if (slot.ClosingRateHasSample)
+                            {
+                                slot.ClosingRateSecPerSec = slot.ClosingRateSmoothed;
+                            }
+                            else
+                            {
+                                slot.ClosingRateSmoothed = 0.0;
+                                slot.ClosingRateHasSample = false;
+                                slot.ClosingRateSecPerSec = double.NaN;
+                            }
                         }
                         else if (!slot.ClosingRateHasSample || double.IsNaN(slot.ClosingRateSmoothed))
                         {


### PR DESCRIPTION
### Motivation
- Prevent transient NaN drops in `ClosingRateSecPerSec` when `rawClosing` is temporarily invalid by continuing to publish the last smoothed sample once one exists.

### Description
- Updated `UpdateSlotGapsFromCarStates` in `CarSAEngine.cs` to special-case `rawClosing` being `NaN` or `Infinity`.
- If `slot.ClosingRateHasSample` is `true`, the code now leaves `slot.ClosingRateSmoothed` unchanged and publishes it via `slot.ClosingRateSecPerSec` instead of clearing the sample.
- If no prior sample exists the previous behavior is preserved (reset `ClosingRateSmoothed` to `0.0`, keep `ClosingRateHasSample=false`, and publish `NaN`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a3954e3c832f8254dd8c67cb08c7)