### PR TITLE
Fix GateGap V2 direction mapping sign handling

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -1073,15 +1073,7 @@ namespace LaunchPlugin
 
             double wrapWindow = 0.5 * lapTimeUsed;
             value = WrapGateGapSec(value, lapTimeUsed, wrapWindow);
-            if (value < 0.0)
-            {
-                value += lapTimeUsed;
-            }
-
-            if (value > wrapWindow)
-            {
-                value = wrapWindow;
-            }
+            value = Math.Min(Math.Abs(value), wrapWindow);
 
             return value;
         }
@@ -1095,17 +1087,9 @@ namespace LaunchPlugin
 
             double wrapWindow = 0.5 * lapTimeUsed;
             value = WrapGateGapSec(value, lapTimeUsed, wrapWindow);
-            if (value > 0.0)
-            {
-                value -= lapTimeUsed;
-            }
+            value = Math.Min(Math.Abs(value), wrapWindow);
 
-            if (value < -wrapWindow)
-            {
-                value = -wrapWindow;
-            }
-
-            return value;
+            return -value;
         }
 
         private static double WrapGateGapSec(double value, double lapTimeUsed, double wrapWindow)


### PR DESCRIPTION
### Motivation
- Prevent Behind mapping from converting small positive gaps into complementary -lapTime values that get clamped to -0.5*lap and destroy RelativeGap.
- Enforce a consistent sign convention for Ahead (positive) and Behind (negative) gaps while keeping values to the short-way around the track.

### Description
- Updated `MapToAhead` to wrap the input via `WrapGateGapSec` and then return `Math.Min(Math.Abs(value), wrapWindow)` so Ahead is always a positive short-way value.
- Updated `MapToBehind` to wrap the input via `WrapGateGapSec` and then return `-Math.Min(Math.Abs(value), wrapWindow)` so Behind is always a negative short-way value.
- Preserved the existing `WrapGateGapSec` behavior and did not change TrackGap calculation, gate truth update, prediction, or correction logic.

### Testing
- Attempted `dotnet build` in the environment via `dotnet build`, which failed because `dotnet` is not installed in the environment. No further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c33f4b84832fbaf02ed8965e25a7)