### PR TITLE
Cycle declutter mode through three states (0/1/2)

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -28,7 +28,7 @@
                     </StackPanel>
                     <StackPanel Grid.Column="1" Margin="0,0,0,0">
                         <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode" FriendlyName="Change Primary Dash Mode" ToolTip="Assign a button to cycle primary dash modes (main screen views)." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.SecondaryDashMode" FriendlyName="Change Secondary Dash Mode" ToolTip="Assign a button to cycle secondary dash modes (widgets/aux views)." />
+                        <ui:ControlsEditor ActionName="LalaLaunch.DeclutterMode" FriendlyName="Cycle Declutter Mode" ToolTip="Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings." />
                         <ui:ControlsEditor ActionName="LalaLaunch.EventMarker" FriendlyName="Event Marker" ToolTip="Assign a button to fire a short event marker pulse for dashboards and CSV exports." />
                     </StackPanel>
                 </Grid>

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -15,7 +15,7 @@
 - L27: Assign a button to show or hide the pit screen popup.
 - L29: Manual prime/abort launch mode (useful for testing and non-standing-start sessions).
 - L33: Assign a button to cycle primary dash modes (main screen views).
-- L34: Assign a button to cycle secondary dash modes (widgets/aux views).
+- L34: Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings.
 - L48: Automatically switch dash screens when a session starts based on context.
 - L50: How long the post-launch results screen stays visible (sec).
 - L52: Minimum confidence (%) before pit strategy uses live fuel. Below this, profile estimates may be used.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -17,8 +17,9 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 - **Message system logs** (`MSGV1`) surface missing evaluators and active stack debug—check when adding new messages.
 
 ## Action, dash, and launch controls
-- **`[LalaPlugin:Dash] PrimaryDashMode action fired (placeholder).`** — Action binding confirmed; no behaviour implemented yet.【F:LalaLaunch.cs†L10-L36】
-- **`[LalaPlugin:Dash] SecondaryDashMode action fired (placeholder).`** — Same as above for secondary dash action.【F:LalaLaunch.cs†L10-L36】
+- **`[LalaPlugin:Dash] PrimaryDashMode action fired (placeholder).`** — Action binding confirmed; no behaviour implemented yet.【F:LalaLaunch.cs†L10-L50】
+- **`[LalaPlugin:Dash] DeclutterMode action fired -> DeclutterMode=0/1/2.`** — Declutter control pressed; cycles the 0/1/2 export used for dash visibility bindings.【F:LalaLaunch.cs†L10-L50】
+- **`[LalaPlugin:Dash] SecondaryDashMode action fired (legacy) -> DeclutterMode=0/1/2.`** — Legacy alias for the same declutter cycle to preserve old bindings.【F:LalaLaunch.cs†L10-L50】
 - **`[LalaPlugin:Launch] LaunchMode pressed -> re-enabled launch mode.`** — User pressed Launch while feature was user-disabled; flag cleared.【F:LalaLaunch.cs†L17-L45】
 - **`[LalaPlugin:Launch] LaunchMode blocked (inPits=..., seriousRejoin=...).`** — Launch button ignored due to pit/rejoin guard.【F:LalaLaunch.cs†L17-L45】
 - **`[LalaPlugin:Launch] LaunchMode pressed -> ManualPrimed.`** — Launch primed manually after passing guards.【F:LalaLaunch.cs†L17-L45】

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -56,6 +56,21 @@ namespace LaunchPlugin
 
         // --- Dashboard Manager ---
         public ScreenManager Screens = new ScreenManager();
+        private int _declutterMode = 0;
+        public int DeclutterMode
+        {
+            get => _declutterMode;
+            private set
+            {
+                if (_declutterMode == value)
+                {
+                    return;
+                }
+
+                _declutterMode = value;
+                OnPropertyChanged();
+            }
+        }
 
         // --- button dash helpers ---
         // NOTE: This region is intended to expose SimHub Actions and keep cancel semantics stable.
