### PR TITLE
Add OffTrack debug CSV probe logging

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -131,6 +131,7 @@ namespace LaunchPlugin
         private double _sessionTypeStartTimeSec = double.NaN;
         private double _lastSessionTimeSec = double.NaN;
         private bool _allowStatusEThisTick = true;
+        private bool _allowLatchesThisTick = true;
         private int _playerCheckpointIndexNow = -1;
         private int _playerCheckpointIndexLast = -1;
         private int _playerCheckpointIndexCrossed = -1;
@@ -240,6 +241,17 @@ namespace LaunchPlugin
             }
         }
 
+        public struct OffTrackDebugState
+        {
+            public bool OffTrackNow { get; set; }
+            public int OffTrackStreak { get; set; }
+            public double OffTrackFirstSeenTimeSec { get; set; }
+            public int CompromisedUntilLap { get; set; }
+            public bool CompromisedOffTrackActive { get; set; }
+            public bool CompromisedPenaltyActive { get; set; }
+            public bool AllowLatches { get; set; }
+        }
+
         public CarSAEngine()
         {
             _outputs = new CarSAOutputs(SlotsAhead, SlotsBehind);
@@ -339,6 +351,7 @@ namespace LaunchPlugin
             _sessionTypeStartTimeSec = double.NaN;
             _lastSessionTimeSec = double.NaN;
             _allowStatusEThisTick = true;
+            _allowLatchesThisTick = true;
             _playerCheckpointIndexNow = -1;
             _playerCheckpointIndexLast = -1;
             _playerCheckpointIndexCrossed = -1;
@@ -346,6 +359,28 @@ namespace LaunchPlugin
             _anyCheckpointCrossedThisTick = false;
             _miniSectorTickId = 0;
             ClearGateGapCaches();
+        }
+
+        public bool TryGetOffTrackDebugState(int carIdx, out OffTrackDebugState state)
+        {
+            state = default;
+            if (carIdx < 0 || carIdx >= _carStates.Length)
+            {
+                return false;
+            }
+
+            var carState = _carStates[carIdx];
+            state = new OffTrackDebugState
+            {
+                OffTrackNow = carState.TrackSurfaceRaw == TrackSurfaceOffTrack,
+                OffTrackStreak = carState.OffTrackStreak,
+                OffTrackFirstSeenTimeSec = carState.OffTrackFirstSeenTimeSec,
+                CompromisedUntilLap = carState.CompromisedUntilLap,
+                CompromisedOffTrackActive = carState.CompromisedOffTrackActive,
+                CompromisedPenaltyActive = carState.CompromisedPenaltyActive,
+                AllowLatches = _allowLatchesThisTick
+            };
+            return true;
         }
 
         // === SA / track-awareness + slot assignment =============================
@@ -438,6 +473,7 @@ namespace LaunchPlugin
                 }
             }
             _allowStatusEThisTick = allowStatusE;
+            _allowLatchesThisTick = allowLatches;
 
             double playerLapPct = double.NaN;
             bool playerLapPctValid = false;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -2865,6 +2865,10 @@ namespace LaunchPlugin
         private string _carSaDebugExportPath;
         private string _carSaDebugExportToken;
         private int _carSaDebugExportPendingLines;
+        private StringBuilder _offTrackDebugExportBuffer;
+        private string _offTrackDebugExportPath;
+        private string _offTrackDebugExportToken;
+        private int _offTrackDebugExportPendingLines;
         private const int CarSaDebugExportSlotCount = 5;
         private const int CarSaDebugCadenceTick = 0;
         private const int CarSaDebugCadenceMiniSector = 1;
@@ -3904,6 +3908,9 @@ namespace LaunchPlugin
             // Optionally discard only if you really want to delete last file on exit
             // _telemetryTraceLogger?.DiscardCurrentTrace();
 
+            ResetOffTrackDebugExportState();
+            ResetCarSaDebugExportState();
+
             // Persist settings
             SaveSettings();
             ProfilesViewModel.SaveProfiles();
@@ -4416,6 +4423,7 @@ namespace LaunchPlugin
                 _carSaEngine?.Reset();
                 ResetCarSaIdentityState();
                 ResetCarSaDebugExportState();
