### PR TITLE
Fix CarSA info messages: pass player last-lap, use DeltaBest string, adjust gating/formatting

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -404,6 +404,7 @@ namespace LaunchPlugin
             int[] carIdxSessionFlags,
             int[] carIdxPaceFlags,
             double playerBestLapTimeSec,
+            double playerLastLapTimeSec,
             double lapTimeEstimateSec,
             double classEstLapTimeSec,
             double notRelevantGapSec,
@@ -413,6 +414,10 @@ namespace LaunchPlugin
             _outputs.Source = "CarIdxTruth";
             _outputs.Debug.SessionTimeSec = sessionTimeSec;
             _outputs.Debug.SourceFastPathUsed = false;
+            if (_outputs.PlayerSlot != null)
+            {
+                _outputs.PlayerSlot.LastLapTimeSec = playerLastLapTimeSec;
+            }
 
             int carCount = carIdxLapDistPct != null ? carIdxLapDistPct.Length : 0;
             int onPitRoadCount = 0;
@@ -1612,24 +1617,24 @@ namespace LaunchPlugin
                         else
                         {
                             string sign = delta >= 0.0 ? "+" : "-";
-                            message = $"LLΔme {sign}{Math.Abs(delta):0.0}";
+                            message = $"LLΔme {sign}{Math.Abs(delta):0.1}";
                         }
                         return true;
                     }
                     return false;
                 case 1:
-                    if (!double.IsNaN(slot.DeltaBestSec) && !double.IsInfinity(slot.DeltaBestSec)
-                        && !double.IsNaN(slot.BestLapTimeSec) && !double.IsInfinity(slot.BestLapTimeSec)
-                        && !double.IsNaN(slot.LastLapTimeSec) && !double.IsInfinity(slot.LastLapTimeSec)
-                        && slot.BestLapTimeSec > 0.0 && slot.LastLapTimeSec > 0.0)
+                    if (!string.IsNullOrWhiteSpace(slot.DeltaBest))
                     {
-                        string sign = slot.DeltaBestSec >= 0.0 ? "+" : "-";
-                        message = $"ΔBL {sign}{Math.Abs(slot.DeltaBestSec):0.1}";
+                        message = $"ΔBL {slot.DeltaBest}";
                         return true;
                     }
                     return false;
                 case 2:
-                    if (slot.LapsSincePit >= 0)
+                    if (slot.LapsSincePit >= 0
+                        && !double.IsNaN(slot.ForwardDistPct)
+                        && !double.IsInfinity(slot.ForwardDistPct)
+                        && slot.ForwardDistPct >= 0.0
+                        && slot.ForwardDistPct <= 0.20)
                     {
                         message = $"{slot.LapsSincePit} Laps Since Pit";
                         return true;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4638,6 +4638,7 @@ namespace LaunchPlugin
                 playerBestLapTimeSec = _carSaBestLapTimeSecByIdx[playerCarIdx];
             }
             playerBestLapTimeSec = SanitizeCarSaLapTimeSec(playerBestLapTimeSec);
+            double playerLastLapTimeSec = SanitizeCarSaLapTimeSec(lastLapSec);
             double classEstLapTimeSec = (playerCarIdx >= 0 && playerCarIdx < _carSaCarClassEstLapTimeSecByIdx.Length)
                 ? _carSaCarClassEstLapTimeSecByIdx[playerCarIdx]
                 : double.NaN;
@@ -4646,7 +4647,7 @@ namespace LaunchPlugin
             {
                 notRelevantGapSec = CarSANotRelevantGapSecDefault;
             }
-            _carSaEngine?.Update(sessionTimeSec, sessionState, sessionTypeName, playerCarIdx, carIdxLapDistPct, carIdxLap, carIdxTrackSurface, carIdxOnPitRoad, carIdxSessionFlags, null, playerBestLapTimeSec, lapTimeEstimateSec, classEstLapTimeSec, notRelevantGapSec, debugMaster);
+            _carSaEngine?.Update(sessionTimeSec, sessionState, sessionTypeName, playerCarIdx, carIdxLapDistPct, carIdxLap, carIdxTrackSurface, carIdxOnPitRoad, carIdxSessionFlags, null, playerBestLapTimeSec, playerLastLapTimeSec, lapTimeEstimateSec, classEstLapTimeSec, notRelevantGapSec, debugMaster);
             if (_carSaEngine != null)
             {
                 UpdateCarSaTelemetryCaches(pluginManager);


### PR DESCRIPTION
### Motivation
- Ensure Info messages display values already computed by the system without inventing new telemetry sources, so LLΔme can show, ΔBL uses the correct exported string, and Laps Since Pit is less spammy.
- Preserve existing timing/visibility behavior while only passing through values already available in `LalaLaunch.cs` / CarSA.

### Description
- Added a new `playerLastLapTimeSec` parameter to `CarSAEngine.Update(...)` immediately after `playerBestLapTimeSec` and store it into the CarSA `PlayerSlot.LastLapTimeSec` at the start of the update (`CarSAEngine.cs`).
- Changed Info message A (msgIndex 0) to format the LLΔme numeric delta with one decimal place and keep the `LLΔme OK` deadband behavior (`CarSAEngine.cs`).
- Changed Info message B (msgIndex 1) to use the per-slot exported `slot.DeltaBest` string when present, returning false otherwise, and removed the previous numeric guards (`CarSAEngine.cs`).
- Changed Info message C (msgIndex 2) to only show when `slot.LapsSincePit >= 0` and `slot.ForwardDistPct` is finite and within `0.0..0.20` (0–20% lap) (`CarSAEngine.cs`).
- In `LalaLaunch.cs` sanitized the existing `lastLapSec` into `playerLastLapTimeSec` and passed it into the updated `CarSAEngine.Update(...)` call.

### Testing
- No automated tests were executed as part of this change.
- Changes were committed and the two modified files (`CarSAEngine.cs`, `LalaLaunch.cs`) were updated successfully in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698878331a98832fb7588b8831206fe1)