### PR TITLE
Add ShiftAssist per-gear ShiftRPM SimHub exports

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -939,6 +939,16 @@ namespace LaunchPlugin
             return _shiftAssistLearningEngine.GetLearnedRpm(_shiftAssistActiveGearStackId, gear);
         }
 
+        private int GetShiftAssistTargetRpmForGear(int gear)
+        {
+            if (gear < 1 || gear > 8 || ActiveProfile == null)
+            {
+                return 0;
+            }
+
+            return ActiveProfile.GetShiftTargetForGear(_shiftAssistActiveGearStackId, gear);
+        }
+
         private bool GetShiftAssistLockedForGear(int gear)
         {
             if (gear < 1 || gear > 8 || ActiveProfile == null)
@@ -4142,6 +4152,14 @@ namespace LaunchPlugin
 
             AttachCore("ShiftAssist.ActiveGearStackId", () => _shiftAssistActiveGearStackId ?? "Default");
             AttachCore("ShiftAssist.TargetRPM_CurrentGear", () => _shiftAssistTargetCurrentGear);
+            AttachCore("ShiftAssist.ShiftRPM_G1", () => GetShiftAssistTargetRpmForGear(1));
+            AttachCore("ShiftAssist.ShiftRPM_G2", () => GetShiftAssistTargetRpmForGear(2));
+            AttachCore("ShiftAssist.ShiftRPM_G3", () => GetShiftAssistTargetRpmForGear(3));
+            AttachCore("ShiftAssist.ShiftRPM_G4", () => GetShiftAssistTargetRpmForGear(4));
+            AttachCore("ShiftAssist.ShiftRPM_G5", () => GetShiftAssistTargetRpmForGear(5));
+            AttachCore("ShiftAssist.ShiftRPM_G6", () => GetShiftAssistTargetRpmForGear(6));
+            AttachCore("ShiftAssist.ShiftRPM_G7", () => GetShiftAssistTargetRpmForGear(7));
+            AttachCore("ShiftAssist.ShiftRPM_G8", () => GetShiftAssistTargetRpmForGear(8));
             AttachCore("ShiftAssist.EffectiveTargetRPM_CurrentGear", () => _shiftAssistEngine.LastEffectiveTargetRpm);
             AttachCore("ShiftAssist.RpmRate", () => _shiftAssistEngine.LastRpmRate);
             AttachCore("ShiftAssist.Beep", () => _shiftAssistBeepLatched);


### PR DESCRIPTION
### Motivation
- Expose the active gear-stack per-gear shift target RPMs as SimHub core properties so dashboards/skins can read live shift targets.
- Ensure values reflect live changes (learning, UI edits, resets) with minimal code changes and no caching.

### Description
- Added a helper `GetShiftAssistTargetRpmForGear(int gear)` in `LalaLaunch.cs` that resolves the active stack id and returns `0` when `ActiveProfile` is null or the gear is out of range.
- Attached new SimHub core properties `ShiftAssist.ShiftRPM_G1` through `ShiftAssist.ShiftRPM_G8` in `LalaLaunch.cs`, each calling `GetShiftAssistTargetRpmForGear(...)` for live reads.
- Reads are forwarded to the existing `ActiveProfile.GetShiftTargetForGear(...)` implementation, so values come directly from the profile stack and are updated immediately when learning/UI/reset actions modify the profile.

### Testing
- Attempted to build with `dotnet build LaunchPlugin.sln -c Release`, but the `dotnet` SDK was not available in the environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948b1051d8832fbd860d40f550d79f)