### PR TITLE
Improve Shift Assist Phase 3 testing UX and stack runtime controls

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -344,6 +344,19 @@ namespace LaunchPlugin
                 ShiftLocked = correctedLocks;
             }
         }
+
+        public ShiftStackData Clone()
+        {
+            EnsureValidShape();
+            var cloned = new ShiftStackData();
+            for (int i = 0; i < 8; i++)
+            {
+                cloned.ShiftRPM[i] = ShiftRPM[i];
+                cloned.ShiftLocked[i] = ShiftLocked[i];
+            }
+
+            return cloned;
+        }
     }
 
     [JsonObject(MemberSerialization.OptIn)]

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -275,16 +275,16 @@
                             <TextBlock Text="Gear stack selection" FontWeight="SemiBold" Margin="0,10,0,4"/>
                             <Grid>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="150" />
-                                    <ColumnDefinition Width="150" />
-                                    <ColumnDefinition Width="160" />
-                                    <ColumnDefinition Width="120" />
-                                    <ColumnDefinition Width="240" />
+                                    <ColumnDefinition Width="200" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <ComboBox Grid.Column="0" ItemsSource="{Binding ShiftStackIds}" SelectedItem="{Binding SelectedShiftStackId, Mode=TwoWay}" Margin="0,0,8,0" MinWidth="130"/>
-                                <ComboBox Grid.Column="1" ItemsSource="{Binding ShiftStackIds}" SelectedItem="{Binding ShiftCopySourceStackId, Mode=TwoWay}" Margin="0,0,8,0" MinWidth="130"/>
-                                <styles:SHButtonPrimary Grid.Column="2" Content="Add stack from current" Command="{Binding ShiftAddCurrentStackCommand}" Margin="0,0,8,0" />
-                                <styles:SHButtonPrimary Grid.Column="3" Content="Copy from..." Command="{Binding ShiftCopyFromStackCommand}" Margin="0,0,8,0" />
+                                <styles:SHButtonPrimary Grid.Column="1" Content="Add current" Command="{Binding ShiftAddCurrentStackCommand}" Margin="0,0,8,0" ToolTip="Add/select the stack currently reported by live data."/>
+                                <styles:SHButtonPrimary Grid.Column="2" Content="Save As..." Command="{Binding ShiftSaveStackAsCommand}" Margin="0,0,8,0" ToolTip="Duplicate selected stack into a new named stack."/>
+                                <styles:SHButtonSecondary Grid.Column="3" Content="Delete" Command="{Binding ShiftDeleteStackCommand}" Margin="0,0,8,0" ToolTip="Delete selected stack (Default cannot be deleted)."/>
                                 <TextBlock Grid.Column="4" Text="{Binding ActiveShiftStackLabel}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
                             </Grid>
 
@@ -315,6 +315,14 @@
                                 </Border>
                             </DockPanel>
                             <TextBlock Text="{Binding ShiftAssistCurrentGearRedlineHint}" Margin="0,0,0,6" Opacity="0.85"/>
+                            <WrapPanel Margin="0,0,0,8">
+                                <styles:SHButtonSecondary Content="Reset Learning" Command="{Binding ShiftResetLearningCommand}" Margin="0,0,6,6"/>
+                                <styles:SHButtonSecondary Content="Reset Targets" Command="{Binding ShiftResetTargetsCommand}" Margin="0,0,6,6"/>
+                                <styles:SHButtonSecondary Content="Reset Targets + Learning" Command="{Binding ShiftResetTargetsAndLearningCommand}" Margin="0,0,6,6"/>
+                                <styles:SHButtonSecondary Content="Reset Delays" Command="{Binding ShiftResetDelaysCommand}" Margin="0,0,6,6"/>
+                                <styles:SHButtonPrimary Content="Apply Learned (Override Locks)" Command="{Binding ShiftApplyLearnedOverrideCommand}" Margin="0,0,6,6"
+                                                       ToolTip="Testing utility: overwrite active stack targets with learned RPM values. Ignores locks and does not change lock states."/>
+                            </WrapPanel>
                             <TextBlock Text="{Binding ShiftAssistStackLearningStatsNotice}" Margin="0,0,0,6" Foreground="#FFB36B" FontStyle="Italic">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">


### PR DESCRIPTION
### Motivation
- Provide the missing Phase‑3 SHIFT tab controls and simple stack management to enable quick A/B testing and one‑click application of learned RPMs for testing.
- Ensure UI stays in sync with profile data when reset/apply actions run so textboxes do not show stale values.
- Keep existing learning/math logic unchanged and provide a predictable testing-only override that ignores locks but does not modify lock state.

### Description
- UI: added SHIFT tab buttons for `Reset Learning`, `Reset Targets`, `Reset Targets + Learning`, `Reset Delays`, and `Apply Learned (Override Locks)`, and simplified gear stack selector with `Add current`, `Save As...`, and `Delete`. (Files: `ProfilesManagerView.xaml`)
- ViewModel: added commands and logic for stack Save As / Delete (unique name generation + input dialog), made selecting a stack also set the active runtime stack, and added `RefreshShiftAssistTargetTextsFromStack` to update target textbox values in-place without rebuilding rows. (Files: `ProfilesManagerViewModel.cs`)
- Plugin: added glue and actions in the plugin to support the UI: a setter to change the active gear stack at runtime, helper actions for resetting learning/targets/delays, and the new action `ShiftAssist_ApplyLearnedToTargets_ActiveStack_OverrideLocks` that writes learned RPMs into the active stack's targets while ignoring (but not changing) locks, and requests UI refreshes after changes. (Files: `LalaLaunch.cs`)
- Model: added `ShiftStackData.Clone()` helper and used it for safe duplication of stacks. (Files: `CarProfiles.cs`)
- Fix: when targets are reset (or Apply Learned runs) the plugin now triggers a VM in-place refresh so the SHIFT target textboxes immediately reflect cleared/updated values (no stale UI). (Files: `LalaLaunch.cs`, `ProfilesManagerViewModel.cs`)

### Testing
- Attempted an automated build with `dotnet build LaunchPlugin.sln`, but `dotnet` is not available in this environment so compilation could not be performed.
- Attempted an automated build with `msbuild`, but `msbuild` is not available in this environment so compilation could not be performed.
- Performed static verification of the wiring and diffs (command-line inspection of changed files, action names and bindings) to ensure the new commands/actions are registered and bound; no automated unit tests exist for these UI glue changes in the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b5ff1b24832fba7899f5d5871dbb)