### PR TITLE
Fix radio transmit frequency fallback resolution

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -7105,12 +7105,22 @@ namespace LaunchPlugin
                 }
 
                 _radioFrequencyNameCache.EnsureBuilt(_currentSessionToken, radioInfo);
-                if (!_radioFrequencyNameCache.TryGetInfo(transmitRadioIdx, transmitFrequencyIdx, out _lastTransmitFrequencyName, out _radioTransmitFrequencyEntry, out _radioTransmitFrequencyMutedAccessor))
+                bool hasInfo = _radioFrequencyNameCache.TryGetInfo(transmitRadioIdx, transmitFrequencyIdx, out _lastTransmitFrequencyName, out _radioTransmitFrequencyEntry, out _radioTransmitFrequencyMutedAccessor);
+                if (!hasInfo || string.IsNullOrEmpty(_lastTransmitFrequencyName))
                 {
-                    _lastTransmitFrequencyName = string.Empty;
-                    _radioTransmitFrequencyEntry = null;
-                    _radioTransmitFrequencyMutedAccessor = null;
-                    _radioTransmitFrequencyMuted = false;
+                    if (_radioFrequencyNameCache.TryGetInfoByTransmittingCar(transmitRadioIdx, transmitCarIdx, out var fallbackName, out var fallbackEntry, out var fallbackMutedAccessor))
+                    {
+                        _lastTransmitFrequencyName = fallbackName;
+                        _radioTransmitFrequencyEntry = fallbackEntry;
+                        _radioTransmitFrequencyMutedAccessor = fallbackMutedAccessor;
+                    }
+                    else if (!hasInfo)
+                    {
+                        _lastTransmitFrequencyName = string.Empty;
+                        _radioTransmitFrequencyEntry = null;
+                        _radioTransmitFrequencyMutedAccessor = null;
+                        _radioTransmitFrequencyMuted = false;
+                    }
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Telemetry `RadioTransmitFrequencyIdx` is not a reliable key for resolving frequency names, causing lookups by `(radioIdx, frequencyIdx)` to miss and return empty names.
- Provide a robust fallback that resolves the active frequency by matching the transmitting car index so UI and mute state display correctly while keeping raw telemetry indices unchanged.

### Description
- Stored the last session `RadioInfo` in `RadioFrequencyNameCache` and added `TryGetInfoByTransmittingCar(int radioIdx, int transmitCarIdx, out string name, out object entry, out Func<object,bool> mutedAccessor)` to resolve a frequency by matching `FrequenciesYY.CarIdx` to the transmitting car.
- Updated `LalaLaunch` in `UpdateCarSaTransmitState` to use the fallback when `TryGetInfo(transmitRadioIdx, transmitFrequencyIdx, ...)` either fails or returns an empty name, and populate `_lastTransmitFrequencyName`, `_radioTransmitFrequencyEntry`, and `_radioTransmitFrequencyMutedAccessor` from the fallback result.
- Preserved raw telemetry semantics (the published indices remain `TalkRadioIdx = RadioTransmitRadioIdx` and `TalkFrequencyIdx = RadioTransmitFrequencyIdx`) and ensured both `Radio.TransmitFrequencyName` and slot `TalkFrequencyName` are populated from the resolved `_lastTransmitFrequencyName` and that `Radio.TransmitFrequencyMuted` continues to read live via the matched entry accessor.
- Modified files: `RadioFrequencyNameCache.cs` and `LalaLaunch.cs`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a14f0446c832f8e69896bc8f33b1c)