### PR TITLE
Expose Friends.Count property

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -2980,6 +2980,7 @@ namespace LaunchPlugin
         private readonly int[] _carSaClassPositionByIdx = new int[CarSAEngine.MaxCars];
         private readonly int[] _carSaIRatingByIdx = new int[CarSAEngine.MaxCars];
         private readonly HashSet<int> _friendUserIds = new HashSet<int>();
+        private int _friendsCount;
         private readonly HashSet<LaunchPluginFriendEntry> _friendEntrySubscriptions = new HashSet<LaunchPluginFriendEntry>();
         private ObservableCollection<LaunchPluginFriendEntry> _friendsCollection;
         private bool _friendsDirty = true;
@@ -3189,6 +3190,7 @@ namespace LaunchPlugin
             this.AddAction("TrackMarkersUnlock", (a, b) => SetTrackMarkersLocked(false));
             SimHub.Logging.Current.Info("[LalaPlugin:Init] Actions registered: MsgCx, TogglePitScreen, PrimaryDashMode, SecondaryDashMode, EventMarker, LaunchMode, TrackMarkersLock, TrackMarkersUnlock");
 
+            AttachCore("LalaLaunch.Friends.Count", () => _friendsCount);
 
             // --- DELEGATES FOR LIVE FUEL CALCULATOR (CORE) ---
             AttachCore("Fuel.LiveFuelPerLap", () => LiveFuelPerLap);
@@ -6775,6 +6777,7 @@ namespace LaunchPlugin
         private void RefreshFriendUserIds()
         {
             _friendUserIds.Clear();
+            _friendsCount = 0;
             var friends = Settings?.Friends;
             if (friends == null)
             {
@@ -6792,6 +6795,7 @@ namespace LaunchPlugin
                 int userId = entry.UserId;
                 if (userId > 0)
                 {
+                    _friendsCount++;
                     _friendUserIds.Add(userId);
                 }
             }


### PR DESCRIPTION
### Motivation
- Add a simple SimHub-exported integer property `LalaLaunch.Friends.Count` so dashboards can show how many valid Friend entries are configured (count only entries with `UserId > 0`) and have it update when the Friends list changes.

### Description
- Added a private field `int _friendsCount` and exposed it via `AttachCore("LalaLaunch.Friends.Count", () => _friendsCount)` in the plugin initialization.
- Updated `RefreshFriendUserIds()` to reset `_friendsCount` and increment it for each friend entry where `UserId > 0`, keeping the change tracking and friend lookup rebuild logic unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d7b57e78832f8963ce6cecf725af)