### PR TITLE
Move debug UI to Dashes tab with live expander binding

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -197,6 +197,41 @@
                     </StackPanel>
                 </Grid>
                 <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" />
+
+                <StackPanel Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock Text="DEBUG" FontSize="16" FontWeight="Bold" Margin="0,5,10,0"/>
+                    <styles:SHToggleCheckbox x:Name="DebugMasterToggle"
+                                             Content="Enable debugging mode"
+                                             Margin="0,10,0,0"
+                                             IsChecked="{Binding Settings.EnableSoftDebug, Mode=TwoWay}"
+                                             ToolTip="Master toggle that enables debug UI and debug processing."/>
+                    <Expander Header="Debug Options"
+                              Margin="0,10,0,0"
+                              IsExpanded="{Binding ElementName=DebugMasterToggle, Path=IsChecked}"
+                              Visibility="{Binding ElementName=DebugMasterToggle, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <StackPanel Margin="10,5,0,0">
+                            <styles:SHToggleCheckbox Content="Enable Debug Logging" Margin="0,10,0,0"
+                                                     IsChecked="{Binding Settings.EnableDebugLogging, Mode=TwoWay}"
+                                                     ToolTip="Enables verbose logging for troubleshooting the plugin."/>
+                            <styles:SHToggleCheckbox Content="Enable CarSA Debug Export" Margin="0,10,0,0"
+                                                     IsChecked="{Binding Settings.EnableCarSADebugExport, Mode=TwoWay}"
+                                                     ToolTip="Writes CarSA debug CSV logs to SimHub\Logs\LalapluginData."/>
+                            <TextBlock Margin="25,6,0,0" Text="CarSA debug cadence mode"/>
+                            <ComboBox Margin="25,4,0,0" Width="220" SelectedIndex="{Binding Settings.CarSADebugExportCadence, Mode=TwoWay}">
+                                <ComboBoxItem Content="Tick (Hz capped)" />
+                                <ComboBoxItem Content="MiniSector (default)" />
+                                <ComboBoxItem Content="EventOnly" />
+                            </ComboBox>
+                            <TextBlock Margin="25,6,0,0" Text="Tick mode max Hz"/>
+                            <TextBox Margin="25,4,0,0" Width="80" Text="{Binding Settings.CarSADebugExportTickMaxHz, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <styles:SHToggleCheckbox Content="EventOnly: write CarSA_Events CSV" Margin="25,6,0,0"
+                                                     IsChecked="{Binding Settings.CarSADebugExportWriteEventsCsv, Mode=TwoWay}"/>
+                            <styles:SHToggleCheckbox Content="PitExit Verbose Logging" Margin="0,10,0,0"
+                                                     IsChecked="{Binding Settings.PitExitVerboseLogging, Mode=TwoWay}"
+                                                     ToolTip="Adds PitExit math audit details to pit-in snapshots for troubleshooting."/>
+                        </StackPanel>
+                    </Expander>
+                </StackPanel>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -100,39 +100,6 @@
                 </StackPanel>
             </styles:SHSection>
 
-            <styles:SHSection Title="DEBUG SETTINGS" ShowSeparator="True"
-                              Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <StackPanel>
-                    <styles:SHToggleCheckbox Content="Enable Soft Debug" Margin="0,10,0,0"
-                                             IsChecked="{Binding Settings.EnableSoftDebug, Mode=TwoWay}"
-                                             ToolTip="Master toggle that enables debug UI and debug processing."/>
-                    <Expander Header="Debug Options" Margin="0,10,0,0"
-                              IsExpanded="{Binding Settings.EnableSoftDebug, Mode=OneWay}"
-                              Visibility="{Binding Settings.EnableSoftDebug, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <StackPanel Margin="10,5,0,0">
-                            <styles:SHToggleCheckbox Content="Enable Debug Logging" Margin="0,10,0,0"
-                                                     IsChecked="{Binding Settings.EnableDebugLogging, Mode=TwoWay}"
-                                                     ToolTip="Enables verbose logging for troubleshooting the plugin."/>
-                            <styles:SHToggleCheckbox Content="Enable CarSA Debug Export" Margin="0,10,0,0"
-                                                     IsChecked="{Binding Settings.EnableCarSADebugExport, Mode=TwoWay}"
-                                                     ToolTip="Writes CarSA debug CSV logs to SimHub\Logs\LalapluginData."/>
-                            <TextBlock Margin="25,6,0,0" Text="CarSA debug cadence mode"/>
-                            <ComboBox Margin="25,4,0,0" Width="220" SelectedIndex="{Binding Settings.CarSADebugExportCadence, Mode=TwoWay}">
-                                <ComboBoxItem Content="Tick (Hz capped)" />
-                                <ComboBoxItem Content="MiniSector (default)" />
-                                <ComboBoxItem Content="EventOnly" />
-                            </ComboBox>
-                            <TextBlock Margin="25,6,0,0" Text="Tick mode max Hz"/>
-                            <TextBox Margin="25,4,0,0" Width="80" Text="{Binding Settings.CarSADebugExportTickMaxHz, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <styles:SHToggleCheckbox Content="EventOnly: write CarSA_Events CSV" Margin="25,6,0,0"
-                                                     IsChecked="{Binding Settings.CarSADebugExportWriteEventsCsv, Mode=TwoWay}"/>
-                            <styles:SHToggleCheckbox Content="PitExit Verbose Logging" Margin="0,10,0,0"
-                                                     IsChecked="{Binding Settings.PitExitVerboseLogging, Mode=TwoWay}"
-                                                     ToolTip="Adds PitExit math audit details to pit-in snapshots for troubleshooting."/>
-                        </StackPanel>
-                    </Expander>
-                </StackPanel>
-            </styles:SHSection>
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation
- The debug controls added previously lived on the Launch settings view and used a POCO settings binding so the Expander did not react live when the master toggle changed.  The debug section must be relocated to the DASHES tab and made immediately responsive to the master toggle. 
- The master toggle label must be updated to "Enable debugging mode" and the entire debug UI must still be hidden when the hard-debug gate is false.

### Description
- Removed the entire "DEBUG SETTINGS" section from `LaunchPluginSettingsUI.xaml` so the debug controls are no longer duplicated there.
- Added a new `StackPanel` at the end of `DashesTabView.xaml` immediately after the "User variables" section, gated by `Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}"`, and with a `TextBlock` header "DEBUG".
- Added the master toggle `styles:SHToggleCheckbox x:Name="DebugMasterToggle" Content="Enable debugging mode" IsChecked="{Binding Settings.EnableSoftDebug, Mode=TwoWay}"` and moved the existing debug controls inside an `Expander` whose `Visibility` and `IsExpanded` are driven by `ElementName=DebugMasterToggle, Path=IsChecked` (using the existing `BooleanToVisibilityConverter`).
- Preserved all existing debug sub-controls and bindings (EnableDebugLogging, EnableCarSADebugExport, CarSA cadence ComboBox, tick max Hz TextBox, EventOnly CSV toggle, PitExitVerboseLogging) without creating or renaming settings.

### Testing
- No automated tests were executed; this is an XAML-only UI wiring change and was committed after local edits (no runtime UI tests run in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879fcfafe4832fbc79f33e658cb9d2)