### PR TITLE
Replace friend checkboxes with unified driver tag dropdown in Global Settings

### DIFF
--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:local="clr-namespace:LaunchPlugin"
              xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins"
              xmlns:ui="clr-namespace:SimHub.Plugins.UI;assembly=SimHub.Plugins"
@@ -12,6 +13,11 @@
 
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <x:Array x:Key="DriverTagOptions" Type="{x:Type sys:String}">
+            <sys:String>Friend</sys:String>
+            <sys:String>Teammate</sys:String>
+            <sys:String>Bad</sys:String>
+        </x:Array>
     </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10">
@@ -53,10 +59,10 @@
             </Grid>
  
             <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" Height="2" />
-            <styles:SHSection Title="FRIENDS" ShowSeparator="True">
+            <styles:SHSection Title="DRIVER TAGS" ShowSeparator="True">
                 <StackPanel>
                     <TextBlock Margin="0,0,0,5" Foreground="LightGray"
-                               Text="Add iRacing Customer IDs to highlight friends in CarSA." />
+                               Text="Add iRacing Customer IDs and assign a driver tag in CarSA." />
                     <StackPanel Margin="0,0,0,8">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -74,11 +80,12 @@
                                       Grid.Column="1"
                                       MinWidth="220"
                                       Margin="0,0,8,0" />
-                            <CheckBox x:Name="IOverlayTeammateCheckBox"
+                            <ComboBox x:Name="IOverlayTagComboBox"
                                       Grid.Column="2"
-                                      Content="Import as teammate"
-                                      VerticalAlignment="Center"
-                                      Margin="0,0,8,0" />
+                                      MinWidth="130"
+                                      Margin="0,0,8,0"
+                                      ItemsSource="{StaticResource DriverTagOptions}"
+                                      SelectedIndex="0" />
                             <styles:SHButtonPrimary Grid.Column="3"
                                                     Content="Import"
                                                     Padding="8,2"
@@ -109,12 +116,10 @@
                             <DataGridTextColumn Header="UserId"
                                                 Binding="{Binding UserId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                 Width="120" />
-                            <DataGridCheckBoxColumn Header="TEAMMATE"
-                                                    Binding="{Binding IsTeammate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                    Width="110" />
-                            <DataGridCheckBoxColumn Header="BAD"
-                                                    Binding="{Binding IsBad, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                    Width="90" />
+                            <DataGridComboBoxColumn Header="TAG"
+                                                    SelectedItemBinding="{Binding Tag, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                    ItemsSource="{StaticResource DriverTagOptions}"
+                                                    Width="120" />
                             <DataGridTemplateColumn Header="REMOVE" Width="90">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
@@ -130,7 +135,7 @@
                             </DataGridTemplateColumn>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <styles:SHButtonPrimary Content="Add Friend"
+                    <styles:SHButtonPrimary Content="Add Driver"
                                             Width="120"
                                             HorizontalAlignment="Left"
                                             Click="AddFriend_Click" />

--- a/GlobalSettingsView.xaml.cs
+++ b/GlobalSettingsView.xaml.cs
@@ -36,7 +36,7 @@ namespace LaunchPlugin
                 Plugin.Settings.Friends = new ObservableCollection<LaunchPluginFriendEntry>();
             }
 
-            Plugin.Settings.Friends.Add(new LaunchPluginFriendEntry { Name = "Friend", UserId = 0, IsTeammate = false, IsBad = false });
+            Plugin.Settings.Friends.Add(new LaunchPluginFriendEntry { Name = "Friend", UserId = 0, Tag = LaunchPluginFriendEntry.TagFriend });
             Plugin.NotifyFriendsChanged();
         }
 
@@ -102,7 +102,8 @@ namespace LaunchPlugin
             UpdateIOverlayCategories(categories);
 
             var selectedCategoryId = selectedCategory.Id;
-            var importAsTeammate = IOverlayTeammateCheckBox?.IsChecked == true;
+            var importTag = IOverlayTagComboBox?.SelectedItem as string;
+            var normalizedImportTag = LaunchPluginFriendEntry.NormalizeTag(importTag);
 
             if (Plugin.Settings.Friends == null)
             {
@@ -149,9 +150,9 @@ namespace LaunchPlugin
                 if (existingById.TryGetValue(userId, out var existing))
                 {
                     bool updated = false;
-                    if (importAsTeammate && existing.IsTeammate == false)
+                    if (!string.Equals(existing.Tag, normalizedImportTag, StringComparison.OrdinalIgnoreCase))
                     {
-                        existing.IsTeammate = true;
+                        existing.Tag = normalizedImportTag;
                         updated = true;
                     }
 
@@ -177,8 +178,7 @@ namespace LaunchPlugin
                 {
                     Name = string.IsNullOrWhiteSpace(driverTag.Name) ? "Friend" : driverTag.Name.Trim(),
                     UserId = userId,
-                    IsTeammate = importAsTeammate,
-                    IsBad = false
+                    Tag = normalizedImportTag
                 };
 
                 Plugin.Settings.Friends.Add(newEntry);


### PR DESCRIPTION
### Motivation
- Simplify and improve the friends UI by replacing two per-row boolean checkboxes with a single, explicit driver tag (Friend / Teammate / Bad) to make intent clearer and reduce UI clutter. 
- Allow iOverlay imports to map directly to the same tag model so imported driver categories integrate with the UI consistently.

### Description
- Renamed the Global Settings section from "FRIENDS" to "DRIVER TAGS" and added a `DriverTagOptions` resource with values `Friend`, `Teammate`, and `Bad` in `GlobalSettingsView.xaml`.
- Replaced the per-row `TEAMMATE` and `BAD` `DataGridCheckBoxColumn`s with a single `DataGridComboBoxColumn` bound to a new `Tag` property, and changed the add button label to "Add Driver" in `GlobalSettingsView.xaml`.
- Updated the iOverlay import UI to present a tag `ComboBox` and changed import logic in `GlobalSettingsView.xaml.cs` to apply the selected tag to existing and new entries.
- Introduced a normalized `Tag` string on `LaunchPluginFriendEntry` in `LalaLaunch.cs` (constants `TagFriend`/`TagTeammate`/`TagBad`), exposed `IsTeammate`/`IsBad` as derived boolean properties, and added legacy JSON compatibility via `LegacyIsTeammate`, `LegacyIsBad`, and an `OnDeserialized` hook so older persisted settings continue to work; also updated dirty-tracking to listen for `Tag` changes.

### Testing
- Attempted to build the project with `dotnet build LaunchPlugin.csproj -v minimal` but the `dotnet` CLI is not available in this environment, so compilation could not be verified (command not found).
- Attempted to build with `msbuild LaunchPlugin.csproj /t:Build /p:Configuration=Debug` but `msbuild` is not available in this environment, so compilation could not be verified (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d17b2c078832f9c08d7eee99153ee)