### PR TITLE
ShiftAssist UI: make stack selection drive active runtime stack

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -282,7 +282,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <ComboBox Grid.Column="0" ItemsSource="{Binding ShiftStackIds}" SelectedItem="{Binding SelectedShiftStackId, Mode=TwoWay}" Margin="0,0,8,0" MinWidth="130"/>
-                                <styles:SHButtonPrimary Grid.Column="1" Content="Add current" Command="{Binding ShiftAddCurrentStackCommand}" Margin="0,0,8,0" ToolTip="Add/select the stack currently reported by live data."/>
+                                <styles:SHButtonPrimary Grid.Column="1" Content="Add current" Command="{Binding ShiftAddCurrentStackCommand}" Margin="0,0,8,0" ToolTip="Add/select the currently active stack name."/>
                                 <styles:SHButtonPrimary Grid.Column="2" Content="Save As..." Command="{Binding ShiftSaveStackAsCommand}" Margin="0,0,8,0" ToolTip="Duplicate selected stack into a new named stack."/>
                                 <styles:SHButtonSecondary Grid.Column="3" Content="Delete" Command="{Binding ShiftDeleteStackCommand}" Margin="0,0,8,0" ToolTip="Delete selected stack (Default cannot be deleted)."/>
                                 <TextBlock Grid.Column="4" Text="{Binding ActiveShiftStackLabel}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
@@ -323,19 +323,6 @@
                                 <styles:SHButtonPrimary Content="Apply Learned (Override Locks)" Command="{Binding ShiftApplyLearnedOverrideCommand}" Margin="0,0,6,6"
                                                        ToolTip="Testing utility: overwrite active stack targets with learned RPM values. Ignores locks and does not change lock states."/>
                             </WrapPanel>
-                            <TextBlock Text="{Binding ShiftAssistStackLearningStatsNotice}" Margin="0,0,0,6" Foreground="#FFB36B" FontStyle="Italic">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding ShiftAssistStackLearningStatsNotice}" Value="">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-
                             <Grid Grid.IsSharedSizeScope="True">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>


### PR DESCRIPTION
### Motivation
- Eliminate the split-brain between the SHIFT tab dropdown selection and the runtime "active gear stack" so that the dropdown is the single source of truth.
- Ensure all SHIFT actions (reset learning/targets/delays/apply learned) operate on the currently selected stack immediately and UI labels/stats remain in sync.
- Make learning/stats columns always reflect the selected/active stack and remove misleading warning text about "active live stack".

### Description
- `ProfilesManagerViewModel.cs`: added `ExecuteShiftAssistActionOnSelectedStack(Action)` and wired SHIFT commands to call it so each action first sets the runtime active stack to `SelectedShiftStackId`, invokes the action, and refreshes runtime stats/UI.
- `ProfilesManagerViewModel.cs`: removed the selected-vs-active gating for learned/sample display and changed `ShiftAssistStackLearningStatsNotice` to always return an empty string.
- `ProfilesManagerView.xaml`: removed the obsolete learning-mismatch warning block and updated the "Add current" tooltip to reflect the new behavior.
- `LalaLaunch.cs`: stopped overwriting the runtime active stack from telemetry each evaluation tick and consistently use the plugin-controlled active stack (`_shiftAssistActiveGearStackId` / `activeStackId`) for learning updates, applying learned RPMs, and target lookups (ensuring default/trim semantics).

### Testing
- Attempted `dotnet build LaunchPlugin.sln -c Release` but it failed because `dotnet` is not available in this environment (failed).
- Attempted `msbuild LaunchPlugin.sln /p:Configuration=Release` but it failed because `msbuild` is not available in this environment (failed).
- No automated unit tests were executed in this environment due to missing build tooling; code changes were committed locally with message `"ShiftAssist UI: make stack selection drive active runtime stack"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c7bd72c4832fb63e59c970b6e581)