### PR TITLE
Improve gap tracking robustness and guard stale filtered RelativeGap

### DIFF
--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -269,6 +269,8 @@ namespace LaunchPlugin
 
         public double LapTimeEstimateSec { get; set; }
         public double LapTimeUsedSec { get; set; }
+        public double Ahead01GapTruthAgeSec { get; set; } = double.NaN;
+        public double Behind01GapTruthAgeSec { get; set; } = double.NaN;
         public int HysteresisReplacementsThisTick { get; set; }
         public int SlotCarIdxChangedThisTick { get; set; }
         public bool HasCarIdxPaceFlags { get; set; }
@@ -303,6 +305,8 @@ namespace LaunchPlugin
             FilteredHalfLapCountBehind = 0;
             LapTimeEstimateSec = 0.0;
             LapTimeUsedSec = 0.0;
+            Ahead01GapTruthAgeSec = double.NaN;
+            Behind01GapTruthAgeSec = double.NaN;
             HysteresisReplacementsThisTick = 0;
             SlotCarIdxChangedThisTick = 0;
             HasCarIdxPaceFlags = false;


### PR DESCRIPTION
### Motivation

- Restore reliable TrackGap values immediately after pit exits without fabricating defaults, and prevent stale filtered RelativeGap values from freezing and migrating between slots.
- Ensure TrackGap uses the most robust available lap-time scale while keeping RelativeGap strict and non-defaulted.

### Description

- Add a cached track-gap scale `_trackGapLastGoodScaleSec` and implement `SelectTrackGapScaleSec` to choose TrackGap scale in order: `lapTimeUsed` -> `classEst` -> last-known-good -> `NaN`, and reset the cache in `ClearGateGapCaches`.
- Use the selected `trackGapScaleSec` for TrackGap computation (TrackGap = signedDistPct * scale) and emit `NaN` when the scale is invalid so no fabricated 120s default is used.
- Prevent publishing stale filtered RelativeGap by gating filtered emission to only when `_gateGapFilteredValidByCar[car]` AND (`_gateGapRateValidByCar[car]` OR truth is fresh), where truth freshness is defined by `truthAge` within `GateGapTruthMaxAgeSec`; otherwise fall back to truth (if fresh), TrackGap, or `NaN`, preserving sticky hold logic.
- Add lightweight debug visibility by exposing per-first-slot truth-age as `Ahead01GapTruthAgeSec` / `Behind01GapTruthAgeSec` and computing it from `_gateGapLastTruthTimeSecByCar` to help validate stale gating.

### Testing

- No automated tests were executed as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d07d8dac832f84e7f968cf95b0f8)