### PR TITLE
docs: refresh PR404 Shift Assist docs, SimHub inventory, and tooltips

### DIFF
--- a/Docs/Code_Snapshot.md
+++ b/Docs/Code_Snapshot.md
@@ -2,8 +2,8 @@
 
 # Code Snapshot
 
-- Source commit/PR: 2a38742 (post-PR381 workspace head)
-- Generated date: 2026-02-14
+- Source commit/PR: 1617166 (post-PR404 workspace head)
+- Generated date: 2026-02-16
 - Regeneration: manual snapshot; no regen pipeline defined
 - Branch: work
 
@@ -14,8 +14,8 @@ If this conflicts with `Project_Index.md` or canonical contract docs, treat this
 - Shift Assist is now a first-class subsystem: runtime evaluator (`ShiftAssistEngine`), audio resolver/player (`ShiftAssistAudio`), settings plumbing in `LaunchPluginSettings`, per-tick exports, action bindings, and delay telemetry capture for tuning.
 - Canonical signal and log contracts are maintained in `SimHubParameterInventory.md` and `SimHubLogMessages.md`; this file is a quick orientation snapshot only.
 
-## Since PR381 (docs-oriented delta)
-- Added Shift Assist subsystem documentation and linked it into the project index.
-- Refreshed canonical docs metadata to current head/date.
-- Synced Shift Assist log coverage with code (toggle/test beep/beep trigger/delay sample/audio fallback/errors).
-- Refreshed repository status and index references so docs align with current branch state.
+## Since PR404 (docs refresh delta)
+- Refreshed canonical docs metadata and validation hashes to the current workspace head/date.
+- Updated Shift Assist subsystem documentation for learning mode, debug telemetry exports, and debug CSV behavior.
+- Synced Shift Assist inventory/log docs with current exports and log lines (including debug CSV toggle and audio-delay telemetry).
+- Refreshed plugin tooltip inventory, project index, and repository status so the documentation set stays aligned.

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -1,7 +1,7 @@
 # Plugin UI Tooltips
 
-Validated against commit: 2a38742  
-Last updated: 2026-02-14  
+Validated against commit: 1617166  
+Last updated: 2026-02-16  
 Branch: work
 
 ## CopyProfileDialog.xaml
@@ -267,9 +267,17 @@ Branch: work
 - L768: Clear wet data and relearn from new live laps (while unlocked).
 - L775: Computed deltas between wet and dry averages for this track.
 
-## Shift Assist controls (currently no tooltip text)
-- ProfilesManagerView.xaml L211: `Enable Shift Assist` toggle exists without a tooltip string.
-- ProfilesManagerView.xaml L222: `Beep Duration (ms)` textbox exists without a tooltip string.
-- ProfilesManagerView.xaml L224: `Lead Time (ms)` textbox exists without a tooltip string.
-- ProfilesManagerView.xaml L269: `Use custom sound` toggle exists without a tooltip string.
-- ProfilesManagerView.xaml L277: `Custom WAV path` textbox exists without a tooltip string.
+## Shift Assist controls
+- L211: `Enable Shift Assist` toggle exists without a tooltip string.
+- L212: `Learning mode` toggle tooltip: enables shift-point learning data mining and dash learning overlay.
+- L223: `Shift Light Duration (ms)` tooltip: controls how long `ShiftAssist.Beep` stays active; does not change WAV length.
+- L226/L227: `Lead time (ms)` label/textbox exist without tooltip text.
+- L230: `Beep sound` toggle exists without a tooltip string.
+- L237/L248: `Beep volume` label/slider tooltip: not implemented yet; uses SimHub master volume.
+- L257-L275: gear stack selection/copy controls exist without tooltip text.
+- L278/L279: shift targets header/redline hint are informational labels (no tooltip text).
+- L299: `Use custom sound` toggle exists without a tooltip string.
+- L307: `Custom WAV path` textbox exists without a tooltip string.
+- L308: `Browse` button exists without a tooltip string.
+- L309: `Use embedded default` button exists without a tooltip string.
+- L310: `Test Beep` button exists without a tooltip string.

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
-Validated against commit: 2a38742  
-Last updated: 2026-02-14  
+Validated against commit: 1617166  
+Last updated: 2026-02-16  
 Branch: work
 
 ## What this repo is
