### PR TITLE
Add soft/hard debug gating; relocate debug UI and gate debug exports/logging

### DIFF
--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -97,25 +97,40 @@
                                                 Tag="{Binding ElementName=TracePathTextBox}" Click="BrowseButton_Click"
                                                 ToolTip="Browse for a launch trace folder."/>
                     </Grid>
-                    <styles:SHToggleCheckbox Content="Enable Debug Logging" Margin="0,20,0,0"
-                                             IsChecked="{Binding Settings.EnableDebugLogging, Mode=TwoWay}" 
-                                             ToolTip="Enables verbose logging for troubleshooting the plugin."/>
-                    <styles:SHToggleCheckbox Content="Enable CarSA Debug Export" Margin="0,10,0,0"
-                                             IsChecked="{Binding Settings.EnableCarSADebugExport, Mode=TwoWay}"
-                                             ToolTip="Writes CarSA debug CSV logs to SimHub\Logs\LalapluginData."/>
-                    <TextBlock Margin="25,6,0,0" Text="CarSA debug cadence mode"/>
-                    <ComboBox Margin="25,4,0,0" Width="220" SelectedIndex="{Binding Settings.CarSADebugExportCadence, Mode=TwoWay}">
-                        <ComboBoxItem Content="Tick (Hz capped)" />
-                        <ComboBoxItem Content="MiniSector (default)" />
-                        <ComboBoxItem Content="EventOnly" />
-                    </ComboBox>
-                    <TextBlock Margin="25,6,0,0" Text="Tick mode max Hz"/>
-                    <TextBox Margin="25,4,0,0" Width="80" Text="{Binding Settings.CarSADebugExportTickMaxHz, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <styles:SHToggleCheckbox Content="EventOnly: write CarSA_Events CSV" Margin="25,6,0,0"
-                                             IsChecked="{Binding Settings.CarSADebugExportWriteEventsCsv, Mode=TwoWay}"/>
-                    <styles:SHToggleCheckbox Content="PitExit Verbose Logging" Margin="0,10,0,0"
-                                             IsChecked="{Binding Settings.PitExitVerboseLogging, Mode=TwoWay}"
-                                             ToolTip="Adds PitExit math audit details to pit-in snapshots for troubleshooting."/>
+                </StackPanel>
+            </styles:SHSection>
+
+            <styles:SHSection Title="DEBUG SETTINGS" ShowSeparator="True"
+                              Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <StackPanel>
+                    <styles:SHToggleCheckbox Content="Enable Soft Debug" Margin="0,10,0,0"
+                                             IsChecked="{Binding Settings.EnableSoftDebug, Mode=TwoWay}"
+                                             ToolTip="Master toggle that enables debug UI and debug processing."/>
+                    <Expander Header="Debug Options" Margin="0,10,0,0"
+                              IsExpanded="{Binding Settings.EnableSoftDebug, Mode=OneWay}"
+                              Visibility="{Binding Settings.EnableSoftDebug, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <StackPanel Margin="10,5,0,0">
+                            <styles:SHToggleCheckbox Content="Enable Debug Logging" Margin="0,10,0,0"
+                                                     IsChecked="{Binding Settings.EnableDebugLogging, Mode=TwoWay}"
+                                                     ToolTip="Enables verbose logging for troubleshooting the plugin."/>
+                            <styles:SHToggleCheckbox Content="Enable CarSA Debug Export" Margin="0,10,0,0"
+                                                     IsChecked="{Binding Settings.EnableCarSADebugExport, Mode=TwoWay}"
+                                                     ToolTip="Writes CarSA debug CSV logs to SimHub\Logs\LalapluginData."/>
+                            <TextBlock Margin="25,6,0,0" Text="CarSA debug cadence mode"/>
+                            <ComboBox Margin="25,4,0,0" Width="220" SelectedIndex="{Binding Settings.CarSADebugExportCadence, Mode=TwoWay}">
+                                <ComboBoxItem Content="Tick (Hz capped)" />
+                                <ComboBoxItem Content="MiniSector (default)" />
+                                <ComboBoxItem Content="EventOnly" />
+                            </ComboBox>
+                            <TextBlock Margin="25,6,0,0" Text="Tick mode max Hz"/>
+                            <TextBox Margin="25,4,0,0" Width="80" Text="{Binding Settings.CarSADebugExportTickMaxHz, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <styles:SHToggleCheckbox Content="EventOnly: write CarSA_Events CSV" Margin="25,6,0,0"
+                                                     IsChecked="{Binding Settings.CarSADebugExportWriteEventsCsv, Mode=TwoWay}"/>
+                            <styles:SHToggleCheckbox Content="PitExit Verbose Logging" Margin="0,10,0,0"
+                                                     IsChecked="{Binding Settings.PitExitVerboseLogging, Mode=TwoWay}"
+                                                     ToolTip="Adds PitExit math audit details to pit-in snapshots for troubleshooting."/>
+                        </StackPanel>
+                    </Expander>
                 </StackPanel>
             </styles:SHSection>
         </StackPanel>


