### PR TITLE
Shift Assist: use SoundPlayer, add predictive cap, fix session-time and append accel columns

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -232,7 +232,8 @@
                                     <ColumnDefinition Width="220" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="Beep volume" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <TextBlock Grid.Column="0" Text="Beep volume" VerticalAlignment="Center" Margin="0,0,8,0"
+                                           ToolTip="0 mutes. Above 0 uses SimHub master volume."/>
                                 <Slider Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Minimum="0"

--- a/ShiftAssistAudio.cs
+++ b/ShiftAssistAudio.cs
@@ -2,11 +2,8 @@ using SimHub.Plugins;
 using System;
 using System.IO;
 using System.Linq;
+using System.Media;
 using System.Reflection;
-using System.Threading;
-using System.Windows;
-using System.Windows.Media;
-using System.Windows.Threading;
 
 namespace LaunchPlugin
 {
@@ -15,8 +12,7 @@ namespace LaunchPlugin
         private const string DefaultFileRelativePath = "ShiftAssist/DefaultBeep.wav";
 
         private readonly Func<LaunchPluginSettings> _settingsProvider;
-        private readonly object _audioThreadSync = new object();
-        private readonly AutoResetEvent _audioDispatcherReady = new AutoResetEvent(false);
+        private readonly object _playerSync = new object();
         private string _resolvedDefaultPath;
         private bool _warnedMissingCustom;
         private bool _loggedSoundChoice;
@@ -26,12 +22,8 @@ namespace LaunchPlugin
         private bool _embeddedUnavailable;
         private bool _embeddedResourceNameResolved;
         private string _embeddedResourceName;
-        private MediaPlayer _player;
+        private SoundPlayer _player;
         private string _playerPath;
-        private EventHandler _playerMediaEndedHandler;
-        private EventHandler<ExceptionEventArgs> _playerMediaFailedHandler;
-        private Thread _audioThread;
-        private Dispatcher _audioDispatcher;
 
         public ShiftAssistAudio(Func<LaunchPluginSettings> settingsProvider)
         {
@@ -140,289 +132,72 @@ namespace LaunchPlugin
             _lastLoggedPath = null;
         }
 
-        public void PlayShiftBeep()
+        public bool TryPlayBeep(out DateTime issuedUtc)
         {
+            issuedUtc = DateTime.MinValue;
+
             var settings = _settingsProvider?.Invoke();
             if (settings != null)
             {
                 if (!settings.ShiftAssistBeepSoundEnabled || settings.ShiftAssistBeepVolumePct <= 0)
                 {
                     HardStop();
-                    return;
+                    return false;
                 }
             }
 
             string path = ResolvePlaybackPath(out bool usingCustom);
             if (string.IsNullOrWhiteSpace(path))
             {
-                return;
+                return false;
             }
 
             string absolutePath = ToAbsolutePath(path);
             if (string.IsNullOrWhiteSpace(absolutePath) || !File.Exists(absolutePath))
             {
-                return;
+                return false;
             }
 
             MaybeLogSoundChoice(absolutePath, usingCustom);
 
-            int volumePct = settings?.ShiftAssistBeepVolumePct ?? 100;
-            if (volumePct < 0) volumePct = 0;
-            if (volumePct > 100) volumePct = 100;
-            double volume = volumePct / 100.0;
-
-            PlayOnce(new Uri(absolutePath, UriKind.Absolute), volume);
-        }
-
-        private void PlayOnce(Uri uri, double volume)
-        {
-            RunOnAudioDispatcher(() =>
+            try
             {
-                bool warnedPlayFailure = false;
-
-                Action<string, Exception> warnOnce = (message, ex) =>
+                lock (_playerSync)
                 {
-                    if (warnedPlayFailure)
+                    if (_player == null || !string.Equals(_playerPath, absolutePath, StringComparison.OrdinalIgnoreCase))
                     {
-                        return;
+                        _player = new SoundPlayer(absolutePath);
+                        _player.Load();
+                        _playerPath = absolutePath;
                     }
 
-                    warnedPlayFailure = true;
-                    string suffix = ex == null ? string.Empty : $": {ex.Message}";
-                    SimHub.Logging.Current.Warn($"[LalaPlugin:ShiftAssist] {message}{suffix}");
-                };
-
-                Action cleanup = null;
-                bool cleanupDone = false;
-
-                cleanup = () =>
-                {
-                    if (cleanupDone)
-                    {
-                        return;
-                    }
-
-                    cleanupDone = true;
-
-                    try
-                    {
-                        DetachPlayerHandlersUnsafe();
-                    }
-                    catch
-                    {
-                    }
-
-                    try
-                    {
-                        if (_player != null)
-                        {
-                            _player.Stop();
-                        }
-                    }
-                    catch
-                    {
-                    }
-
-                    try
-                    {
-                        if (_player != null)
-                        {
-                            _player.Close();
-                        }
-                    }
-                    catch
-                    {
-                    }
-
-                    _player = null;
-                    _playerPath = null;
-                };
-
-                try
-                {
-                    HardStopUnsafe();
-
-                    _player = new MediaPlayer();
-                    _playerPath = uri.LocalPath;
-
-                    _playerMediaEndedHandler = (sender, args) =>
-                    {
-                        cleanup();
-                    };
-
-                    _playerMediaFailedHandler = (sender, args) =>
-                    {
-                        warnOnce($"Failed to play sound '{_playerPath}'", args != null ? args.ErrorException : null);
-                        cleanup();
-                    };
-
-                    _player.MediaEnded += _playerMediaEndedHandler;
-                    _player.MediaFailed += _playerMediaFailedHandler;
-
-                    _player.Volume = volume;
-                    _player.Open(uri);
+                    issuedUtc = DateTime.UtcNow;
                     _player.Play();
+                    return true;
                 }
-                catch (Exception ex)
-                {
-                    warnOnce($"Failed to play sound '{uri}'", ex);
-                    cleanup();
-                }
-            });
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn($"[LalaPlugin:ShiftAssist] Failed to play sound '{absolutePath}': {ex.Message}");
+                return false;
+            }
         }
 
         public void HardStop()
         {
-            RunOnAudioDispatcher(() =>
+            lock (_playerSync)
             {
                 try
                 {
-                    HardStopUnsafe();
+                    if (_player != null)
+                    {
+                        _player.Stop();
+                    }
                 }
                 catch (Exception ex)
                 {
                     SimHub.Logging.Current.Warn($"[LalaPlugin:ShiftAssist] HardStop failed: {ex.Message}");
                 }
-            }, true);
-        }
-
-        private void RunOnAudioDispatcher(Action action, bool waitForCompletion = false)
-        {
-            if (action == null)
-            {
-                return;
-            }
-
-            Dispatcher dispatcher = EnsureAudioDispatcher();
-            if (dispatcher == null)
-            {
-                return;
-            }
-
-            if (dispatcher.CheckAccess())
-            {
-                action();
-                return;
-            }
-
-            if (waitForCompletion)
-            {
-                var operation = dispatcher.BeginInvoke(action);
-                operation.Wait();
-                return;
-            }
-
-            dispatcher.BeginInvoke(action);
-        }
-
-        private Dispatcher EnsureAudioDispatcher()
-        {
-            lock (_audioThreadSync)
-            {
-                if (_audioDispatcher != null)
-                {
-                    return _audioDispatcher;
-                }
-
-                if (_audioThread == null)
-                {
-                    _audioThread = new Thread(() =>
-                    {
-                        _audioDispatcher = Dispatcher.CurrentDispatcher;
-                        _audioDispatcherReady.Set();
-                        Dispatcher.Run();
-                    });
-                    _audioThread.IsBackground = true;
-                    _audioThread.Name = "ShiftAssistAudioDispatcher";
-                    _audioThread.SetApartmentState(ApartmentState.STA);
-                    _audioThread.Start();
-                }
-            }
-
-            if (_audioDispatcher == null)
-            {
-                _audioDispatcherReady.WaitOne(2000);
-            }
-
-            if (_audioDispatcher == null)
-            {
-                SimHub.Logging.Current.Warn("[LalaPlugin:ShiftAssist] Failed to initialize audio dispatcher thread.");
-            }
-
-            return _audioDispatcher;
-        }
-
-        private void ShutdownAudioDispatcher()
-        {
-            Dispatcher dispatcher = _audioDispatcher;
-            if (dispatcher == null)
-            {
-                return;
-            }
-
-            try
-            {
-                dispatcher.BeginInvokeShutdown(DispatcherPriority.Background);
-            }
-            catch
-            {
-            }
-            finally
-            {
-                _audioDispatcher = null;
-                _audioThread = null;
-            }
-        }
-
-        private void HardStopUnsafe()
-        {
-            DetachPlayerHandlersUnsafe();
-
-            try
-            {
-                if (_player != null)
-                {
-                    _player.Stop();
-                }
-            }
-            catch
-            {
-            }
-
-            try
-            {
-                if (_player != null)
-                {
-                    _player.Close();
-                }
-            }
-            catch
-            {
-            }
-
-            _player = null;
-            _playerPath = null;
-        }
-
-        private void DetachPlayerHandlersUnsafe()
-        {
-            if (_player == null)
-            {
-                _playerMediaEndedHandler = null;
-                _playerMediaFailedHandler = null;
-                return;
-            }
-
-            if (_playerMediaEndedHandler != null)
-            {
-                _player.MediaEnded -= _playerMediaEndedHandler;
-                _playerMediaEndedHandler = null;
-            }
-
-            if (_playerMediaFailedHandler != null)
-            {
-                _player.MediaFailed -= _playerMediaFailedHandler;
-                _playerMediaFailedHandler = null;
             }
         }
 
