### PR TITLE
Add `Car.Debug.OffTrack.ProbeCarIdx` SimHub export

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3683,6 +3683,7 @@ namespace LaunchPlugin
             AttachCore("Car.Debug.PlayerLapPct", () => SoftDebugEnabled ? (_carSaEngine?.Outputs.Debug.PlayerLapPct ?? double.NaN) : double.NaN);
             AttachCore("Car.Debug.PlayerLap", () => SoftDebugEnabled ? (_carSaEngine?.Outputs.Debug.PlayerLap ?? 0) : 0);
             AttachCore("Car.Debug.SessionTimeSec", () => SoftDebugEnabled ? (_carSaEngine?.Outputs.Debug.SessionTimeSec ?? 0.0) : 0.0);
+            AttachCore("Car.Debug.OffTrack.ProbeCarIdx", () => SoftDebugEnabled ? (Settings?.OffTrackDebugProbeCarIdx ?? -1) : -1);
             AttachCore("Car.Debug.SourceFastPathUsed", () => SoftDebugEnabled ? (_carSaEngine?.Outputs.Debug.SourceFastPathUsed ?? false) : false);
             AttachCore("Car.Debug.HasCarIdxPaceFlags", () => SoftDebugEnabled ? (_carSaEngine?.Outputs.Debug.HasCarIdxPaceFlags ?? false) : false);
             AttachCore("Car.Debug.HasCarIdxSessionFlags", () => SoftDebugEnabled ? (_carSaEngine?.Outputs.Debug.HasCarIdxSessionFlags ?? false) : false);


### PR DESCRIPTION
### Motivation
- Expose the configured off-track debug probe car index to SimHub dashboards as a debug property. 
- Respect the existing soft-debug gating so that when debugging is disabled the export publishes a safe default and performs no work.

### Description
- Added an export via `AttachCore` in `LalaLaunch.cs` named `Car.Debug.OffTrack.ProbeCarIdx` placed alongside the other `Car.Debug.*` exports. 
- The export value uses the gating `SoftDebugEnabled ? (Settings?.OffTrackDebugProbeCarIdx ?? -1) : -1` so it yields `-1` when soft debug is disabled and the configured probe index when enabled. 
- No other logic or files were modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b34c0990832fac5204d1789ca128)