### PR TITLE
Fix precision gap mapping and strip hidden BOM

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -609,7 +609,8 @@ namespace LaunchPlugin
             ApplySlots(false, sessionTimeSec, playerCarIdx, playerLapPct, playerLap, carIdxLapDistPct, carIdxLap, carIdxTrackSurface, carIdxOnPitRoad, _behindCandidateIdx, _behindCandidateDist, _outputs.BehindSlots, ref hysteresisReplacements, ref slotCarIdxChanged);
             UpdateSlotGapsFromCarStates(_outputs.AheadSlots, sessionTimeSec, lapTimeUsed, lapTimeUsedValid, trackGapScaleSec, trackGapScaleValid, isRace, true);
             UpdateSlotGapsFromCarStates(_outputs.BehindSlots, sessionTimeSec, lapTimeUsed, lapTimeUsedValid, trackGapScaleSec, trackGapScaleValid, isRace, false);
-            UpdateSlot01PrecisionGaps(sessionTimeSec, lapTimeUsed);
+            double lapTimeMapSec = lapTimeUsedValid ? lapTimeUsed : lapTimeEstimateSec;
+            UpdateSlot01PrecisionGaps(sessionTimeSec, lapTimeMapSec);
 
             if (debugEnabled)
             {
@@ -1364,11 +1365,11 @@ namespace LaunchPlugin
             }
         }
 
-        private void UpdateSlot01PrecisionGaps(double sessionTimeSec, double lapTimeUsed)
+        private void UpdateSlot01PrecisionGaps(double sessionTimeSec, double lapTimeMapSec)
         {
             _ = sessionTimeSec;
-            _outputs.Ahead01PrecisionGapSec = ComputeSlotPrecisionGap(_outputs.AheadSlots, lapTimeUsed, true);
-            _outputs.Behind01PrecisionGapSec = ComputeSlotPrecisionGap(_outputs.BehindSlots, lapTimeUsed, false);
+            _outputs.Ahead01PrecisionGapSec = ComputeSlotPrecisionGap(_outputs.AheadSlots, lapTimeMapSec, true);
+            _outputs.Behind01PrecisionGapSec = ComputeSlotPrecisionGap(_outputs.BehindSlots, lapTimeMapSec, false);
         }
 
         private double ComputeSlotPrecisionGap(CarSASlot[] slots, double lapTimeUsed, bool isAhead)

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1,4 +1,4 @@
-﻿// --- Using Directives ---
+// --- Using Directives ---
 using GameReaderCommon;
 using LaunchPlugin.Messaging;
 using Newtonsoft.Json;


### PR DESCRIPTION
### Motivation
- Fix a bug where Slot01 precision gap mapping used `lapTimeUsed` even when that value was invalid, which could cause computed gaps to clamp to 0.  
- Remove hidden/bidi Unicode control characters that triggered GitHub’s warning banner (preserve visible characters such as `Δ`).

### Description
- Compute a mapped lap time before calling the precision-gap path by adding `double lapTimeMapSec = lapTimeUsedValid ? lapTimeUsed : lapTimeEstimateSec;` and pass `lapTimeMapSec` to `UpdateSlot01PrecisionGaps`.  
- Change `UpdateSlot01PrecisionGaps` signature to accept `lapTimeMapSec` and use it when calling `ComputeSlotPrecisionGap`.  
- Remove the ZERO WIDTH NO-BREAK SPACE (BOM / Unicode Cf) from `LalaLaunch.cs` while leaving visible text (including `Δ`) unchanged.  
- Only touched `CarSAEngine.cs` and `LalaLaunch.cs`; no changes to any `Car.AheadXX`/`BehindXX` outputs or `StatusE` behavior were made.

### Testing
- Ran an automated Unicode scan (Python + `unicodedata.category`) which detected a `ZERO WIDTH NO-BREAK SPACE` in `LalaLaunch.cs` before the change and confirmed no `Cf` category characters remain in the touched files after the change (scan succeeded).  
- Ran code searches to verify the updated call and new parameter name in `CarSAEngine.cs` (searches succeeded).  
- No unit or runtime tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b45abf04832fb314fa6dc978d991)