### PR TITLE
OffTrack debug CSV: add 'Log changes/events only' mode and extend EventMarker to 5s

### DIFF
--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -172,6 +172,9 @@
                             <styles:SHToggleCheckbox Content="OffTrack Debug CSV" Margin="0,0,15,0"
                                                      IsChecked="{Binding Settings.EnableOffTrackDebugCsv, Mode=TwoWay}"
                                                      ToolTip="Enable per-tick OffTrack debug CSV logging for the probed car."/>
+                            <styles:SHToggleCheckbox Content="Log changes/events only" Margin="0,0,15,0"
+                                                     IsChecked="{Binding Settings.OffTrackDebugLogChangesOnly, Mode=TwoWay}"
+                                                     ToolTip="When enabled, only logs when values change or event marker is active."/>
                             <TextBlock Text="Probe CarIdx" VerticalAlignment="Center" Margin="0,0,8,0"/>
                             <TextBox Width="80" Text="{Binding Settings.OffTrackDebugProbeCarIdx, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Margin="15,0,0,0" Foreground="LightGray" VerticalAlignment="Center"


### PR DESCRIPTION
### Motivation
- Reduce huge per-tick OffTrack debug CSV files by making logging optional only-on-change / event slices and let users capture dense slices via a longer EventMarker window.
- Preserve existing full-per-tick behaviour when the new mode is disabled and keep file/header layout unchanged.
- Maintain stability by resetting snapshot state when logging or mode toggles change and by reusing existing safe helpers for array/index reads.

### Description
- Added a persisted settings flag `OffTrackDebugLogChangesOnly` and exposed it in the Debug UI as a checkbox labeled "Log changes/events only" next to the OffTrack CSV toggle (`GlobalSettingsView.xaml` and `LaunchPluginSettings`).
- Increased the EventMarker pulse hold from ~0.5s to 5.0s by introducing `EventMarkerPulseMs = 5000` and using it in the marker cooldown handling so markers remain active longer for dense logging windows.
- Implemented change-only CSV gating inside `WriteOffTrackDebugExport` by building an `OffTrackDebugSnapshot` (all CSV columns except session time), caching the last-written snapshot, and only writing a row when one of: first-row (snapshot uninitialized), event marker is active, or the snapshot differs from last written; when the change-only mode is toggled or logging restarts the snapshot is reset so an initial row is always emitted.
- Kept existing CSV formatting and null/sentinel behaviour by reusing `ReadCarIdx*` helpers and `AppendCsvOptional*` helpers; added snapshot equality helpers that handle `double.NaN` correctly.
- Files modified: `LalaLaunch.cs` (core logic & snapshot machinery, event marker pulse change, write gating, reset logic) and `GlobalSettingsView.xaml` (UI checkbox binding).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c476482c832fa07ba8de78356185)