### PR TITLE
Rebuild friends HashSet only on settings/entry changes (dirty flag)

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -6637,6 +6637,13 @@ namespace LaunchPlugin
             var friends = settings?.Friends;
             if (friends == null)
             {
+                if (_friendsCollection != null)
+                {
+                    _friendsCollection.CollectionChanged -= OnFriendsCollectionChanged;
+                    _friendsCollection = null;
+                }
+
+                UnsubscribeAllFriendEntries();
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Avoid rebuilding the friends `HashSet` on every tick to eliminate redundant work and per-tick allocations while preserving all external behavior and UI semantics.
- Ensure in-place edits made through the settings `DataGrid` (Label/UserId) also trigger a rebuild only when necessary.

### Description
- Added change-tracking: introduced a private `_friendsDirty` flag, `MarkFriendsDirty()` helper, and a `HookFriendSettings()` call during `Init` to wire settings once and mark initial state dirty.
- Subscribed to `Settings.Friends.CollectionChanged` and added per-entry `PropertyChanged` subscriptions using `_friendEntrySubscriptions` so add/remove/reset and in-place edits mark the friends set dirty; implemented `OnFriendsCollectionChanged` and `OnFriendEntryPropertyChanged` to manage subscriptions and mark dirty on `Label`/`UserId` changes.
- Gated the per-tick refresh in the main update path so `RefreshFriendUserIds()` only runs when `_friendsDirty` is true and clears the flag after rebuilding.
- Implemented `INotifyPropertyChanged` on `LaunchPluginFriendEntry` with backing fields for `Label` (default "Friend") and `UserId`, raising `PropertyChanged` only when values actually change, and added the necessary `using` import for `System.Collections.Specialized`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d2885a98832fb60f6461b876546b)