@@ -36,6 +36,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 | Dash integration | Main/message/overlay visibility and screen state exports | [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## Freshness
-- Validated against commit: 2a38742  
-- Date: 2026-02-14  
+- Validated against commit: 1617166  
+- Date: 2026-02-16  
 - Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,13 +1,13 @@
 # Repository status
 
-Validated against commit: 2a38742  
-Last updated: 2026-02-14  
+Validated against commit: 1617166  
+Last updated: 2026-02-16  
 Branch: work
 
 ## Current repo/link status
 - Local branch present: `work`.
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
-- HEAD includes post-PR381 updates, including Shift Assist runtime + docs refresh.
+- HEAD includes post-PR404 updates, including Shift Assist learning/debug telemetry and docs refresh.
 
 ## Documentation sync status (requested set)
 - `SimHubParameterInventory.md` — refreshed to current head/date and includes Shift Assist export inventory.
@@ -20,7 +20,7 @@ Branch: work
 ## Delivery status highlights
 - Shift Assist subsystem: **INTEGRATED** (settings, evaluation, audio, exports, logs, delay telemetry).
 - Declutter mode + event marker actions: **COMPLETE** (post-PR381 baseline retained).
-- Canonical docs listed above: **SYNCED** to `2a38742`.
+- Canonical docs listed above: **SYNCED** to `1617166`.
 
 ## Notes
 - `Code_Snapshot.md` remains intentionally non-canonical; contract truth lives in parameter/log inventories and subsystem docs.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -2,9 +2,9 @@
 
 **CANONICAL OBSERVABILITY MAP**
 
-Validated against: 2a38742  
-Last reviewed: 2026-02-14  
-Last updated: 2026-02-14  
+Validated against: 1617166  
+Last reviewed: 2026-02-16  
+Last updated: 2026-02-16  
 Branch: work
 
 Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
@@ -171,15 +171,19 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 - **`[LalaPlugin:Rejoin Assist] MsgCx override triggered.`** — Message context override fired inside rejoin assist engine.【F:RejoinAssistEngine.cs†L601-L622】
 
 ## Shift Assist
-- **`[LalaPlugin:ShiftAssist] Enabled=true/false`** — Shift assist runtime evaluation toggled on/off (startup + live toggle + action toggle).【F:LalaLaunch.cs†L3523-L3549】【F:LalaLaunch.cs†L5739-L5747】
-- **`[LalaPlugin:ShiftAssist] Toggle action -> Enabled=...`** — Action binding flipped shift assist on/off from the button map.【F:LalaLaunch.cs†L3544-L3550】
-- **`[LalaPlugin:ShiftAssist] Test beep triggered (duration=...ms)`** — UI test button fired a manual confirmation beep and latch window.【F:LalaLaunch.cs†L5710-L5721】
-- **`[LalaPlugin:ShiftAssist] Beep gear=... target=... effectiveTarget=... rpm=... throttle=... leadMs=...`** — Normal runtime shift cue fired and includes full trigger context for tuning lead-time/targets.【F:LalaLaunch.cs†L5821-L5853】
-- **`[LalaPlugin:ShiftAssist] Delay sample captured gear=... delayMs=... avgMs=...`** — Beep-to-upshift timing sample accepted into the rolling per-gear delay averages.【F:LalaLaunch.cs†L5776-L5795】
-- **`[LalaPlugin:ShiftAssist] Delay stats reset via action.`** — Manual reset of all runtime delay statistics from the action binding/UI control.【F:LalaLaunch.cs†L3534-L3539】
-- **`[LalaPlugin:ShiftAssist] Sound=Custom path='...'`** — Beep playback currently resolved to a valid custom WAV file path.【F:ShiftAssistAudio.cs†L153-L163】
-- **`[LalaPlugin:ShiftAssist] Sound=EmbeddedDefault path='...'`** — Beep playback resolved to the extracted embedded default WAV.【F:ShiftAssistAudio.cs†L164-L167】
-- **`[LalaPlugin:ShiftAssist] WARNING custom wav missing/invalid, falling back to embedded default`** — Custom WAV was enabled but missing/invalid; warning is emitted once per session and playback falls back to embedded default sound.【F:ShiftAssistAudio.cs†L126-L139】
-- **`[LalaPlugin:ShiftAssist] Embedded default beep resource missing.`** — Embedded WAV resource was unavailable in the assembly; default extraction cannot proceed.【F:ShiftAssistAudio.cs†L52-L64】
-- **`[LalaPlugin:ShiftAssist] Failed to extract embedded beep: ...`** — IO/extraction error while writing the default WAV to disk.【F:ShiftAssistAudio.cs†L72-L82】
-- **`[LalaPlugin:ShiftAssist] Failed to play sound '...': ...`** — Sound playback failed for selected path; shift cue remains logically triggered but audio output failed.【F:ShiftAssistAudio.cs†L111-L118】
+- **`[LalaPlugin:ShiftAssist] Enabled=true/false`** — Shift assist runtime evaluation toggled on/off (startup + live toggle + action toggle).【F:LalaLaunch.cs†L3616-L3616】【F:LalaLaunch.cs†L5905-L5913】
+- **`[LalaPlugin:ShiftAssist] Toggle action -> Enabled=...`** — Action binding flipped shift assist on/off from the button map.【F:LalaLaunch.cs†L3635-L3643】
+- **`[LalaPlugin:ShiftAssist] Debug CSV toggle action -> Enabled=...`** — Action binding toggled the Shift Assist debug CSV writer on/off for the current settings profile.【F:LalaLaunch.cs†L3651-L3659】
+- **`[LalaPlugin:ShiftAssist] Test beep triggered (duration=...ms)`** — UI test button fired a manual confirmation beep and latch window.【F:LalaLaunch.cs†L5844-L5871】
+- **`[LalaPlugin:ShiftAssist] Beep type=primary/urgent gear=... rawGear=... maxForwardGears=... target=... redline=... effectiveTarget=... rpm=... rpmRate=... leadMs=... throttle=... suppressDown=... suppressUp=...`** — Normal runtime shift cue fired and includes full trigger context for tuning lead-time, gear interpretation, and suppression behavior.【F:LalaLaunch.cs†L6072-L6110】
+- **`[LalaPlugin:ShiftAssist] Delay sample captured gear=... delayMs=... avgMs=...`** — Beep-to-upshift timing sample accepted into the rolling per-gear delay averages.【F:LalaLaunch.cs†L5957-L5975】
+- **`[LalaPlugin:ShiftAssist] AudioDelayMs=... backend=SoundPlayer`** — Optional telemetry log (when debug CSV mode is enabled) recording trigger-to-audio-issue latency.【F:LalaLaunch.cs†L6082-L6089】
+- **`[LalaPlugin:ShiftAssist] Debug CSV disabled for session after write failure path='...' error='...'`** — Debug CSV writer hit an IO/write error and self-disabled for the remainder of the session.【F:LalaLaunch.cs†L6306-L6310】
+- **`[LalaPlugin:ShiftAssist] Delay stats reset via action.`** — Manual reset of all runtime delay statistics from the action binding/UI control.【F:LalaLaunch.cs†L3624-L3632】
+- **`[LalaPlugin:ShiftAssist] Sound=Custom path='...'`** — Beep playback currently resolved to a valid custom WAV file path.【F:ShiftAssistAudio.cs†L261-L264】
+- **`[LalaPlugin:ShiftAssist] Sound=EmbeddedDefault path='...'`** — Beep playback resolved to the extracted embedded default WAV.【F:ShiftAssistAudio.cs†L265-L268】
+- **`[LalaPlugin:ShiftAssist] WARNING custom wav missing/invalid, falling back to embedded default`** — Custom WAV was enabled but missing/invalid; warning is emitted once per session and playback falls back to embedded default sound.【F:ShiftAssistAudio.cs†L233-L241】
+- **`[LalaPlugin:ShiftAssist] Embedded default beep resource missing.`** — Embedded WAV resource was unavailable in the assembly; default extraction cannot proceed.【F:ShiftAssistAudio.cs†L105-L110】
+- **`[LalaPlugin:ShiftAssist] Failed to extract embedded beep: ...`** — IO/extraction error while writing the default WAV to disk.【F:ShiftAssistAudio.cs†L72-L85】
+- **`[LalaPlugin:ShiftAssist] Failed to play sound '...': ...`** — Sound playback failed for selected path; shift cue remains logically triggered but audio output failed.【F:ShiftAssistAudio.cs†L175-L182】
+- **`[LalaPlugin:ShiftAssist] HardStop failed: ...`** — Audio stop attempt failed while disabling/muting beeps; logged as warning.【F:ShiftAssistAudio.cs†L192-L200】

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -2,9 +2,9 @@
 
 **CANONICAL CONTRACT**
 
-Validated against: 2a38742  
-Last reviewed: 2026-02-14  
-Last updated: 2026-02-14  
+Validated against: 1617166  
+Last reviewed: 2026-02-16  
+Last updated: 2026-02-16  
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -219,7 +219,12 @@ Branch: work
 | ShiftAssist.DelayAvg_G1..ShiftAssist.DelayAvg_G8 | int | Runtime rolling average beep→upshift delay (ms) per source gear, over last 5 valid samples. | Per tick. | `LalaLaunch.cs` runtime delay tracker + `AttachCore`. |
 | ShiftAssist.DelayN_G1..ShiftAssist.DelayN_G8 | int | Runtime sample count currently included in each per-gear rolling average (0..5). | Per tick. | `LalaLaunch.cs` runtime delay tracker + `AttachCore`. |
 | ShiftAssist.Beep | bool | True during configurable beep latch window (default 250 ms, clamp 100..1000 ms; dash flash fallback/testing). | Per tick. | `LalaLaunch.cs` — beep latch update in `EvaluateShiftAssist` + `AttachCore`. |
+| ShiftAssist.Learn.Enabled | int | Learning mode state exported as `1`/`0` for dash overlays and learning workflows. | Per tick. | `LalaLaunch.cs` settings bridge + `AttachCore`. |
 | ShiftAssist.State | string | Runtime evaluator state (`Off` / `On` / `NoData` / `Cooldown`). | Per tick. | `ShiftAssistEngine.cs` state machine + `LalaLaunch.cs` export. |
+| ShiftAssist.Debug.AudioDelayMs | int | Most recent measured delay between trigger and `SoundPlayer` issue time (ms), clamped and session-local. | Per tick. | `LalaLaunch.cs` — `EvaluateShiftAssist` + `AttachCore`. |
+| ShiftAssist.Debug.AudioDelayAgeMs | int | Age (ms) of `AudioDelayMs`; returns `-1` when no measurement exists yet this session. | Per tick. | `LalaLaunch.cs` — `GetShiftAssistAudioDelayAgeMs` + `AttachCore`. |
+| ShiftAssist.Debug.AudioIssued | bool | Pulse true when an audio issue timestamp is captured this tick. | Per tick. | `LalaLaunch.cs` — `EvaluateShiftAssist` + `AttachCore`. |
+| ShiftAssist.Debug.AudioBackend | string | Current playback backend identifier (`SoundPlayer`). | Per tick. | `LalaLaunch.cs` — `AttachCore`. |
 | ShiftAssist UI gear rows | n/a | Profile storage remains 8 slots, but UI only shows up-shiftable gears `1..(maxForwardGears-1)` where max forward gears comes from `DataCorePlugin.GameData.CarSettings_MaxGears`, then `DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverCarGearNumForward`, then defaults to `8`. | On profile/UI refresh. | `ProfilesManagerViewModel.cs` — `ShiftAssistMaxTargetGears` + `ShiftGearRows`. |
 
 ## Session / Identity


### PR DESCRIPTION
### Motivation
- Bring repository documentation up to date with the PR404-era workspace head and updated Shift Assist behaviour (learning mode, debug telemetry, debug CSV). 
- Ensure canonical contract surfaces (`SimHubParameterInventory.md`, `SimHubLogMessages.md`) match the runtime exports and log lines now present in the code. 
- Refresh UI tooltip inventory, project index, code snapshot, and repo status so docs and metadata reference the current head. 

### Description
- Updated Shift Assist subsystem doc (`Docs/Subsystems/Shift_Assist.md`) to document learning-mode settings, debug-audio-delay telemetry, and debug CSV behaviour. 
- Extended the canonical export inventory (`Docs/SimHubParameterInventory.md`) to include `ShiftAssist.Learn.Enabled` and the `ShiftAssist.Debug.*` telemetry exports. 
- Expanded the log catalogue (`Docs/SimHubLogMessages.md`) with the richer Shift Assist log lines (debug CSV toggle, audio-delay telemetry, richer beep context, CSV write-failure and HardStop warnings). 
- Refreshed `Docs/Plugin_UI_Tooltips.md`, `Docs/Code_Snapshot.md`, `Docs/Project_Index.md`, and `Docs/RepoStatus.md` to reference the current short-head (`1617166`) and note the docs refresh/PR404 context. 
- This is a documentation-only change set; no runtime code changes were made. 

### Testing
- Ran `git diff --stat` and reviewed the diffs for the seven modified docs files, which reported the intended insertions/deletions. (succeeded). 
- Verified working-tree state with `git status --short` and `git rev-parse --short HEAD` to confirm the commit id for the refresh (succeeded). 
- Committed the changes with a descriptive message (`docs: refresh PR404 shift assist documentation set`) and confirmed the commit hash returned by `git` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993587f8e54832fb99c54aee4ff6f75)