### PR TITLE
Shift Assist: add EffectiveGear CSV column and Learning Mode toggle/export

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -209,6 +209,8 @@
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <StackPanel Margin="10">
                             <styles:SHToggleCheckbox Content="Enable Shift Assist" IsChecked="{Binding ShiftAssistEnabled, Mode=TwoWay}" />
+                            <styles:SHToggleCheckbox Content="Learning mode" Margin="0,8,0,0" IsChecked="{Binding ShiftAssistLearningModeEnabled, Mode=TwoWay}"
+                                                     ToolTip="Enables data mining for shift-point learning and allows the dash learning overlay to be shown." />
 
                             <Grid Margin="0,8,0,0">
                                 <Grid.ColumnDefinitions>

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -44,6 +44,8 @@ namespace LaunchPlugin
         private readonly Func<string> _getCurrentGearStackId;
         private readonly Func<bool> _getShiftAssistEnabled;
         private readonly Action<bool> _setShiftAssistEnabled;
+        private readonly Func<bool> _getShiftAssistLearningModeEnabled;
+        private readonly Action<bool> _setShiftAssistLearningModeEnabled;
         private readonly Func<int> _getShiftAssistBeepDurationMs;
         private readonly Action<int> _setShiftAssistBeepDurationMs;
         private readonly Func<int> _getShiftAssistLeadTimeMs;
@@ -555,6 +557,16 @@ namespace LaunchPlugin
             }
         }
 
+        public bool ShiftAssistLearningModeEnabled
+        {
+            get => _getShiftAssistLearningModeEnabled?.Invoke() == true;
+            set
+            {
+                _setShiftAssistLearningModeEnabled?.Invoke(value);
+                OnPropertyChanged();
+            }
+        }
+
         public int ShiftAssistBeepDurationMs
         {
             get => _getShiftAssistBeepDurationMs?.Invoke() ?? 250;
@@ -849,7 +861,7 @@ namespace LaunchPlugin
         }
 
 
