### PR TITLE
Use lap-delta normalization for gate gaps when cars are on different laps

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -869,7 +869,10 @@ namespace LaunchPlugin
                                 && playerGateLap == state.Lap)
                             {
                                 _gateRawGapSecByCar[carIdx] = sessionTimeSec - playerGateTimeSec;
-                                double gateTruth = NormalizeGateGapProximity(_gateRawGapSecByCar[carIdx], lapTimeUsedSec);
+                                int lapDelta = state.Lap - playerLap;
+                                double gateTruth = lapDelta == 0
+                                    ? NormalizeGateGapProximity(_gateRawGapSecByCar[carIdx], lapTimeUsedSec)
+                                    : NormalizeGateGapSec(_gateRawGapSecByCar[carIdx], lapDelta, lapTimeUsedSec);
                                 UpdateGateGapTruthForCar(carIdx, sessionTimeSec, gateTruth);
                             }
                         }


### PR DESCRIPTION
### Motivation
- Fix incorrect large `Gap.RelativeSec` magnitudes observed for lapped cars by applying lap-delta normalization when the target car is on a different lap, because `NormalizeGateGapProximity` is only correct for same-lap matches (`LapDelta == 0`).

### Description
- Updated `CarSAEngine.cs` gate-cross handling to compute `int lapDelta = state.Lap - playerLap` and select gate truth with `NormalizeGateGapProximity(_gateRawGapSecByCar[carIdx], lapTimeUsedSec)` for `lapDelta == 0` or `NormalizeGateGapSec(_gateRawGapSecByCar[carIdx], lapDelta, lapTimeUsedSec)` when `lapDelta != 0`, preserving the existing player-gate lap equality guard and leaving track-gap, slot selection/order, and publish property names unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985db806ff8832f898a048e4df391f3)