+                ResetOffTrackDebugExportState();
                 _currentCarModel = string.Empty;
                 CurrentTrackName = string.Empty;
                 CurrentTrackKey = string.Empty;
@@ -4644,6 +4652,29 @@ namespace LaunchPlugin
                 {
                     UpdateCarSaRawTelemetryDebug(pluginManager, _carSaEngine.Outputs, playerCarIdx, verboseLogs);
                 }
+
+                int probeCarIdx = Settings?.OffTrackDebugProbeCarIdx ?? -1;
+                bool offTrackDebugEnabled = Settings?.EnableOffTrackDebugCsv == true && probeCarIdx >= 0;
+                int[] carIdxTrackSurfaceMaterial = null;
+                int sessionFlagsRaw = -1;
+                if (offTrackDebugEnabled)
+                {
+                    carIdxTrackSurfaceMaterial = SafeReadIntArray(pluginManager, "DataCorePlugin.GameRawData.Telemetry.CarIdxTrackSurfaceMaterial");
+                    sessionFlagsRaw = SafeReadInt(pluginManager, "DataCorePlugin.GameRawData.Telemetry.SessionFlags", -1);
+                }
+                WriteOffTrackDebugExport(
+                    pluginManager,
+                    sessionTimeSec,
+                    sessionState,
+                    sessionFlagsRaw,
+                    probeCarIdx,
+                    playerCarIdx,
+                    carIdxTrackSurface,
+                    carIdxTrackSurfaceMaterial,
+                    carIdxSessionFlags,
+                    carIdxOnPitRoad,
+                    carIdxLap,
+                    carIdxLapDistPct);
 
                 WriteCarSaDebugExport(pluginManager, _carSaEngine.Outputs, sessionState, sessionTypeName, debugMaster);
                 RefreshCarSaSlotIdentities(pluginManager, sessionTimeSec);
@@ -5203,6 +5234,91 @@ namespace LaunchPlugin
                 {
                     _carSaDebugExportBuffer.Clear();
                 }
