### PR TITLE
CarSA: deterministic GateGap v2 lapTimeUsed, remove fabricated defaults, add debug and tidy state

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -87,6 +87,7 @@ namespace LaunchPlugin
         public bool HotCoolConflictCached { get; set; }
         public int HotCoolConflictLastTickId { get; set; } = -1;
         public double GapRelativeSec { get; set; } = double.NaN;
+        public int GapRelativeSource { get; set; }
 
         internal double LastGapUpdateTimeSec { get; set; } = 0.0;
         internal double LastGapSec { get; set; } = double.NaN;
@@ -207,6 +208,7 @@ namespace LaunchPlugin
             HotCoolConflictCached = false;
             HotCoolConflictLastTickId = -1;
             GapRelativeSec = double.NaN;
+            GapRelativeSource = 0;
             LastGapUpdateTimeSec = 0.0;
             LastGapSec = double.NaN;
             HasGap = false;
@@ -266,6 +268,7 @@ namespace LaunchPlugin
         public int FilteredHalfLapCountBehind { get; set; }
 
         public double LapTimeEstimateSec { get; set; }
+        public double LapTimeUsedSec { get; set; }
         public int HysteresisReplacementsThisTick { get; set; }
         public int SlotCarIdxChangedThisTick { get; set; }
         public bool HasCarIdxPaceFlags { get; set; }
@@ -299,6 +302,7 @@ namespace LaunchPlugin
             FilteredHalfLapCountAhead = 0;
             FilteredHalfLapCountBehind = 0;
             LapTimeEstimateSec = 0.0;
+            LapTimeUsedSec = 0.0;
             HysteresisReplacementsThisTick = 0;
             SlotCarIdxChangedThisTick = 0;
             HasCarIdxPaceFlags = false;


### PR DESCRIPTION
### Motivation
- Make GateGap V2 deterministic and safer by selecting a single `lapTimeUsed` per tick with a clear priority, and avoid publishing misleading fabricated defaults (no 120s fallbacks). 
- Preserve existing TrackGap behavior as the authoritative fallback and add minimal debug signals to aid live testing.

### Description
- Implement deterministic lap time selection with `SelectLapTimeUsed(playerBest, sessionEstimate, classEstimate)` and treat missing/invalid values as `double.NaN` so GateGap V2 falls back to TrackGap or NaN (no 120s substitution).
- Pass `playerBestLapTimeSec` and `classEstLapTimeSec` into `CarSAEngine.Update(...)`, compute `lapTimeUsed` once per tick and thread it through `UpdateCarStates`, `PredictGateGapForward` and `UpdateSlotGapsFromCarStates` for wrap/prediction/mapping.
- Make all GateGap helpers tolerant of invalid lap time: `PredictGateGapForward`, `WrapGateGapSec`, `MapToAhead`, `MapToBehind`, `NormalizeGateGapSec`, and `NormalizeGateGapProximity` now handle `NaN`/invalid lap times and avoid wrap/correction when invalid.
- Add per-slot debug/source signals: `CarSASlot.GapRelativeSource` (0=none,1=filtered,2=truth,3=trackgap,4=sticky) and global `Debug.LapTimeUsedSec`, expose them via `AttachCore` bindings and include CSV export columns; keep existing `LapTimeEstimateSec` debug field.
- Remove legacy/unused gate-gap arrays (`_gateGapSecByCar`, `_gateGapValidByCar`) and update `ClearGateGapCaches` accordingly; keep TrackGap calculation unchanged.

### Testing
- No automated tests were run on the modified code in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c5f8ad48832f9d6ac595d3a5ffe0)