### PR TITLE
Add CarSA friend tagging and FRIEND border mode (UI, persistence, exports)

### DIFF
--- a/CarSAEngine.cs
+++ b/CarSAEngine.cs
@@ -1959,6 +1959,7 @@ namespace LaunchPlugin
                 slot.LicLevel = 0;
                 slot.UserID = 0;
                 slot.TeamID = 0;
+                slot.IsFriend = false;
                 slot.BestLapTimeSec = double.NaN;
                 slot.LastLapTimeSec = double.NaN;
                 slot.BestLap = string.Empty;

--- a/CarSASlot.cs
+++ b/CarSASlot.cs
@@ -70,6 +70,7 @@ namespace LaunchPlugin
         public int LicLevel { get; set; }
         public int UserID { get; set; }
         public int TeamID { get; set; }
+        public bool IsFriend { get; set; }
         public int LapsSincePit { get; set; } = -1;
         public double BestLapTimeSec { get; set; } = double.NaN;
         public double LastLapTimeSec { get; set; } = double.NaN;
@@ -138,6 +139,7 @@ namespace LaunchPlugin
         private string _styleLastPlayerClassColor = string.Empty;
         private bool _styleLastIsValid;
         private int _styleLastCarIdx;
+        private bool _styleLastIsFriend;
 
         public void SetTransmitState(bool isTalking, int radioIdx, int frequencyIdx, string frequencyName)
         {
@@ -147,7 +149,7 @@ namespace LaunchPlugin
             TalkFrequencyName = frequencyName ?? string.Empty;
         }
 