-        public ProfilesManagerViewModel(PluginManager pluginManager, Action<CarProfile> applyProfileToLiveAction, Func<string> getCurrentCarModel, Func<string> getCurrentTrackName, Func<string, TrackMarkersSnapshot> getTrackMarkersSnapshotForKey, Action<string, bool> setTrackMarkersLockForKey, Action reloadTrackMarkersFromDisk, Action<string> resetTrackMarkersForKey, Func<string> getCurrentGearStackId, Func<bool> getShiftAssistEnabled, Action<bool> setShiftAssistEnabled, Func<int> getShiftAssistBeepDurationMs, Action<int> setShiftAssistBeepDurationMs, Func<int> getShiftAssistLeadTimeMs, Action<int> setShiftAssistLeadTimeMs, Func<bool> getShiftAssistUseCustomWav, Action<bool> setShiftAssistUseCustomWav, Func<string> getShiftAssistCustomWavPath, Action<string> setShiftAssistCustomWavPath, Func<bool> getShiftAssistBeepSoundEnabled, Action<bool> setShiftAssistBeepSoundEnabled, Func<int> getShiftAssistBeepVolumePct, Action<int> setShiftAssistBeepVolumePct, Action playShiftAssistTestBeep)
+        public ProfilesManagerViewModel(PluginManager pluginManager, Action<CarProfile> applyProfileToLiveAction, Func<string> getCurrentCarModel, Func<string> getCurrentTrackName, Func<string, TrackMarkersSnapshot> getTrackMarkersSnapshotForKey, Action<string, bool> setTrackMarkersLockForKey, Action reloadTrackMarkersFromDisk, Action<string> resetTrackMarkersForKey, Func<string> getCurrentGearStackId, Func<bool> getShiftAssistEnabled, Action<bool> setShiftAssistEnabled, Func<bool> getShiftAssistLearningModeEnabled, Action<bool> setShiftAssistLearningModeEnabled, Func<int> getShiftAssistBeepDurationMs, Action<int> setShiftAssistBeepDurationMs, Func<int> getShiftAssistLeadTimeMs, Action<int> setShiftAssistLeadTimeMs, Func<bool> getShiftAssistUseCustomWav, Action<bool> setShiftAssistUseCustomWav, Func<string> getShiftAssistCustomWavPath, Action<string> setShiftAssistCustomWavPath, Func<bool> getShiftAssistBeepSoundEnabled, Action<bool> setShiftAssistBeepSoundEnabled, Func<int> getShiftAssistBeepVolumePct, Action<int> setShiftAssistBeepVolumePct, Action playShiftAssistTestBeep)
         {
             _pluginManager = pluginManager;
             _applyProfileToLiveAction = applyProfileToLiveAction;
@@ -862,6 +874,8 @@ namespace LaunchPlugin
             _getCurrentGearStackId = getCurrentGearStackId;
             _getShiftAssistEnabled = getShiftAssistEnabled;
             _setShiftAssistEnabled = setShiftAssistEnabled;
+            _getShiftAssistLearningModeEnabled = getShiftAssistLearningModeEnabled;
+            _setShiftAssistLearningModeEnabled = setShiftAssistLearningModeEnabled;
             _getShiftAssistBeepDurationMs = getShiftAssistBeepDurationMs;
             _setShiftAssistBeepDurationMs = setShiftAssistBeepDurationMs;
             _getShiftAssistLeadTimeMs = getShiftAssistLeadTimeMs;


### PR DESCRIPTION
### Motivation
- Provide visibility into the gear value actually used by the ShiftAssist engine (including gear=0 hold behavior) by adding an `EffectiveGear` column to the debug CSV for accurate diagnosis and tuning.
- Introduce a UI control to flip a future learning/data-mining mode so the dash overlay can show/hide the learning overlay state without shipping learning logic yet.
- Expose a simple SimHub property that dashboards can read to toggle the learning overlay independent of Shift Assist runtime state.

### Description
- Appended a final CSV column `EffectiveGear` to the Shift Assist debug CSV header and each written row, and updated the writer signature and caller to pass `effectiveGear` (the evaluated gear, accounting for the gear-zero hold logic) while preserving all existing columns and their order (`Gear` remains raw telemetry). (`WriteShiftAssistDebugCsv` signature and its call sites updated in `LalaLaunch.cs`).
- Added a persisted setting `public bool ShiftAssistLearningModeEnabled` (default `false`) to `LaunchPluginSettings` so the toggle state is saved like other Shift Assist settings.
- Added a new `Learning mode` toggle on the SHIFT tab (UI) with tooltip: `Enables data mining for shift-point learning and allows the dash learning overlay to be shown.` (`ProfilesManagerView.xaml`).
- Wired the setting into `ProfilesManagerViewModel` (delegate getters/setters, bindable `ShiftAssistLearningModeEnabled` property, and constructor injection) and into the `ProfilesManagerViewModel` construction in `LalaLaunch` so UI toggles update and persist immediately.
- Exported a SimHub property `ShiftAssist.Learn.Enabled` that returns `1` when `ShiftAssistLearningModeEnabled` is true and `0` otherwise, and attached it at init so the dash can always read it regardless of Shift Assist runtime enabled state.
- Explicitly did not add any learning/capture algorithm; this PR only implements state, UI, persistence, CSV export and the SimHub property.

### Testing
- Performed static verification searches to confirm new symbols and usages: looked for `ShiftAssistLearningModeEnabled`, `ShiftAssist.Learn.Enabled`, `EffectiveGear`, and `WriteShiftAssistDebugCsv` changes across `LalaLaunch.cs`, `ProfilesManagerViewModel.cs`, and `ProfilesManagerView.xaml` and validated the updated CSV header/format string and added constructor wiring.
- Attempted to build the solution via `dotnet build` and `msbuild` in this environment but both tools were not available, so a compile verification was not possible here (build commands failed in the runtime environment).
- Performed local file diffs and inspected the generated changes to confirm header includes `,EffectiveGear`, UI contains the new toggle, and the SimHub export delegate returns `0/1` as required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699331fcbd08832fbb92615bfdbd94b2)