### PR TITLE
Replace CarSA GapRelativeSec with gate-stopwatch (Dahl) gap v2 and remove RelativeSec experiment

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -84,9 +84,6 @@ namespace LaunchPlugin
         public bool HotCoolConflictCached { get; set; }
         public int HotCoolConflictLastTickId { get; set; } = -1;
         public double GapRelativeSec { get; set; } = double.NaN;
-        public double RelativeTargetSec { get; set; } = double.NaN;
-        public double RelativeFilterSec { get; set; } = double.NaN;
-        public double RelativeFilterLastTimeSec { get; set; } = double.NaN;
 
         internal double LastGapUpdateTimeSec { get; set; } = 0.0;
         internal double LastGapSec { get; set; } = double.NaN;
@@ -172,9 +169,6 @@ namespace LaunchPlugin
             HotCoolConflictCached = false;
             HotCoolConflictLastTickId = -1;
             GapRelativeSec = double.NaN;
-            RelativeTargetSec = double.NaN;
-            RelativeFilterSec = double.NaN;
-            RelativeFilterLastTimeSec = double.NaN;
             LastGapUpdateTimeSec = 0.0;
             LastGapSec = double.NaN;
             HasGap = false;


### PR DESCRIPTION
### Motivation
- Replace the running RelativeSec experiment with a single Dahl-style gate-stopwatch proximity gap (v2) so there is one authoritative gap system besides TrackGap and to avoid collisions with older "RealGap" attempts.
- Preserve all existing TrackGap/distPct logic and dash export name `slot.GapRelativeSec` while removing parallel RelativeSec prediction/correction paths.

### Description
- Added per-gate/player/car caches and state: `playerGateTimeSecByGate[60]`, `carGateTimeSecByCarGate[carIdx,gate]`, `_gateRawGapSecByCar`, `_gateGapSecByCar`, `_gateGapValidByCar`, `_hadValidTick`, and `ClearGateGapCaches()` to manage gate-stopwatch gap lifecycle.
- On gate crossing the engine stores gate timestamps and (when player gate time exists) computes `raw = carGateTime - playerGateTime` and marks the per-car gate gap valid; slot mapping normalizes with `normalized = raw - (lapDelta * lapTimeEstimateSec)` and wraps into ±0.5 lap-time using `NormalizeGateGapSec` (no lap seconds are re-added afterwards).
- Removed the RelativeSec experiment internals: deleted `RelativeTargetSec`, `RelativeFilterSec`, `RelativeFilterLastTimeSec` fields and their computation/update code paths, and changed `UpdateSlotGapsFromCarStates` so `slot.GapRelativeSec` comes from the new gate-gap cache when valid and falls back to `slot.GapTrackSec` otherwise.
- Added reset/rebind hygiene so slot rebinds do not clear per-car gate caches while full-session resets and session/time-backwards events clear player/car gate caches and validity flags.

### Testing
- Searched codebase for legacy identifiers with `rg` (`RealGap|RealGapStopwatch|GapReal|GapRace|RaceGap|Stopwatch`) and for the old Relative fields (`RelativeTargetSec|RelativeFilterSec|RelativeFilterLastTimeSec`) and confirmed the active code paths no longer use the legacy RelativeSec logic.
- Verified presence and insertion points of the new gate caches and normalization helper via targeted `rg` and file diffs.
- Attempted automated build (`dotnet build` / `msbuild`) but runtime tooling is not available in this environment so full compilation/tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852d12bfcc832f907c536f65c1dadc)