@@ -496,7 +271,6 @@ namespace LaunchPlugin
         public void Dispose()
         {
             HardStop();
-            ShutdownAudioDispatcher();
         }
     }
 }

--- a/ShiftAssistEngine.cs
+++ b/ShiftAssistEngine.cs
@@ -15,7 +15,7 @@ namespace LaunchPlugin
         private const double MinRpmRateDtSec = 0.02;
         private const double MaxRpmRateDtSec = 0.20;
         private const int MaxRpmRatePerSec = 8000;
-        private const int MaxLeadDeltaRpm = 1500;
+        private const int MaxPredictiveEarlyRpm = 800;
         private const int MinEffectiveTargetRpmFloor = 1000;
         private const int EffectiveTargetFloorOffset = 1500;
 
@@ -68,9 +68,16 @@ namespace LaunchPlugin
                         if (leadTimeMs > 0)
                         {
                             double leadDeltaRpm = clampedRate * (leadTimeMs / 1000.0);
-                            if (leadDeltaRpm > MaxLeadDeltaRpm)
+                            if (leadDeltaRpm > MaxPredictiveEarlyRpm)
                             {
-                                leadDeltaRpm = MaxLeadDeltaRpm;
+                                leadDeltaRpm = MaxPredictiveEarlyRpm;
+                            }
+
+                            if (engineRpm < (targetRpm - MaxPredictiveEarlyRpm))
+                            {
+                                LastRpmRate = 0;
+                                LastEffectiveTargetRpm = targetRpm;
+                                leadDeltaRpm = 0;
                             }
 
                             int computedEffectiveTarget = targetRpm - (int)Math.Round(leadDeltaRpm);


### PR DESCRIPTION
### Motivation
- Reduce runtime audio jitter and cross-thread ownership issues by reverting runtime beeps to a simple, synchronous backend. 
- Prevent overly aggressive predictive early-triggering that was firing ~Target-1500 rpm by capping predictive lead and guarding when RPM is far below target. 
- Ensure `SessionTimeSec` in the Shift Assist debug CSV uses the same telemetry source as other CSVs so replay/live logs contain increasing session time. 
- Provide acceleration data for Phase 3 learning and per-beep timing instrumentation to measure audio path latency.

### Description
- Replaced the `MediaPlayer`/dispatcher-thread audio implementation with a synchronous `System.Media.SoundPlayer` backend while preserving embedded default extraction and custom WAV fallback; playback remains gated by `ShiftAssistBeepSoundEnabled` and `ShiftAssistBeepVolumePct` (0 = mute, >0 uses SimHub master volume). 
- Added audio timing instrumentation and exports: `ShiftAssist.Debug.AudioDelayMs` (int), `ShiftAssist.Debug.AudioIssued` (bool pulse), and `ShiftAssist.Debug.AudioBackend` (`"SoundPlayer"`), and emit a single INFO line per beep when Shift Assist debug CSV is enabled. 
- Implemented a predictive-cap change in `ShiftAssistEngine`: introduced `MaxPredictiveEarlyRpm = 800`, clamped `leadDeltaRpm` to this cap, and added a guard that disables predictive lowering when `engineRpm < targetRpm - MaxPredictiveEarlyRpm`. 
- Fixed Shift Assist debug CSV session-time sourcing to prefer `DataCorePlugin.GameRawData.Telemetry.SessionTime` with fallback to `DataCorePlugin.GameData.SessionTime`, and changed CSV file stamping to use session-time milliseconds (`ShiftAssist_Debug_Sess_{SessionTimeSecMs}.csv`). 
- Appended three acceleration columns to the end of the existing Shift Assist CSV (keeps all prior columns and order): `SpeedMps`, `AccelDerivedMps2`, and `LonAccelTelemetryMps2`, where `SpeedMps` is resolved from the most direct telemetry (or converted from km/h or mph), `AccelDerivedMps2` = `(speed - lastSpeed)/dt` computed only for `dt` in `0.02..0.20` and otherwise `0.0`, and `LonAccelTelemetryMps2` is taken from `LongAccel`/`LonAccel` telemetry or `0.0` if unavailable. 
- Kept `ShiftAssist.Beep` latch semantics unchanged and did not modify existing exported property names or actions. 
- Updated SHIFT tab tooltip for beep volume to read: `0 mutes. Above 0 uses SimHub master volume.`

### Testing
- Ran repository hygiene/check `git diff --check` which reported no whitespace/patch issues. 
- Attempted automated build runs with `dotnet` and `msbuild`, but those tools are unavailable in the execution environment so a full compile was not performed here. 
- No unit tests exist for the plugin in this environment; behavior validation (audio latency measurement, CSV contents and column ordering, and predictive gating) should be verified in a SimHub runtime with live/replay telemetry and `EnableShiftAssistDebugCsv` enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e9df74f0832fb3cbf5e0153a7eb6)