### PR TITLE
Fix OffTrack Debug CSV changes-only filtering and 5s event window

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -2907,9 +2907,9 @@ namespace LaunchPlugin
                 && left.CarLap == right.CarLap
                 && (ignoreContextFields || OffTrackDebugDoubleEquals(left.CarLapDistPct, right.CarLapDistPct))
                 && left.OffTrackNow == right.OffTrackNow
-                && left.OffTrackStreak == right.OffTrackStreak
-                && OffTrackDebugDoubleEquals(left.OffTrackFirstSeenTimeSec, right.OffTrackFirstSeenTimeSec)
-                && left.CompromisedUntilLap == right.CompromisedUntilLap
+                && (ignoreContextFields || left.OffTrackStreak == right.OffTrackStreak)
+                && (ignoreContextFields || OffTrackDebugDoubleEquals(left.OffTrackFirstSeenTimeSec, right.OffTrackFirstSeenTimeSec))
+                && (ignoreContextFields || left.CompromisedUntilLap == right.CompromisedUntilLap)
                 && left.CompromisedOffTrackActive == right.CompromisedOffTrackActive
                 && left.CompromisedPenaltyActive == right.CompromisedPenaltyActive
                 && left.AllowLatches == right.AllowLatches


### PR DESCRIPTION
### Motivation
- Changes-only CSV mode was still writing nearly every tick because continuously-varying fields (notably `CarLapDistPct`) were compared with exact double equality during snapshot equality checks.  
- The event marker should force per-tick logging for a short window, but previously behaved like a brief pulse; we need a 5.0s session-time window that holds the marker true and overrides changes-only suppression.

### Description
- Update snapshot comparison by changing `OffTrackDebugSnapshotEquals` to accept `ignoreContextFields` and skip comparing `CarLapDistPct` when `true`, so context fields are still written to the CSV but don’t trigger changes-only writes.  
- Add a session-time event window via `_offTrackDebugEventWindowUntilSessionTimeSec` that is set to `sessionTimeSec + 5.0` when `_eventMarkerPressed` is seen, compute `eventActive` each tick, set the CSV `EventFired` (`EventFired` column) while `eventActive` is true, and clear the window after expiry.  
- Make change-only logic write the first row always (`!_offTrackDebugSnapshotInitialized`) and force per-tick writes while `eventActive`, and invoke snapshot equality using `ignoreContextFields: true` to avoid noisy continuous-field comparisons; also reset the event window in `ResetOffTrackDebugExportState` to avoid stale state.  
- Preserved existing CSV header, column ordering and payload writing; no CSV columns renamed or removed and no new allocations introduced to the hot path beyond a small state double.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5e51cf9c832f98d3c2fa5d3b4987)