### PR TITLE
Remove embedded beep binary, add maintainer restore note, and fix shift gear index closure

### DIFF
--- a/LaunchPlugin.csproj
+++ b/LaunchPlugin.csproj
@@ -166,7 +166,7 @@
     <Compile Include="TrackMarkerMessagingModels.cs" />
   </ItemGroup>
   <ItemGroup>
-    <!-- TODO(maintainer): add Resources\ShiftAssist_DefaultBeep.wav as EmbeddedResource manually after merge. -->
+    <!-- Maintainer manual step: after merge, add Resources\ShiftAssist_DefaultBeep.wav locally and restore this line: <EmbeddedResource Include="Resources\ShiftAssist_DefaultBeep.wav" /> -->
     <Page Include="CopyProfileDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -616,10 +616,11 @@ namespace LaunchPlugin
                 var stack = EnsureShiftStackForSelectedProfile(SelectedShiftStackId);
                 for (int i = 0; i < 8; i++)
                 {
+                    int gearIndex = i;
                     yield return new ShiftGearRow
                     {
-                        GearLabel = $"Gear {i + 1}",
-                        RpmText = stack.ShiftRPM[i] > 0 ? stack.ShiftRPM[i].ToString(CultureInfo.InvariantCulture) : string.Empty,
+                        GearLabel = $"Gear {gearIndex + 1}",
+                        RpmText = stack.ShiftRPM[gearIndex] > 0 ? stack.ShiftRPM[gearIndex].ToString(CultureInfo.InvariantCulture) : string.Empty,
                         SaveAction = txt =>
                         {
                             int value;
@@ -628,7 +629,7 @@ namespace LaunchPlugin
                                 value = 0;
                             }
 
-                            stack.ShiftRPM[i] = value;
+                            stack.ShiftRPM[gearIndex] = value;
                             SaveProfiles();
                             OnPropertyChanged(nameof(ShiftGearRows));
                         }


### PR DESCRIPTION
### Motivation
- Fix a runtime bug where the SHIFT tab save lambda closed over the loop index and could write an out-of-range gear RPM index. 
- Avoid committing a binary WAV into the PR payload while preserving guidance so maintainers can re-enable the embedded default beep after merge.

### Description
- Capture the loop index into a local `gearIndex` in `ProfilesManagerViewModel.cs` and use it for `GearLabel`, `RpmText`, and the `SaveAction` assignment to prevent the closure bug. 
- Replace the `<EmbeddedResource Include="Resources\ShiftAssist_DefaultBeep.wav" />` entry in `LaunchPlugin.csproj` with a one-line maintainer instruction comment that documents the exact `<EmbeddedResource ... />` line to restore after merge. 
- Remove `Resources/ShiftAssist_DefaultBeep.wav` from the repository so the branch contains no committed binary WAV.

### Testing
- Verified `LaunchPlugin.csproj` contains the maintainer instruction comment in place of the embedded-resource entry (succeeded). 
- Confirmed `Resources/ShiftAssist_DefaultBeep.wav` is no longer present in the workspace (succeeded). 
- Confirmed `ProfilesManagerViewModel.cs` now declares and uses `gearIndex` for label, RPM text and save assignment (succeeded). 
- Attempted to perform a `dotnet build` previously but the environment lacks the `dotnet` CLI, so a full compile/test run could not be executed here (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909aec61c8832fa7499b84b48bc72a)