-        public bool StyleInputsChanged(int statusE, string classColorHex, int positionInClass, string playerClassColorHex, int carIdx, bool isValid)
+        public bool StyleInputsChanged(int statusE, string classColorHex, int positionInClass, string playerClassColorHex, int carIdx, bool isValid, bool isFriend)
         {
             classColorHex = classColorHex ?? string.Empty;
             playerClassColorHex = playerClassColorHex ?? string.Empty;
@@ -157,6 +159,7 @@ namespace LaunchPlugin
                 || _styleLastPositionInClass != positionInClass
                 || _styleLastIsValid != isValid
                 || _styleLastCarIdx != carIdx
+                || _styleLastIsFriend != isFriend
                 || !string.Equals(_styleLastClassColorHex, classColorHex, StringComparison.OrdinalIgnoreCase)
                 || !string.Equals(_styleLastPlayerClassColor, playerClassColorHex, StringComparison.OrdinalIgnoreCase);
 
@@ -166,6 +169,7 @@ namespace LaunchPlugin
             _styleLastPlayerClassColor = playerClassColorHex;
             _styleLastIsValid = isValid;
             _styleLastCarIdx = carIdx;
+            _styleLastIsFriend = isFriend;
             _styleCacheInitialized = true;
 
             return changed;
@@ -209,6 +213,7 @@ namespace LaunchPlugin
             LicLevel = 0;
             UserID = 0;
             TeamID = 0;
+            IsFriend = false;
             LapsSincePit = -1;
             BestLapTimeSec = double.NaN;
             LastLapTimeSec = double.NaN;

--- a/CarSAStyleResolver.cs
+++ b/CarSAStyleResolver.cs
@@ -5,14 +5,17 @@ namespace LaunchPlugin
 {
     public static class CarSAStyleResolver
     {
+        public const string BorderModeFriend = "FRIEND";
         public const string BorderModeTeam = "TEAM";
         public const string BorderModeLead = "LEAD";
         public const string BorderModeOtherClass = "OCLS";
         public const string BorderModeDefault = "DEF";
+        private const string FriendBorderHex = "#00FF00";
 
         public static void Resolve(
             int statusE,
             string classColorHex,
+            bool isFriend,
             bool isTeammate,
             bool isClassLeader,
             bool isOtherClass,
@@ -22,7 +25,7 @@ namespace LaunchPlugin
             out string borderMode,
             out string borderHex)
         {
-            borderMode = ResolveBorderMode(isTeammate, isClassLeader, isOtherClass);
+            borderMode = ResolveBorderMode(isFriend, isTeammate, isClassLeader, isOtherClass);
             statusBgHex = ResolveStatusBackgroundHex(statusE, classColorHex, statusEColorMap);
             borderHex = ResolveBorderHex(borderMode, borderColorMap);
         }
@@ -47,8 +50,13 @@ namespace LaunchPlugin
             return "#000000";
         }
 
-        private static string ResolveBorderMode(bool isTeammate, bool isClassLeader, bool isOtherClass)
+        private static string ResolveBorderMode(bool isFriend, bool isTeammate, bool isClassLeader, bool isOtherClass)
         {
+            if (isFriend)
+            {
+                return BorderModeFriend;
+            }
+
             if (isTeammate)
             {
                 return BorderModeTeam;
@@ -69,6 +77,11 @@ namespace LaunchPlugin
 
         private static string ResolveBorderHex(string borderMode, IDictionary<string, string> borderColorMap)
         {
+            if (string.Equals(borderMode, BorderModeFriend, StringComparison.OrdinalIgnoreCase))
+            {
+                return FriendBorderHex;
+            }
+
             if (borderColorMap != null && !string.IsNullOrWhiteSpace(borderMode) &&
                 borderColorMap.TryGetValue(borderMode, out var color) && IsValidHexColor(color))
             {

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -100,6 +100,42 @@
                 </StackPanel>
             </styles:SHSection>
 
+            <styles:SHSection Title="FRIENDS" ShowSeparator="True">
+                <StackPanel>
+                    <TextBlock Margin="0,0,0,5" Foreground="LightGray"
+                               Text="Add iRacing Customer IDs to highlight friends in CarSA." />
+                    <DataGrid ItemsSource="{Binding Settings.Friends}"
+                              AutoGenerateColumns="False"
+                              CanUserAddRows="False"
+                              CanUserDeleteRows="False"
+                              HeadersVisibility="Column"
+                              Margin="0,0,0,8">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Label"
+                                                Binding="{Binding Label, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                Width="*" />
+                            <DataGridTextColumn Header="UserId"
+                                                Binding="{Binding UserId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                Width="120" />
+                            <DataGridTemplateColumn Header="" Width="Auto">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <styles:SHButtonPrimary Content="Remove"
+                                                                Padding="8,2"
+                                                                Margin="2"
+                                                                Click="RemoveFriend_Click" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <styles:SHButtonPrimary Content="Add Friend"
+                                            Width="120"
+                                            HorizontalAlignment="Left"
+                                            Click="AddFriend_Click" />
+                </StackPanel>
+            </styles:SHSection>
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/LaunchPluginSettingsUI.xaml.cs
+++ b/LaunchPluginSettingsUI.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using SimHub.Plugins;
+using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -44,8 +45,38 @@ namespace LaunchPlugin
                 }
             }
         }
+
+        private void AddFriend_Click(object sender, RoutedEventArgs e)
+        {
+            if (Plugin?.Settings == null)
+            {
+                return;
+            }
+
+            if (Plugin.Settings.Friends == null)
+            {
+                Plugin.Settings.Friends = new ObservableCollection<LaunchPluginFriendEntry>();
+            }
+
+            Plugin.Settings.Friends.Add(new LaunchPluginFriendEntry { Label = "Friend", UserId = 0 });
+        }
+
+        private void RemoveFriend_Click(object sender, RoutedEventArgs e)
+        {
+            if (Plugin?.Settings?.Friends == null)
+            {
+                return;
+            }
+
+            var entry = (sender as FrameworkElement)?.DataContext as LaunchPluginFriendEntry;
+            if (entry == null)
+            {
+                return;
+            }
+
+            Plugin.Settings.Friends.Remove(entry);
+        }
     }
 
     
 }
-


### PR DESCRIPTION
### Motivation

- Provide a user-editable, persisted friends list so users can mark known iRacing drivers as friends and highlight them in CarSA overlays.
- Surface per-slot friend state to dashes and logic by exporting `IsFriend` for Ahead/Behind and Player slots.
- Make FRIEND a first-class BorderMode with higher priority than TEAM and a fixed green border color so friend highlighting overrides teammate coloring.

### Description

- Added a simple model `LaunchPluginFriendEntry` and a persisted `Settings.Friends` collection (`ObservableCollection<LaunchPluginFriendEntry>`) with normalization (`NormalizeFriendSettings`).
- Implemented a minimal WPF settings UI section (DataGrid) with Add/Remove handlers in `LaunchPluginSettingsUI.xaml` / `.xaml.cs` to maintain label/UserId rows.
- Added a fast lookup cache (`HashSet<int> _friendUserIds`) and per-tick methods `RefreshFriendUserIds`, `UpdateCarSaFriendFlags`, and `UpdateCarSaPlayerFriendFlag` which set `CarSASlot.IsFriend` and player slot `IsFriend` from `UserID` without LINQ or per-tick allocations in tight loops.
- Extended `CarSASlot` with `IsFriend`, updated `Reset` and `StyleInputsChanged` to include friend in style cache, and exported per-slot booleans via `AttachCore` (e.g. `Car.Ahead01.IsFriend`, `Car.Behind01.IsFriend`, `Car.Player.IsFriend`).
- Extended `CarSAStyleResolver` with `BorderModeFriend = "FRIEND"`, hard-coded friend border hex `#00FF00`, and updated resolution to prefer FRIEND over TEAM (no changes to StatusBgHex logic).
- Wired the new friend flag into style resolution call sites so FRIEND overrides TEAM and sets a green border while existing TEAM behavior remains unchanged when not a friend.
- Minor settings normalization and defensive guards added to avoid invalid friend entries.

### Testing

- No automated tests were run for this change.
- Changes were committed locally; no CI/test results are available in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ceb1f998832fa24b2e940be6f77a)