+            }
+        }
+
+        private void WriteOffTrackDebugExport(
+            PluginManager pluginManager,
+            double sessionTimeSec,
+            int sessionState,
+            int sessionFlagsRaw,
+            int probeCarIdx,
+            int playerCarIdx,
+            int[] carIdxTrackSurface,
+            int[] carIdxTrackSurfaceMaterial,
+            int[] carIdxSessionFlags,
+            bool[] carIdxOnPitRoad,
+            int[] carIdxLap,
+            float[] carIdxLapDistPct)
+        {
+            if (Settings?.EnableOffTrackDebugCsv != true || probeCarIdx < 0)
+            {
+                ResetOffTrackDebugExportState();
+                return;
+            }
+
+            EnsureOffTrackDebugExportFile();
+
+            StringBuilder buffer = _offTrackDebugExportBuffer ?? (_offTrackDebugExportBuffer = new StringBuilder(512));
+            buffer.Append(sessionTimeSec.ToString("F3", CultureInfo.InvariantCulture)).Append(',');
+            buffer.Append(sessionState).Append(',');
+            AppendCsvHexValue(buffer, sessionFlagsRaw);
+            buffer.Append(',');
+            AppendCsvOptionalInt(buffer, sessionFlagsRaw, -1);
+            buffer.Append(',');
+            buffer.Append(probeCarIdx).Append(',');
+
+            int trackSurface = ReadCarIdxInt(carIdxTrackSurface, probeCarIdx, int.MinValue);
+            int trackSurfaceMaterial = ReadCarIdxInt(carIdxTrackSurfaceMaterial, probeCarIdx, int.MinValue);
+            int carSessionFlags = ReadCarIdxInt(carIdxSessionFlags, probeCarIdx, int.MinValue);
+            bool? carOnPitRoad = ReadCarIdxBool(carIdxOnPitRoad, probeCarIdx);
+            int carLap = ReadCarIdxInt(carIdxLap, probeCarIdx, int.MinValue);
+            double carLapDistPct = ReadCarIdxFloat(carIdxLapDistPct, probeCarIdx);
+
+            AppendCsvOptionalInt(buffer, trackSurface, int.MinValue);
+            buffer.Append(',');
+            AppendCsvOptionalInt(buffer, trackSurfaceMaterial, int.MinValue);
+            buffer.Append(',');
+            AppendCsvHexValue(buffer, carSessionFlags);
+            buffer.Append(',');
+            AppendCsvOptionalInt(buffer, carSessionFlags, int.MinValue);
+            buffer.Append(',');
+            AppendCsvOptionalBool(buffer, carOnPitRoad);
+            buffer.Append(',');
+            AppendCsvOptionalInt(buffer, carLap, int.MinValue);
+            buffer.Append(',');
+            AppendCsvOptionalDouble(buffer, carLapDistPct, "F6");
+            buffer.Append(',');
+
+            bool hasState = _carSaEngine != null && _carSaEngine.TryGetOffTrackDebugState(probeCarIdx, out var offTrackState);
+            AppendCsvOptionalBool(buffer, hasState ? (bool?)offTrackState.OffTrackNow : null);
+            buffer.Append(',');
+            AppendCsvOptionalInt(buffer, hasState ? offTrackState.OffTrackStreak : int.MinValue, int.MinValue);
+            buffer.Append(',');
+            AppendCsvOptionalDouble(buffer, hasState ? offTrackState.OffTrackFirstSeenTimeSec : double.NaN, "F3");
+            buffer.Append(',');
+            AppendCsvOptionalInt(buffer, hasState ? offTrackState.CompromisedUntilLap : int.MinValue, int.MinValue);
+            buffer.Append(',');
+            AppendCsvOptionalBool(buffer, hasState ? (bool?)offTrackState.CompromisedOffTrackActive : null);
+            buffer.Append(',');
+            AppendCsvOptionalBool(buffer, hasState ? (bool?)offTrackState.CompromisedPenaltyActive : null);
+            buffer.Append(',');
+            AppendCsvOptionalBool(buffer, hasState ? (bool?)offTrackState.AllowLatches : null);
+            buffer.Append(',');
+
+            AppendCsvOptionalInt(buffer, playerCarIdx, -1);
+            buffer.Append(',');
+            int incidentCount = SafeReadInt(pluginManager, "DataCorePlugin.GameRawData.Telemetry.PlayerCarMyIncidentCount", -1);
+            AppendCsvOptionalInt(buffer, incidentCount, -1);
+            buffer.Append(',');
+            bool? lapInvalidated = SafeReadBoolNullable(pluginManager, "DataCorePlugin.GameRawData.GameData.LapInvalidated");
+            AppendCsvOptionalBool(buffer, lapInvalidated);
+            buffer.AppendLine();
+
+            _offTrackDebugExportPendingLines++;
+            if (_offTrackDebugExportPendingLines >= 20 || buffer.Length >= 4096)
+            {
+                FlushOffTrackDebugExportBuffer();
             }
         }
 
@@ -5934,6 +6050,63 @@ namespace LaunchPlugin
             _carSaDebugExportPendingLines = 0;
         }
 