@@ -71,9 +86,18 @@ namespace LaunchPlugin
 
         public void SecondaryDashMode()
         {
-            // Placeholder: wired for Controls & Events + UI mapping.
-            // TODO: implement real behaviour (switch message/sub dash mode/page).
-            SimHub.Logging.Current.Info("[LalaPlugin:Dash] SecondaryDashMode action fired (placeholder).");
+            ToggleDeclutterMode("SecondaryDashMode action fired (legacy)");
+        }
+
+        public void DeclutterMode()
+        {
+            ToggleDeclutterMode("DeclutterMode action fired");
+        }
+
+        private void ToggleDeclutterMode(string actionLabel)
+        {
+            DeclutterMode = (DeclutterMode + 1) % 3;
+            SimHub.Logging.Current.Info($"[LalaPlugin:Dash] {actionLabel} -> DeclutterMode={DeclutterMode}.");
         }
 
         // --- Launch button helper ---
@@ -3251,11 +3275,12 @@ namespace LaunchPlugin
             this.AddAction("TogglePitScreen", (a, b) => TogglePitScreen());
             this.AddAction("PrimaryDashMode", (a, b) => PrimaryDashMode());
             this.AddAction("SecondaryDashMode", (a, b) => SecondaryDashMode());
+            this.AddAction("DeclutterMode", (a, b) => DeclutterMode());
             this.AddAction("EventMarker", (a, b) => EventMarker());
             this.AddAction("LaunchMode", (a, b) => LaunchMode());
             this.AddAction("TrackMarkersLock", (a, b) => SetTrackMarkersLocked(true));
             this.AddAction("TrackMarkersUnlock", (a, b) => SetTrackMarkersLocked(false));
-            SimHub.Logging.Current.Info("[LalaPlugin:Init] Actions registered: MsgCx, TogglePitScreen, PrimaryDashMode, SecondaryDashMode, EventMarker, LaunchMode, TrackMarkersLock, TrackMarkersUnlock");
+            SimHub.Logging.Current.Info("[LalaPlugin:Init] Actions registered: MsgCx, TogglePitScreen, PrimaryDashMode, DeclutterMode, SecondaryDashMode (legacy), EventMarker, LaunchMode, TrackMarkersLock, TrackMarkersUnlock");
 
             AttachCore("LalaLaunch.Friends.Count", () => _friendsCount);
 
@@ -3420,6 +3445,7 @@ namespace LaunchPlugin
             AttachCore("DashControlMode", () => Screens.Mode);
             AttachCore("FalseStartDetected", () => _falseStartDetected);
             AttachCore("LastSessionType", () => _lastSessionType);
+            AttachCore("DeclutterMode", () => DeclutterMode);
             AttachCore("Race.OverallLeaderHasFinished", () => OverallLeaderHasFinished);
             AttachCore("Race.OverallLeaderHasFinishedValid", () => OverallLeaderHasFinishedValid);
             AttachCore("Race.ClassLeaderHasFinished", () => ClassLeaderHasFinished);


### PR DESCRIPTION
### Motivation
- Replace the previous binary declutter toggle with a 3-state cycle so dash visibility can support three declutter levels (0 → 1 → 2 → 0). 
- Preserve existing mappings by keeping the legacy `SecondaryDashMode` as an alias to the new control and expose the numeric state for dashboard bindings and external consumers. 
- Update UI labels and documentation to accurately describe the new cycle behavior.

### Description
- Added an integer `DeclutterMode` property with a private backing field and `OnPropertyChanged` notifications (`_declutterMode` / `DeclutterMode`).
- Implemented `DeclutterMode()` action and changed `ToggleDeclutterMode` to increment `DeclutterMode` with `DeclutterMode = (DeclutterMode + 1) % 3;`, and made `SecondaryDashMode()` call the same toggle as a legacy alias.
- Registered the new action via `AddAction("DeclutterMode", ...)` and exported the value with `AttachCore("DeclutterMode", () => DeclutterMode);` while updating the init log message to list the new action and legacy alias.
- Updated the dash bindings UI (`DashesTabView.xaml`) and documentation (`Docs/Plugin_UI_Tooltips.md`, `Docs/SimHubLogMessages.md`) to reflect the `0/1/2` cycle and revised tooltips/log message descriptions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a17ff44dc832fb71a9aae60bfac29)