### PR TITLE
Fix off-track debug state definite-assignment (CS0165)

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5296,7 +5296,12 @@ namespace LaunchPlugin
             AppendCsvOptionalDouble(buffer, carLapDistPct, "F6");
             buffer.Append(',');
 
-            bool hasState = _carSaEngine != null && _carSaEngine.TryGetOffTrackDebugState(probeCarIdx, out var offTrackState);
+            CarSAEngine.OffTrackDebugState offTrackState = default;
+            bool hasState = false;
+            if (_carSaEngine != null)
+            {
+                hasState = _carSaEngine.TryGetOffTrackDebugState(probeCarIdx, out offTrackState);
+            }
             AppendCsvOptionalBool(buffer, hasState ? (bool?)offTrackState.OffTrackNow : null);
             buffer.Append(',');
             AppendCsvOptionalInt(buffer, hasState ? offTrackState.OffTrackStreak : int.MinValue, int.MinValue);


### PR DESCRIPTION
### Motivation
- Fix the CS0165 compiler error caused by an `out var` declared inside a short-circuit `&&` so the compiler could not prove `offTrackState` was assigned when `_carSaEngine` is null.

### Description
- Predeclare `CarSAEngine.OffTrackDebugState offTrackState = default;`, initialize `bool hasState = false;` and call `TryGetOffTrackDebugState(...)` inside `if (_carSaEngine != null)` to set `hasState`, preserving existing CSV logging columns and OFFTK logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b779dcd4832f8523c001737e184c)