### PR TITLE
CarSA Hot/Cool: don’t consume coarse sector when DeltaBest is NaN

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -1694,8 +1694,6 @@ namespace LaunchPlugin
                 return;
             }
 
-            slot.HotCoolLastCoarseIdx = coarseIdx;
-
             bool hasDeltaBest;
             int candidateIntent = ComputeHotCoolCandidateIntent(slot, isAhead, out hasDeltaBest);
             if (!hasDeltaBest)
@@ -1703,6 +1701,7 @@ namespace LaunchPlugin
                 return;
             }
 
+            slot.HotCoolLastCoarseIdx = coarseIdx;
             slot.HotCoolIntent = candidateIntent;
         }
 


### PR DESCRIPTION
### Motivation
- Avoid consuming a coarse-sector update when `slot.DeltaBestSec` is NaN by ensuring the coarse-index marker is only set after confirming `DeltaBest` is valid so the intent can be re-evaluated later in the same coarse sector.

### Description
- Moved the assignment `slot.HotCoolLastCoarseIdx = coarseIdx` in `UpdateHotCoolIntent()` (file `CarSAEngine.cs`) to occur after `ComputeHotCoolCandidateIntent(..., out hasDeltaBest)` and the `hasDeltaBest` check; no other logic, conflict cadence, or `StatusE` override priorities were changed.

### Testing
- Attempted `dotnet build LaunchPlugin.sln`, which failed in this environment because the `dotnet` SDK is not installed, so no automated build/unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849da0c8f4832f9218dbf9cb56753a)