### PR TITLE
Add Event Marker dash pulse, export and CSV EventFired column

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -32,6 +32,7 @@
                     <StackPanel Grid.Column="1" Margin="0,0,0,0">
                         <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode" FriendlyName="Change Primary Dash Mode" ToolTip="Assign a button to cycle primary dash modes (main screen views)." />
                         <ui:ControlsEditor ActionName="LalaLaunch.SecondaryDashMode" FriendlyName="Change Secondary Dash Mode" ToolTip="Assign a button to cycle secondary dash modes (widgets/aux views)." />
+                        <ui:ControlsEditor ActionName="LalaLaunch.EventMarker" FriendlyName="Event Marker" ToolTip="Assign a button to fire a short event marker pulse for dashboards and CSV exports." />
                     </StackPanel>
                 </Grid>
                 <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" />

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -192,6 +192,7 @@ Branch: work
 | RejoinCurrentPitPhase / RejoinCurrentPitPhaseName | int/string | Current pit phase enum and label. | Per tick. | `RejoinAssistEngine` state + `AttachCore`【F:LalaLaunch.cs†L2819-L2825】【F:RejoinAssistEngine.cs†L90-L160】 |
 | RejoinThreatLevel / RejoinThreatLevelName / RejoinTimeToThreat | int/string/double | Threat scoring and time-to-threat for rejoin assist. | Per tick. | `RejoinAssistEngine` outputs + `AttachCore`【F:LalaLaunch.cs†L2826-L2831】【F:RejoinAssistEngine.cs†L540-L640】 |
 | MsgCxPressed | bool | Latched true for 500 ms after MsgCx action. | Per tick. | `LalaLaunch.cs` — `RegisterMsgCxPress` + `AttachCore`【F:LalaLaunch.cs†L2475-L2479】【F:LalaLaunch.cs†L2815-L2820】 |
+| Debug.EventMarkerPressed | bool | Latched true for 500 ms after the Event Marker action. | Per tick. | `LalaLaunch.cs` — `RegisterEventMarkerPress` + `AttachCore`【F:LalaLaunch.cs†L2481-L2492】【F:LalaLaunch.cs†L2816-L2822】 |
 
 ## Session / Identity
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
@@ -226,3 +227,7 @@ Branch: work
 | PitLite.InLapSec / OutLapSec / DeltaInSec / DeltaOutSec / TimePitLaneSec / TimePitBoxSec / DirectSec / DTLSec | double | PitLite lap/timer breakdowns. | Per tick/out-lap; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L122-L217】【F:LalaLaunch.cs†L2781-L2790】 |
 | PitLite.LossSource | string | Whether DTL or direct was published. | Per publish; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L170-L217】【F:LalaLaunch.cs†L2796-L2799】 |
 | PitLite.LastSaved.Sec / LastSaved.Source | double/string | Last saved pit-lite candidate/time source. | On save; **verbose**. | `PitCycleLite.cs` + `AttachVerbose`【F:PitCycleLite.cs†L170-L217】【F:LalaLaunch.cs†L2797-L2799】 |
+
+## CSV exports (debug)
+* `OffTrackDebug_<Track>_<Timestamp>.csv` includes an `EventFired` column immediately after `SessionTimeSec`, populated with `1`/`0` based on the event marker pulse state.【F:LalaLaunch.cs†L5278-L5338】【F:LalaLaunch.cs†L6212-L6218】
+* `CarSA_Debug_YYYY-MM-DD_HH-mm-ss_<TrackName>.csv` includes an `EventFired` column immediately after `SessionTimeSec`, populated with `1`/`0` based on the event marker pulse state.【F:LalaLaunch.cs†L5189-L5222】【F:LalaLaunch.cs†L6220-L6242】


### PR DESCRIPTION
### Motivation
- Provide a simple dash binding that emits a short, latched pulse so dashboards and CSV debug logs can reliably capture discrete user events.
- Surface the pulse as a SimHub export so dashboards can read the state (`Debug.EventMarkerPressed`) alongside existing `MsgCxPressed` semantics.
- Record the pulse per-tick in the two primary debug CSVs so offline analysis can detect when the event occurred.

### Description
- Added a new action and UI binding: `EventMarker` action exposed to controls and a `ControlsEditor` entry on the DASH settings (`DashesTabView.xaml`) for `LalaLaunch.EventMarker`.
- Implemented a 500ms latched pulse using `_eventMarkerPressed` and `_eventMarkerCooldownTimer` with `RegisterEventMarkerPress()` and `EventMarker()` methods following the existing `MsgCxPressed` pattern.
- Exposed the pulse via `AttachCore` as `Debug.EventMarkerPressed` so it is available to dashboards/exports.
- Added the `EventFired` column immediately after `SessionTimeSec` in both `OffTrackDebug_*.csv` and `CarSA_Debug_*.csv` headers and row writers, writing `1` when the pulse is active and `0` otherwise, and updated `GetOffTrackDebugExportHeader` / `GetCarSaDebugExportHeader` accordingly.
- Updated `Docs/SimHubParameterInventory.md` to document the new export and CSV column addition.

### Testing
- No automated unit or integration tests were executed for this change.
- Changes were validated by inspecting the modified files (`LalaLaunch.cs`, `DashesTabView.xaml`, `Docs/SimHubParameterInventory.md`) and committing the updates to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c7b44bac832faa0d0b2d9a84e9d3)