### PR TITLE
CarSA: smooth relative-gap anchors, debug CSV cadence & events, BestLap fallback

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -67,6 +67,7 @@ namespace LaunchPlugin
         public double BestLapTimeSec { get; set; } = double.NaN;
         public double LastLapTimeSec { get; set; } = double.NaN;
         public string BestLap { get; set; } = string.Empty;
+        public bool BestLapIsEstimated { get; set; }
         public string LastLap { get; set; } = string.Empty;
         public double DeltaBestSec { get; set; } = double.NaN;
         public string DeltaBest { get; set; } = string.Empty;
@@ -83,6 +84,8 @@ namespace LaunchPlugin
         public bool HotCoolConflictCached { get; set; }
         public int HotCoolConflictLastTickId { get; set; } = -1;
         public double GapRelativeSec { get; set; } = double.NaN;
+        public double RelativeBaseSec { get; set; } = double.NaN;
+        public double RelativeBaseTrackSec { get; set; } = double.NaN;
 
         internal double LastGapUpdateTimeSec { get; set; } = 0.0;
         internal double LastGapSec { get; set; } = double.NaN;
@@ -151,6 +154,7 @@ namespace LaunchPlugin
             BestLapTimeSec = double.NaN;
             LastLapTimeSec = double.NaN;
             BestLap = string.Empty;
+            BestLapIsEstimated = false;
             LastLap = string.Empty;
             DeltaBestSec = double.NaN;
             DeltaBest = "-";
@@ -167,6 +171,8 @@ namespace LaunchPlugin
             HotCoolConflictCached = false;
             HotCoolConflictLastTickId = -1;
             GapRelativeSec = double.NaN;
+            RelativeBaseSec = double.NaN;
+            RelativeBaseTrackSec = double.NaN;
             LastGapUpdateTimeSec = 0.0;
             LastGapSec = double.NaN;
             HasGap = false;

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -102,7 +102,17 @@
                                              ToolTip="Enables verbose logging for troubleshooting the plugin."/>
                     <styles:SHToggleCheckbox Content="Enable CarSA Debug Export" Margin="0,10,0,0"
                                              IsChecked="{Binding Settings.EnableCarSADebugExport, Mode=TwoWay}"
-                                            ToolTip="Writes a CarSA debug CSV on player checkpoint crossings (SimHub\\Logs\\LalapluginData)."/>
+                                             ToolTip="Writes CarSA debug CSV logs to SimHub\Logs\LalapluginData."/>
+                    <TextBlock Margin="25,6,0,0" Text="CarSA debug cadence mode"/>
+                    <ComboBox Margin="25,4,0,0" Width="220" SelectedIndex="{Binding Settings.CarSADebugExportCadence, Mode=TwoWay}">
+                        <ComboBoxItem Content="Tick (Hz capped)" />
+                        <ComboBoxItem Content="MiniSector (default)" />
+                        <ComboBoxItem Content="EventOnly" />
+                    </ComboBox>
+                    <TextBlock Margin="25,6,0,0" Text="Tick mode max Hz"/>
+                    <TextBox Margin="25,4,0,0" Width="80" Text="{Binding Settings.CarSADebugExportTickMaxHz, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <styles:SHToggleCheckbox Content="EventOnly: write CarSA_Events CSV" Margin="25,6,0,0"
+                                             IsChecked="{Binding Settings.CarSADebugExportWriteEventsCsv, Mode=TwoWay}"/>
                     <styles:SHToggleCheckbox Content="PitExit Verbose Logging" Margin="0,10,0,0"
                                              IsChecked="{Binding Settings.PitExitVerboseLogging, Mode=TwoWay}"
                                              ToolTip="Adds PitExit math audit details to pit-in snapshots for troubleshooting."/>


### PR DESCRIPTION
### Motivation
- Improve visual smoothness of per-slot relative gap outputs so dash shows continuous movement instead of stepping only on mini-sector updates. 
- Reduce CarSA debug CSV volume and add an event-only export mode to make debugging in long sessions/replays tractable. 
- Avoid the BestLap display regression where `BestLap` shows `-` early in replays/warmup when an estimated lap is available.

### Description
- Implement per-slot hybrid smoothing anchors by adding `RelativeBaseSec` and `RelativeBaseTrackSec` to `CarSASlot` and recording them when a valid checkpoint baseline is computed, then reconstruct `GapRelativeSec` each tick as `RelativeBaseSec + (GapTrackSec - RelativeBaseTrackSec)` with the specified NaN fallbacks and anchor resets on slot rebind/session reset (changes in `CarSAEngine.cs` and `CarSASlot.cs`).
- Add CarSA debug export cadence modes (`Tick` with configurable max Hz, `MiniSector` default, and `EventOnly`) and an optional events CSV `CarSA_Events_*.csv` that records edges for `CarIdx`, `StatusE`, `HotCoolIntent`, and conflict changes; include buffering/flush behavior and settings model/UI bindings (changes in `LalaLaunch.cs` and `LaunchPluginSettingsUI.xaml`, and `LaunchPluginSettings`).
- Provide BestLap fallback logic so `BestLap` uses an estimate when the true best is unavailable and expose `BestLapIsEstimated` for slots and exports; introduce `FormatBestLapDisplay` helper and ensure initialization paths set `BestLapIsEstimated` consistently (changes in `LalaLaunch.cs` and `CarSASlot.cs`).
- Expose new settings: `CarSADebugExportCadence`, `CarSADebugExportTickMaxHz`, and `CarSADebugExportWriteEventsCsv` in settings model and WPF UI.

### Testing
- Attempted to build with `dotnet build LaunchPlugin.sln`, which failed because the `dotnet` toolchain is not available in this environment (automated build failed). 
- Performed automated static/sanity checks by running `rg`/`sed`/scripted text transforms and inspected diffs to verify the intended code insertions and that anchors, cadence logic, and BestLap fallback were added; these checks succeeded. 
- Committed changes and created branch `feat/carsa-testing-readiness` (`git commit`/branch operations succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c8d2a8d0832f9eef49c8f8f15b23)