+        private void EnsureOffTrackDebugExportFile()
+        {
+            string token = string.IsNullOrWhiteSpace(_currentSessionToken) ? "na" : _currentSessionToken.Replace(":", "_");
+            if (string.Equals(token, _offTrackDebugExportToken, StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(_offTrackDebugExportPath))
+            {
+                return;
+            }
+
+            FlushOffTrackDebugExportBuffer();
+            _offTrackDebugExportToken = token;
+            string folder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs", "LalapluginData");
+            Directory.CreateDirectory(folder);
+            string timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+            _offTrackDebugExportPath = Path.Combine(folder, $"OffTrackDebug_{timestamp}.csv");
+            if (!File.Exists(_offTrackDebugExportPath))
+            {
+                File.WriteAllText(_offTrackDebugExportPath, GetOffTrackDebugExportHeader() + Environment.NewLine);
+            }
+        }
+
+        private void FlushOffTrackDebugExportBuffer()
+        {
+            if (string.IsNullOrWhiteSpace(_offTrackDebugExportPath) || _offTrackDebugExportBuffer == null || _offTrackDebugExportBuffer.Length == 0)
+            {
+                return;
+            }
+
+            File.AppendAllText(_offTrackDebugExportPath, _offTrackDebugExportBuffer.ToString());
+            _offTrackDebugExportBuffer.Clear();
+            _offTrackDebugExportPendingLines = 0;
+        }
+
+        private void ResetOffTrackDebugExportState()
+        {
+            if (string.IsNullOrWhiteSpace(_offTrackDebugExportPath) && (_offTrackDebugExportBuffer == null || _offTrackDebugExportBuffer.Length == 0))
+            {
+                return;
+            }
+
+            FlushOffTrackDebugExportBuffer();
+            _offTrackDebugExportPath = null;
+            _offTrackDebugExportToken = null;
+            _offTrackDebugExportPendingLines = 0;
+        }
+
+        private static string GetOffTrackDebugExportHeader()
+        {
+            StringBuilder buffer = new StringBuilder(512);
+            buffer.Append("SessionTimeSec,SessionState,SessionFlagsHex,SessionFlagsDec,ProbeCarIdx,");
+            buffer.Append("CarIdxTrackSurface,CarIdxTrackSurfaceMaterial,CarIdxSessionFlagsHex,CarIdxSessionFlagsDec,");
+            buffer.Append("CarIdxOnPitRoad,CarIdxLap,CarIdxLapDistPct,");
+            buffer.Append("OffTrackNow,OffTrackStreak,OffTrackFirstSeenTimeSec,CompromisedUntilLap,");
+            buffer.Append("CompromisedOffTrackActive,CompromisedPenaltyActive,AllowLatches,");
+            buffer.Append("PlayerCarIdx,PlayerMyIncidentCount,GameData.LapInvalidated");
+            return buffer.ToString();
+        }
+
         private static string GetCarSaDebugExportHeader()
         {
             StringBuilder buffer = new StringBuilder(2048);
@@ -6017,6 +6190,94 @@ namespace LaunchPlugin
             if (buffer.Length == startLength)
             {
                 buffer.Append(fallback);
+            }
+        }
+
+        private static void AppendCsvHexValue(StringBuilder buffer, int value)
+        {
+            if (value < 0)
+            {
+                return;
+            }
+
+            buffer.Append("0x").Append(value.ToString("X", CultureInfo.InvariantCulture));
+        }
+
+        private static void AppendCsvOptionalInt(StringBuilder buffer, int value, int unsetValue)
+        {
+            if (value == unsetValue)
+            {
+                return;
+            }
+
+            buffer.Append(value);
+        }
+
+        private static void AppendCsvOptionalDouble(StringBuilder buffer, double value, string format)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                return;
+            }
+
+            buffer.Append(value.ToString(format, CultureInfo.InvariantCulture));
+        }
+
+        private static void AppendCsvOptionalBool(StringBuilder buffer, bool? value)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            buffer.Append(value.Value ? "1" : "0");
+        }
+
+        private static int ReadCarIdxInt(int[] values, int carIdx, int fallback)
+        {
+            if (values == null || carIdx < 0 || carIdx >= values.Length)
+            {
+                return fallback;
+            }
+
+            return values[carIdx];
+        }
+
+        private static bool? ReadCarIdxBool(bool[] values, int carIdx)
+        {
+            if (values == null || carIdx < 0 || carIdx >= values.Length)
+            {
+                return null;
+            }
+
+            return values[carIdx];
+        }
+
+        private static double ReadCarIdxFloat(float[] values, int carIdx)
+        {
+            if (values == null || carIdx < 0 || carIdx >= values.Length)
+            {
+                return double.NaN;
+            }
+
+            return values[carIdx];
+        }
+
+        private static bool? SafeReadBoolNullable(PluginManager pluginManager, string propertyName)
+        {
+            try
+            {
+                object value = pluginManager.GetPropertyValue(propertyName);
+                if (value == null)
+                {
+                    return null;
+                }
+
+                return Convert.ToBoolean(value);
+            }
+            catch
+            {
+                return null;
             }
         }
 
@@ -9395,10 +9656,12 @@ namespace LaunchPlugin
         public bool EnableSoftDebug { get; set; } = false;
         public bool EnableDebugLogging { get; set; } = false;
         public bool EnableCarSADebugExport { get; set; } = false;
