### PR TITLE
Hot/Cool StatusE for Ahead/Behind in Practice & Open Qualify (HLW/HLC/CLW/CLC)

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -74,7 +74,8 @@ namespace LaunchPlugin
         public double ReboundTimeSec { get; set; } = 0.0;
         public int HotCoolIntent { get; set; }
         public int HotCoolStreak { get; set; }
-        public int HotCoolLastMiniSectorTickId { get; set; } = -1;
+        public int HotCoolPendingIntent { get; set; }
+        public int HotCoolLastMiniSectorTickId { get; set; }
 
         internal double LastGapUpdateTimeSec { get; set; } = 0.0;
         internal double LastGapSec { get; set; } = double.NaN;
@@ -149,8 +150,9 @@ namespace LaunchPlugin
             JustRebound = false;
             ReboundTimeSec = 0.0;
             HotCoolIntent = 0;
+            HotCoolPendingIntent = 0;
             HotCoolStreak = 0;
-            HotCoolLastMiniSectorTickId = -1;
+            HotCoolLastMiniSectorTickId = 0;
             LastGapUpdateTimeSec = 0.0;
             LastGapSec = double.NaN;
             HasGap = false;


### PR DESCRIPTION
### Motivation
- Implement Hot/Cool intent detection and conflict urgency for Ahead01..05 and Behind01..05 slots only during Practice and Open Qualify sessions, with locked StatusE codes and anti-flicker persistence.
- Preserve existing suppression rules (OutLap/InPits/Compromised) and avoid introducing cross-car computations while reusing existing lap timing state where possible.
- No external skill was used for this change.

### Description
- Added new StatusE enum values and per-slot persistence fields in `CarSASlot.cs`: `HotlapWarning(130)`, `HotlapCaution(131)`, `CoolLapWarning(140)`, `CoolLapCaution(141)` and `HotCoolIntent`, `HotCoolStreak`, `HotCoolLastMiniSectorTickId`.
- Extended `CarSAEngine.cs` with hot/cool constants (bands, closing-rate threshold, gap max, intent codes), a `_miniSectorTickId` and per-mini-sector update gating, and wired the mini-sector tick increment into `Update`.
- Implemented `IsHotCoolSessionType`/`IsHotCoolSessionActive` gating so hot/cool only runs when `SessionState == 4` and `SessionTypeName` is `Practice` or `Open Qualify`; hot/cool state is reset when gating is off.
- Added hot/cool intent computation (`ComputeHotCoolCandidateIntent`) using `DeltaBestSec` primary/secondary bands and secondary-hot support via `ClosingRateSecPerSec`, plus persistence anti-flicker via `UpdateHotCoolIntent` that requires two consecutive mini-sector confirmations before committing intent.
- Implemented deterministic conflict/urgency test (`IsHotCoolConflict`) using smoothed closing rate and a `timeToCatch = gap / closingRate` check against an estimated `TimeRemainingInLap` provided by `EstimateRemainingLapSec` (uses `BestLapTimeSec`+`LapStartTimeSec`, or `LapPct` fallback, then `EstLapTimeSec`).
- Applied hot/cool overrides in `UpdateStatusE` via `ApplyHotCoolOverrides` while preserving hard-status suppression for `OutLap`, `InPits`, `CompromisedOffTrack`, and `CompromisedPenalty`.
- Updated session policy to suppress hot/cool labels in Race/other disabled contexts and updated Status short/long text mappings and `StatusEReason` strings to expose `hot_warning`, `hot_caution`, `cool_warning`, and `cool_caution`.
- Files changed: `CarSASlot.cs`, `CarSAEngine.cs`.

### Testing
- No automated tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bd0c7960832f868989b77cb56af6)