### PR TITLE
CarSA: smooth Gap.RelativeSec with soft-anchor EMA

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -86,7 +86,6 @@ namespace LaunchPlugin
         public double GapRelativeSec { get; set; } = double.NaN;
         public double RelativeTargetSec { get; set; } = double.NaN;
         public double RelativeSmoothedSec { get; set; } = double.NaN;
-        public double RelativeBaseTrackSec { get; set; } = double.NaN;
 
         internal double LastGapUpdateTimeSec { get; set; } = 0.0;
         internal double LastGapSec { get; set; } = double.NaN;
@@ -174,7 +173,6 @@ namespace LaunchPlugin
             GapRelativeSec = double.NaN;
             RelativeTargetSec = double.NaN;
             RelativeSmoothedSec = double.NaN;
-            RelativeBaseTrackSec = double.NaN;
             LastGapUpdateTimeSec = 0.0;
             LastGapSec = double.NaN;
             HasGap = false;


### PR DESCRIPTION
### Motivation
- `Gap.RelativeSec` currently jumps every mini-sector because the checkpoint-derived baseline is hard-replaced; this change smooths the displayed relative gap while still converging to checkpoint timing truth. 
- Preserve all existing `GapTrackSec` math, Hot/Cool, `StatusE`, and slot selection behavior as fallbacks and for compatibility.

### Description
- Add per-slot state `RelativeTargetSec` and `RelativeSmoothedSec` and a new engine constant `RelativeGapEmaAlpha = 0.10` for EMA tuning. 
- On checkpoint timing updates compute the normalized relative gap exactly as before and assign it to `RelativeTargetSec`, and initialize `RelativeSmoothedSec` to the target on the first valid sample. 
- Each tick, if a `RelativeTargetSec` is available apply EMA: `RelativeSmoothedSec += alpha * (RelativeTargetSec - RelativeSmoothedSec)` and publish `GapRelativeSec = RelativeSmoothedSec`. 
- Keep robust fallback rules so that when smoothed relative is not available we publish `GapTrackSec`, otherwise `NaN`, and do not alter `GapTrackSec` computation or other slot logic. 

### Testing
- Attempted to build with `dotnet build LaunchPlugin.sln -c Release`, which failed in this environment because `dotnet` is not installed. 
- No other automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984df2b9bbc832fb4f96667adf8775d)