### PR TITLE
Fix SHIFT tab RPM entry IndexOutOfRange crash

### DIFF
--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -616,10 +616,11 @@ namespace LaunchPlugin
                 var stack = EnsureShiftStackForSelectedProfile(SelectedShiftStackId);
                 for (int i = 0; i < 8; i++)
                 {
+                    int gearIdx = i;
                     yield return new ShiftGearRow
                     {
-                        GearLabel = $"Gear {i + 1}",
-                        RpmText = stack.ShiftRPM[i] > 0 ? stack.ShiftRPM[i].ToString(CultureInfo.InvariantCulture) : string.Empty,
+                        GearLabel = $"Gear {gearIdx + 1}",
+                        RpmText = stack.ShiftRPM[gearIdx] > 0 ? stack.ShiftRPM[gearIdx].ToString(CultureInfo.InvariantCulture) : string.Empty,
                         SaveAction = txt =>
                         {
                             int value;
@@ -628,7 +629,7 @@ namespace LaunchPlugin
                                 value = 0;
                             }
 
-                            stack.ShiftRPM[i] = value;
+                            stack.ShiftRPM[gearIdx] = value;
                             SaveProfiles();
                             OnPropertyChanged(nameof(ShiftGearRows));
                         }


### PR DESCRIPTION
### Motivation
- Prevent `IndexOutOfRangeException` when editing RPM entries on the SHIFT tab by avoiding closure capture of the loop variable in `ShiftGearRows` so each row's lambda retains the correct gear index.

### Description
- Introduced a per-iteration local `int gearIdx = i;` inside the `for` loop in `ProfilesManagerViewModel.ShiftGearRows` and updated `GearLabel`, `RpmText`, and the `SaveAction` writeback to use `gearIdx` instead of the loop variable, preserving existing parsing/fallback and persistence behavior.

### Testing
- Attempted `dotnet build LaunchPlugin.sln`, which failed because the `dotnet` CLI is not available in this environment, so compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a23d9934832fbf8c38cf76387dcd)