### PR DESCRIPTION
### Motivation
- Introduce a two-level debug control model so debug work can be made effectively zero-cost at runtime unless explicitly enabled. 
- Provide a build-time hard switch to completely hide and disable debug UI and logic for shipping builds. 
- Keep all existing debug features and exports intact but make them subordinate to a single soft master toggle to reduce CPU and I/O when off. 

### Description
- Added a hard compile-time switch `HARD_DEBUG_ENABLED` and helper properties (`HardDebugEnabled`, `SoftDebugEnabled`, `IsDebugOnForLogic`, `IsVerboseDebugLoggingOn`) in `LalaLaunch.cs` and enforced hard-disable on settings load/save via `EnforceHardDebugSettings`. 
- Added the soft master setting `EnableSoftDebug` to `LaunchPluginSettings` (`public bool EnableSoftDebug { get; set; } = false;`) and exposed `HardDebugEnabledForUi` for XAML visibility binding. 
- Moved and grouped existing debug toggles into a new settings area in `LaunchPluginSettingsUI.xaml` under a `DEBUG SETTINGS` section with a single master `Enable Soft Debug` toggle and an `Expander` containing the existing toggles; the entire debug area is hidden when the hard switch is off and the expander auto-opens/auto-hides based on soft toggle. 
- Enforced early/cheap gating across runtime logic in `DataUpdate`: introduced `debugMaster` and `verboseLogs` booleans and propagated these to subsystems; changed the `CarSAEngine` update call to use `debugMaster`, passed verbose flag into `OpponentsEngine`, and made expensive debug telemetry reads/writes only run when `debugMaster` permits (e.g., `WriteCarSaDebugExport` now takes a `debugMaster` flag and returns early when false). 
- Gate debug exports to safe defaults when Soft Debug is OFF by wrapping `AttachCore` delegates for `Car.Debug.*` and `Car.Player.*` so they return zeros/NaN/false/empty instead of touching debug outputs when `SoftDebugEnabled` is false. 
- Make verbose logging conditional: many `SimHub.Logging.Current.Debug(...)` calls are now emitted only when `IsVerboseDebugLoggingOn` is true, and `TelemetryTraceLogger` debug traces are guarded by the plugin’s verbose flag. 
- Make `PitExitVerboseLogging` subordinate to the soft debug master by gating the pit-exit math-audit log behind `SoftDebugEnabled && Settings.PitExitVerboseLogging`. 
- Kept all tuning constants, public exports, field names and debug features intact; no renames/removals of existing debug exports were performed. 

Files touched (high level): `LalaLaunch.cs` (logic, exports, settings load/save), `LaunchPluginSettingsUI.xaml` (UI relocation/grouping). 

### Testing
- No automated tests were executed for this change set (no test suite ran as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877b71d73c832f9b17d62082e2c002)