### PR TITLE
ShiftAssist: block re-arm during high-RPM pulls, reset learn exports, and add CSV-enabled export

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3734,12 +3734,17 @@ namespace LaunchPlugin
                 }
 
                 SaveSettings();
+                ProfilesViewModel?.RefreshShiftAssistRuntimeStats();
                 SimHub.Logging.Current.Info($"[LalaPlugin:ShiftAssist] Debug CSV toggle action -> Enabled={Settings.EnableShiftAssistDebugCsv}");
             });
             this.AddAction("ShiftAssist_TestBeep", (a, b) => TriggerShiftAssistTestBeep());
             this.AddAction("ShiftAssist_Learn_ResetSamples", (a, b) =>
             {
                 _shiftAssistLearningEngine.ResetSamplesForStack(_shiftAssistActiveGearStackId);
+                _shiftAssistLastLearningTick = new ShiftAssistLearningTick
+                {
+                    State = Settings?.ShiftAssistLearningModeEnabled == true ? ShiftAssistLearningState.Armed : ShiftAssistLearningState.Off
+                };
                 ProfilesViewModel?.RefreshShiftAssistRuntimeStats();
                 SimHub.Logging.Current.Info($"[LalaPlugin:ShiftAssist] Learning samples reset for stack '{_shiftAssistActiveGearStackId}'.");
             });
@@ -4076,6 +4081,7 @@ namespace LaunchPlugin
             AttachCore("ShiftAssist.Debug.AudioDelayAgeMs", () => GetShiftAssistAudioDelayAgeMs());
             AttachCore("ShiftAssist.Debug.AudioIssued", () => _shiftAssistAudioIssuedPulse);
             AttachCore("ShiftAssist.Debug.AudioBackend", () => "SoundPlayer");
+            AttachCore("ShiftAssist.Debug.CsvEnabled", () => Settings?.EnableShiftAssistDebugCsv == true ? 1 : 0);
             AttachCore("ShiftAssist.DelayAvg_G1", () => GetShiftAssistDelayAverageMs(1));
             AttachCore("ShiftAssist.DelayAvg_G2", () => GetShiftAssistDelayAverageMs(2));
             AttachCore("ShiftAssist.DelayAvg_G3", () => GetShiftAssistDelayAverageMs(3));


### PR DESCRIPTION
### Motivation
- Prevent multiple learning samples being recorded during a single continuous acceleration pull by requiring RPM to drop after a captured peak before re-arming for that gear.
- Make the learning-samples reset action immediately visible in exports/UI so users see sample counts and learned RPMs clear right away.
- Expose whether Shift Assist debug CSV logging is enabled via a SimHub export for dashboard/UI visibility.

### Description
- Added a re-arm threshold constant `ReArmRpmDrop = 500` and per-gear runtime fields `LastCapturedPeakRpm` and `RequireRpmReset` to `ShiftAssistLearningEngine`.
- Implemented `SetReArmRequired` on sample accept and `TryClearReArmReset` called each update to clear the require-reset flag when `rpm <= LastCapturedPeakRpm - ReArmRpmDrop`, and blocked arming while `RequireRpmReset` is true.
- Kept all existing window gating, falloff capture, min-samples and beep logic unchanged; only added the re-arm inhibition path.
- Updated `ShiftAssist_Learn_ResetSamples` action to also reset the last learning tick snapshot (`_shiftAssistLastLearningTick`) so `ShiftAssist.Learn.Samples_G1..G8` and `ShiftAssist.Learn.LearnedRpm_G1..G8` reflect zero immediately.
- Added a new export `ShiftAssist.Debug.CsvEnabled` (0/1) and refreshed runtime bindings after toggling the debug CSV setting so the export updates immediately.
- Ensured `ShiftAssist_ResetDelayStats` continues to clear delay backing arrays and the runtime refresh keeps `ShiftAssist.DelayAvg_G1..G8` and `ShiftAssist.DelayN_G1..G8` visible as reset.

### Testing
- Attempted an automated build with `dotnet build LaunchPlugin.sln -c Release`, but the `dotnet` CLI is not available in the current environment so the build could not be executed (failed with `bash: command not found: dotnet`).
- Performed code inspection of affected files and runtime export attachments to verify the new fields, gating calls and export wiring were inserted as intended; no runtime tests were executed due to missing `dotnet` tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699445194680832f9a78f3bb416fc931)