+        public bool EnableOffTrackDebugCsv { get; set; } = false;
         public int CarSADebugExportCadence { get; set; } = 1;
         public int CarSADebugExportTickMaxHz { get; set; } = 20;
         public bool CarSADebugExportWriteEventsCsv { get; set; } = true;
         public int CarSARawTelemetryMode { get; set; } = 1;
+        public int OffTrackDebugProbeCarIdx { get; set; } = -1;
         public bool PitExitVerboseLogging { get; set; } = false;
         public double ResultsDisplayTime { get; set; } = 5.0; // Corrected to 5 seconds
         public double FuelReadyConfidence { get; set; } = LalaLaunch.FuelReadyConfidenceDefault;

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -100,6 +100,20 @@
                 </StackPanel>
             </styles:SHSection>
 
+            <styles:SHSection Title="DEBUG" ShowSeparator="True">
+                <StackPanel>
+                    <styles:SHToggleCheckbox Content="OffTrack Debug CSV" Margin="0,5,0,0"
+                                             IsChecked="{Binding Settings.EnableOffTrackDebugCsv, Mode=TwoWay}"
+                                             ToolTip="Enable per-tick OffTrack debug CSV logging for the probed car."/>
+                    <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                        <TextBlock Text="Probe CarIdx" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                        <TextBox Width="80" Text="{Binding Settings.OffTrackDebugProbeCarIdx, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <TextBlock Margin="20,6,0,0" Foreground="LightGray"
+                               Text="Tip: find your PlayerCarIdx in SimHub property list"/>
+                </StackPanel>
+            </styles:SHSection>
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation

- Provide a lightweight, selectable per-tick probe for OffTrack-related telemetry and the internal OffTrack latch state for a single CarIdx to help with testing and tuning without changing OffTrack logic.

### Description

- UI: added a small Debug section to the settings UI (`LaunchPluginSettingsUI.xaml`) with a checkbox `OffTrack Debug CSV` bound to `Settings.EnableOffTrackDebugCsv` (default false) and a numeric textbox `Probe CarIdx` bound to `Settings.OffTrackDebugProbeCarIdx` (default -1) plus a short tip line for locating PlayerCarIdx.
- Settings: added `EnableOffTrackDebugCsv` (bool) and `OffTrackDebugProbeCarIdx` (int) to `LaunchPluginSettings` in `LalaLaunch.cs` (defaults: false and -1 respectively).
- Engine API: added `OffTrackDebugState` struct and `TryGetOffTrackDebugState(int carIdx, out OffTrackDebugState)` to `CarSAEngine.cs` to expose a snapshot of the per-car OffTrack-related state (OffTrackNow, OffTrackStreak, OffTrackFirstSeenTimeSec, CompromisedUntilLap, CompromisedOffTrackActive, CompromisedPenaltyActive, AllowLatches) without altering existing OFFTK behavior.
- Logging: implemented `WriteOffTrackDebugExport` and supporting helpers in `LalaLaunch.cs` to append per-tick CSV rows for the probed car when enabled; uses a reusable `StringBuilder` buffer and flushes to disk in batches to minimize allocations and overhead; file pattern is `Logs/LalapluginData/OffTrackDebug_<UTC-timestamp>.csv` and the header row is written when a new file is created.
- Guards and lifecycle: logging only runs when `Settings.EnableOffTrackDebugCsv == true` and `ProbeCarIdx >= 0`; the code reads live `ProbeCarIdx` each tick; disabling or probe < 0 will close and reset the file state to avoid file locks; export state is reset on session changes and plugin shutdown.
- CSV content: writes session context (SessionTimeSec, SessionState, SessionFlags hex/dec), probe context (ProbeCarIdx, CarIdxTrackSurface, CarIdxTrackSurfaceMaterial, CarIdxSessionFlags hex/dec, CarIdxOnPitRoad, CarIdxLap, CarIdxLapDistPct), CarSA OffTrack state fields described above, and some player-truth fields (PlayerCarIdx, PlayerMyIncidentCount, GameData.LapInvalidated).

### Testing

- Automated tests: none were executed for this change (no CI/unit tests were run as part of this PR).
- Manual/compiler checks: code was added and committed; no runtime validation or end-to-end telemetry capture was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b3d029f0832f88a43c11f3784c2b)