### PR TITLE
CarSA PR337 follow-up: 60-mini-sector cadence, RelativeSec NaN guard, slimmer debug CSV

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -233,6 +233,9 @@ namespace LaunchPlugin
         public int PlayerSessionFlagsRaw { get; set; } = -1;
         public int PlayerTrackSurfaceMaterialRaw { get; set; } = -1;
         public int PlayerTrackSurfaceRaw { get; set; } = -1;
+        public int PlayerCheckpointIndexNow { get; set; } = -1;
+        public int PlayerCheckpointIndexCrossed { get; set; } = -1;
+        public int MiniSectorTickId { get; set; }
         public string RawTelemetryReadMode { get; set; } = string.Empty;
         public string RawTelemetryFailReason { get; set; } = string.Empty;
 
@@ -263,6 +266,9 @@ namespace LaunchPlugin
             PlayerSessionFlagsRaw = -1;
             PlayerTrackSurfaceMaterialRaw = -1;
             PlayerTrackSurfaceRaw = -1;
+            PlayerCheckpointIndexNow = -1;
+            PlayerCheckpointIndexCrossed = -1;
+            MiniSectorTickId = 0;
             RawTelemetryReadMode = string.Empty;
             RawTelemetryFailReason = string.Empty;
         }


### PR DESCRIPTION
### Motivation
- MiniSector debug cadence was writing on a 100-checkpoint grid instead of the CarSA 60-mini-sector cadence used by the player, producing incorrect row counts in MiniSector mode.
- The RelativeSec smoothing could become permanently NaN when the baseline `RelativeBaseTrackSec` was initialized from a NaN `GapTrackSec` and later track gaps became valid.
- High-rate debug CSV rows remained wide and repeated static identity fields after PR337, causing very large timeseries files that are hard to use for tuning.

### Description
- Exposed player mini-sector signals from the engine by adding `PlayerCheckpointIndexNow`, `PlayerCheckpointIndexCrossed`, and `MiniSectorTickId` into `CarSADebug` and plumbing them from `CarSAEngine` to `CarSAOutputs.Debug` (`CarSASlot.cs`, `CarSAEngine.cs`).
- Switched `LalaLaunch` debug cadence to consume the engine player mini-sector signal via `UpdateCarSaDebugCadenceState(...)`, making MiniSector mode operate on a true 60-sector crossing (with an engine-debug payload fast-path), and removed the old 100-checkpoint-only mapping (`LalaLaunch.cs`).
- Hardened Relative smoothing by only assigning `RelativeBaseTrackSec` when `GapTrackSec` is a valid finite value and by changing `GapRelativeSec` publish logic to prefer: base+delta when all valid, `RelativeBaseSec` when only base is valid, track gap when only track is valid, or `NaN` otherwise (`CarSAEngine.cs`).
- Slimmed the high-rate CarSA debug CSV header and per-row serialization to remove identity-heavy and slow-changing columns (names, car number, class color, long status strings, etc.) while retaining tuning-critical fields (session + player mini-sector context, per-slot `CarIdx`, `DistPct`/`LapDelta`, `GapTrackSec`, `GapRelativeSec`, `ClosingRateSecPerSec`, `DeltaBestSec`, `HotCoolIntent`, `HotCoolConflict`, `StatusE`, `TrackSurfaceRaw`, `IsOnPitRoad`, `SessionFlagsRaw`) and updated header serialization to match (`LalaLaunch.cs`).
- Adjusted Reset/initialization state and debug buffers to reflect the new cadence/tick fields and kept `Tick` and `EventOnly` cadence modes unchanged unless engine debug payload supplies the values (`LalaLaunch.cs`, `CarSASlot.cs`).

### Testing
- Attempted to build the solution with `dotnet build /workspace/LalaLaunchPlugin/LaunchPlugin.sln`, which failed because `dotnet` is not installed in this environment, so no compiled build verification was performed (failure).
- No unit tests or other automated test suites were available or executed in this environment beyond the attempted build, so changes were validated via static code updates and local repository commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d431ec8c832faba7bc7af26ea18b)