### PR TITLE
Tidy Friends table buttons and layout

### DIFF
--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -81,11 +81,13 @@
                             <styles:SHButtonPrimary Grid.Column="3"
                                                     Content="Import"
                                                     Padding="8,2"
+                                                    MinWidth="70"
                                                     Margin="0,0,8,0"
                                                     Click="ImportIOverlay_Click" />
                             <styles:SHButtonPrimary Grid.Column="4"
                                                     Content="Reload"
                                                     Padding="8,2"
+                                                    MinWidth="70"
                                                     Click="ReloadIOverlay_Click" />
                         </Grid>
                         <TextBlock x:Name="IOverlayStatusText"
@@ -109,12 +111,15 @@
                             <DataGridCheckBoxColumn Header="TEAMMATE"
                                                     Binding="{Binding IsTeammate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                     Width="110" />
-                            <DataGridTemplateColumn Header="" Width="Auto">
+                            <DataGridTemplateColumn Header="REMOVE" Width="90">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <styles:SHButtonPrimary Content="Remove"
                                                                 Padding="8,2"
-                                                                Margin="2"
+                                                                Margin="0"
+                                                                MinWidth="70"
+                                                                Background="#C62828"
+                                                                Foreground="White"
                                                                 Click="RemoveFriend_Click" />
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
### Motivation
- Make the "Friends" section table neater and prevent the Remove button from being pushed off-screen by enforcing sizing and clearer visual affordance.
- Make the import controls visually consistent by matching the `Import` button width to the adjacent `Reload` button.

### Description
- Set `MinWidth="70"` on the `Import` and `Reload` `styles:SHButtonPrimary` controls to align toolbar button sizing.
- Replace the empty template column header with `Header="REMOVE"` and fixed `Width="90"` to label the action column.
- Make the row `Remove` button fixed-width and prominent by adding `MinWidth="70"`, removing extra margin, and applying `Background="#C62828"` and `Foreground="White"` in `GlobalSettingsView.xaml`.

### Testing
- No automated tests were run because this is a UI-only XAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b65cfd2c832faaf6d215f4c78dc2)