### PR TITLE
Polish SHIFT tab UI and add Shift Light toggle + SimHub export

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -789,6 +789,11 @@ namespace LaunchPlugin
             return value;
         }
 
+        private bool IsShiftAssistLightEnabled()
+        {
+            return Settings?.ShiftAssistLightEnabled != false;
+        }
+
         private int GetShiftAssistLeadTimeMs()
         {
             int value = Settings?.ShiftAssistLeadTimeMs ?? ShiftAssistLeadTimeMsDefault;
@@ -3925,6 +3930,17 @@ namespace LaunchPlugin
                     Settings.ShiftAssistBeepDurationMs = durationMs;
                     SaveSettings();
                 },
+                () => IsShiftAssistLightEnabled(),
+                (enabled) =>
+                {
+                    if (Settings == null)
+                    {
+                        return;
+                    }
+
+                    Settings.ShiftAssistLightEnabled = enabled;
+                    SaveSettings();
+                },
                 () => GetShiftAssistLeadTimeMs(),
                 (leadTimeMs) =>
                 {
@@ -4394,6 +4410,7 @@ namespace LaunchPlugin
             AttachCore("ShiftAssist.EffectiveTargetRPM_CurrentGear", () => _shiftAssistEngine.LastEffectiveTargetRpm);
             AttachCore("ShiftAssist.RpmRate", () => _shiftAssistEngine.LastRpmRate);
             AttachCore("ShiftAssist.Beep", () => _shiftAssistBeepLatched);
+            AttachCore("ShiftAssist.ShiftLightEnabled", () => IsShiftAssistLightEnabled() ? 1 : 0);
             AttachCore("ShiftAssist.Learn.Enabled", () => Settings?.ShiftAssistLearningModeEnabled == true ? 1 : 0);
             AttachCore("ShiftAssist.Learn.State", () => ToLearningStateText(_shiftAssistLastLearningTick?.State ?? ShiftAssistLearningState.Off));
             AttachCore("ShiftAssist.Learn.ActiveGear", () => _shiftAssistLastLearningTick?.ActiveGear ?? 0);
@@ -12681,6 +12698,7 @@ namespace LaunchPlugin
         public bool ShiftAssistEnabled { get; set; } = false;
         public bool ShiftAssistLearningModeEnabled { get; set; } = false;
         public int ShiftAssistBeepDurationMs { get; set; } = LalaLaunch.ShiftAssistBeepDurationMsDefault;
+        public bool ShiftAssistLightEnabled { get; set; } = true;
         public int ShiftAssistLeadTimeMs { get; set; } = LalaLaunch.ShiftAssistLeadTimeMsDefault;
         public bool ShiftAssistBeepSoundEnabled { get; set; } = true;
         public int ShiftAssistBeepVolumePct { get; set; } = 100;

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -226,12 +226,33 @@
                                     <ColumnDefinition Width="24" />
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="120" />
+                                    <ColumnDefinition Width="24" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="120" />
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="Shift Light Duration (ms)" VerticalAlignment="Center" Margin="0,0,8,0"
-                                           ToolTip="Controls how long the ShiftAssist.Beep export remains active. Does not affect WAV playback length."/>
-                                <TextBox Grid.Column="1" Text="{Binding ShiftAssistBeepDurationMs, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                                <TextBlock Grid.Column="3" Text="Lead time (ms)" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                <TextBox Grid.Column="4" Text="{Binding ShiftAssistLeadTimeMs, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                <styles:SHToggleCheckbox Grid.Column="0" Content="Shift Light" IsChecked="{Binding ShiftAssistLightEnabled, Mode=TwoWay}" VerticalAlignment="Center"
+                                                         ToolTip="Controls whether the ShiftAssist.Beep light/export should be considered enabled for dash visibility."/>
+                                <Grid Grid.Column="3" Grid.ColumnSpan="2">
+                                    <Grid.Style>
+                                        <Style TargetType="Grid">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ShiftAssistLightEnabled}" Value="False">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Grid.Style>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="120"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Shift Light Duration (ms)" VerticalAlignment="Center" Margin="0,0,8,0"
+                                               ToolTip="Controls how long the ShiftAssist.Beep export remains active. Does not affect WAV playback length."/>
+                                    <TextBox Grid.Column="1" Text="{Binding ShiftAssistBeepDurationMs, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                </Grid>
+                                <TextBlock Grid.Column="6" Text="Lead time (ms)" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <TextBox Grid.Column="7" Text="{Binding ShiftAssistLeadTimeMs, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
                             </Grid>
 
                             <Grid Margin="0,8,0,0">
@@ -240,23 +261,30 @@
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="16"/>
                                     <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="16"/>
-                                    <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
                                 <styles:SHToggleCheckbox Grid.Column="0" Content="Shift Sound" IsChecked="{Binding ShiftAssistBeepSoundEnabled, Mode=TwoWay}" VerticalAlignment="Center"/>
-                                <styles:SHButtonPrimary Grid.Column="1" Content="Test Sound" Command="{Binding ShiftTestBeepCommand}" Margin="8,0,0,0" MinWidth="90"/>
-                                <TextBlock Grid.Column="3" Text="Muted:" VerticalAlignment="Center" Opacity="0.75"/>
-                                <TextBlock Grid.Column="4" Text="{Binding ShiftAssistBeepMuteStateText}" VerticalAlignment="Center" Opacity="0.75"/>
-                                <Grid Grid.Column="6">
+                                <Grid Grid.Column="1" Grid.ColumnSpan="3">
+                                    <Grid.Style>
+                                        <Style TargetType="Grid">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ShiftAssistBeepSoundEnabled}" Value="False">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Grid.Style>
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="16" />
                                         <ColumnDefinition Width="Auto" />
                                         <ColumnDefinition Width="220" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Text="Beep volume" VerticalAlignment="Center" Margin="0,0,8,0"
+                                    <styles:SHButtonPrimary Grid.Column="0" Content="Test Sound" Command="{Binding ShiftTestBeepCommand}" MinWidth="90"/>
+                                    <TextBlock Grid.Column="2" Text="Beep volume" VerticalAlignment="Center" Margin="0,0,8,0"
                                         ToolTip="Not implemented yet. Uses SimHub master volume."/>
-                                    <Slider Grid.Column="1"
+                                    <Slider Grid.Column="3"
                                         VerticalAlignment="Center"
                                         Minimum="0"
                                         Maximum="100"
@@ -266,7 +294,7 @@
                                         IsEnabled="False"
                                         Opacity="0.6"
                                         ToolTip="Not implemented yet. Uses SimHub master volume."/>
-                                    <TextBlock Grid.Column="2"
+                                    <TextBlock Grid.Column="4"
                                        Text="{Binding ShiftAssistBeepVolumePct, StringFormat={}{0}%}"
                                        VerticalAlignment="Center"
                                        Margin="10,0,0,0"
@@ -328,17 +356,19 @@
                                 <Grid Grid.Row="1" Margin="0,0,0,6">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="122" SharedSizeGroup="GearCol"/>
-                                        <ColumnDefinition Width="86" SharedSizeGroup="TargetCol"/>
+                                        <ColumnDefinition Width="160" SharedSizeGroup="TargetCol"/>
                                         <ColumnDefinition Width="58" SharedSizeGroup="LockCol"/>
-                                        <ColumnDefinition Width="82" SharedSizeGroup="LearnedCol"/>
+                                        <ColumnDefinition Width="220" SharedSizeGroup="LearnedCol"/>
                                         <ColumnDefinition Width="55" SharedSizeGroup="SamplesCol"/>
-                                        <ColumnDefinition Width="76" SharedSizeGroup="DelayCol"/>
+                                        <ColumnDefinition Width="160" SharedSizeGroup="DelayCol"/>
                                         <ColumnDefinition Width="55" SharedSizeGroup="DelaySamplesCol"/>
                                     </Grid.ColumnDefinitions>
                                     <styles:SHButtonSecondary Grid.Column="1" Content="Reset Targets" MinWidth="96" Command="{Binding ShiftResetTargetsCommand}" Margin="0,0,6,0" HorizontalAlignment="Left" Background="#FD7E14" Foreground="White"/>
-                                    <styles:SHButtonSecondary Grid.Column="3" Content="Reset Learning" MinWidth="102" Command="{Binding ShiftResetLearningCommand}" Margin="0,0,6,0" HorizontalAlignment="Left" Background="#FD7E14" Foreground="White"/>
-                                    <styles:SHButtonPrimary Grid.Column="3" Content="Apply Learned (Override Locks)" MinWidth="190" Command="{Binding ShiftApplyLearnedOverrideCommand}" Margin="112,0,6,0" HorizontalAlignment="Left"
+                                    <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Left">
+                                        <styles:SHButtonSecondary Content="Reset Learning" MinWidth="102" Command="{Binding ShiftResetLearningCommand}" Margin="0,0,6,0" HorizontalAlignment="Left" Background="#FD7E14" Foreground="White"/>
+                                        <styles:SHButtonPrimary Content="Apply Learned (Override Locks)" MinWidth="190" Command="{Binding ShiftApplyLearnedOverrideCommand}" HorizontalAlignment="Left"
                                                            ToolTip="Testing utility: overwrite active stack targets with learned RPM values. Ignores locks and does not change lock states."/>
+                                    </StackPanel>
                                     <styles:SHButtonSecondary Grid.Column="5" Content="Reset Delays" MinWidth="92" Command="{Binding ShiftResetDelaysCommand}" Margin="0,0,6,0" HorizontalAlignment="Left" Background="#FD7E14" Foreground="White"/>
                                 </Grid>
                                 <Grid Grid.Row="2" Margin="0,0,0,3">

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -51,6 +51,8 @@ namespace LaunchPlugin
         private readonly Action<bool> _setShiftAssistLearningModeEnabled;
         private readonly Func<int> _getShiftAssistBeepDurationMs;
         private readonly Action<int> _setShiftAssistBeepDurationMs;
+        private readonly Func<bool> _getShiftAssistLightEnabled;
+        private readonly Action<bool> _setShiftAssistLightEnabled;
         private readonly Func<int> _getShiftAssistLeadTimeMs;
         private readonly Action<int> _setShiftAssistLeadTimeMs;
         private readonly Func<bool> _getShiftAssistUseCustomWav;
@@ -595,6 +597,16 @@ namespace LaunchPlugin
             }
         }
 
+        public bool ShiftAssistLightEnabled
+        {
+            get => _getShiftAssistLightEnabled?.Invoke() != false;
+            set
+            {
+                _setShiftAssistLightEnabled?.Invoke(value);
+                OnPropertyChanged();
+            }
+        }
+
         public int ShiftAssistLeadTimeMs
         {
             get => _getShiftAssistLeadTimeMs?.Invoke() ?? 200;
@@ -636,11 +648,8 @@ namespace LaunchPlugin
             {
                 _setShiftAssistBeepSoundEnabled?.Invoke(value);
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(ShiftAssistBeepMuteStateText));
             }
         }
-
-        public string ShiftAssistBeepMuteStateText => ShiftAssistBeepSoundEnabled ? "No" : "Yes";
 
         public int ShiftAssistBeepVolumePct
         {
@@ -1122,7 +1131,7 @@ namespace LaunchPlugin
         public RelayCommand ShiftApplyLearnedOverrideCommand { get; }
 
 
-        public ProfilesManagerViewModel(PluginManager pluginManager, Action<CarProfile> applyProfileToLiveAction, Func<string> getCurrentCarModel, Func<string> getCurrentTrackName, Func<string, TrackMarkersSnapshot> getTrackMarkersSnapshotForKey, Action<string, bool> setTrackMarkersLockForKey, Action reloadTrackMarkersFromDisk, Action<string> resetTrackMarkersForKey, Func<string> getCurrentGearStackId, Action<string> setCurrentGearStackId, Func<bool> getShiftAssistEnabled, Action<bool> setShiftAssistEnabled, Func<bool> getShiftAssistLearningModeEnabled, Action<bool> setShiftAssistLearningModeEnabled, Func<int> getShiftAssistBeepDurationMs, Action<int> setShiftAssistBeepDurationMs, Func<int> getShiftAssistLeadTimeMs, Action<int> setShiftAssistLeadTimeMs, Func<bool> getShiftAssistUseCustomWav, Action<bool> setShiftAssistUseCustomWav, Func<string> getShiftAssistCustomWavPath, Action<string> setShiftAssistCustomWavPath, Func<bool> getShiftAssistBeepSoundEnabled, Action<bool> setShiftAssistBeepSoundEnabled, Func<int> getShiftAssistBeepVolumePct, Action<int> setShiftAssistBeepVolumePct, Action playShiftAssistTestBeep, Action shiftAssistResetLearningAction, Action shiftAssistResetTargetsAction, Action shiftAssistResetTargetsAndLearningAction, Action shiftAssistResetDelayStatsAction, Action shiftAssistApplyLearnedOverrideAction)
+        public ProfilesManagerViewModel(PluginManager pluginManager, Action<CarProfile> applyProfileToLiveAction, Func<string> getCurrentCarModel, Func<string> getCurrentTrackName, Func<string, TrackMarkersSnapshot> getTrackMarkersSnapshotForKey, Action<string, bool> setTrackMarkersLockForKey, Action reloadTrackMarkersFromDisk, Action<string> resetTrackMarkersForKey, Func<string> getCurrentGearStackId, Action<string> setCurrentGearStackId, Func<bool> getShiftAssistEnabled, Action<bool> setShiftAssistEnabled, Func<bool> getShiftAssistLearningModeEnabled, Action<bool> setShiftAssistLearningModeEnabled, Func<int> getShiftAssistBeepDurationMs, Action<int> setShiftAssistBeepDurationMs, Func<bool> getShiftAssistLightEnabled, Action<bool> setShiftAssistLightEnabled, Func<int> getShiftAssistLeadTimeMs, Action<int> setShiftAssistLeadTimeMs, Func<bool> getShiftAssistUseCustomWav, Action<bool> setShiftAssistUseCustomWav, Func<string> getShiftAssistCustomWavPath, Action<string> setShiftAssistCustomWavPath, Func<bool> getShiftAssistBeepSoundEnabled, Action<bool> setShiftAssistBeepSoundEnabled, Func<int> getShiftAssistBeepVolumePct, Action<int> setShiftAssistBeepVolumePct, Action playShiftAssistTestBeep, Action shiftAssistResetLearningAction, Action shiftAssistResetTargetsAction, Action shiftAssistResetTargetsAndLearningAction, Action shiftAssistResetDelayStatsAction, Action shiftAssistApplyLearnedOverrideAction)
         {
             _pluginManager = pluginManager;
             _applyProfileToLiveAction = applyProfileToLiveAction;
@@ -1140,6 +1149,8 @@ namespace LaunchPlugin
             _setShiftAssistLearningModeEnabled = setShiftAssistLearningModeEnabled;
             _getShiftAssistBeepDurationMs = getShiftAssistBeepDurationMs;
             _setShiftAssistBeepDurationMs = setShiftAssistBeepDurationMs;
+            _getShiftAssistLightEnabled = getShiftAssistLightEnabled;
+            _setShiftAssistLightEnabled = setShiftAssistLightEnabled;
             _getShiftAssistLeadTimeMs = getShiftAssistLeadTimeMs;
             _setShiftAssistLeadTimeMs = setShiftAssistLeadTimeMs;
             _getShiftAssistUseCustomWav = getShiftAssistUseCustomWav;


### PR DESCRIPTION
### Motivation
- Clean up and DPI-resilient polish of the SHIFT tab UI: remove the redundant "Muted" helper text and fix mis-sized/misaligned reset buttons without using magic margins.  
- Reduce visual clutter by collapsing irrelevant controls when audio is disabled, and add a controllable Shift Light feature with dashboard visibility export.  
- Expose the Shift Light state to SimHub so dashboards can hide/show a shift light element based on the profile setting.

### Description
- UI: updated `ProfilesManagerView.xaml` to add a `Shift Light` toggle (`styles:SHToggleCheckbox`) that conditionally shows the `Shift Light Duration (ms)` controls while keeping `Lead time (ms)` always visible and aligned.  
- UI: removed the `Muted:` label and bound mute text, placed the `Test Sound` button directly adjacent to the `Shift Sound` toggle, and made everything right of the toggle collapse when `ShiftAssistBeepSoundEnabled` is `false`.  
- Layout: removed the hard-coded push margin for the "Apply Learned" button and reworked the reset button row to use layout containers (`StackPanel`) and `SharedSizeGroup` column sizing to avoid magic margins and improve DPI/theme resilience.  
- ViewModel: added `ShiftAssistLightEnabled` with TwoWay binding in `ProfilesManagerViewModel.cs` and removed the now-unused mute state helper UI property.  
- Plugin core: added `IsShiftAssistLightEnabled()` helper and wired the `ShiftAssistLightEnabled` get/set into `LalaLaunch.cs` constructor plumbing (persisting to `Settings`) and exposed a live SimHub export `ShiftAssist.ShiftLightEnabled` (1/0).  
- Settings: added `ShiftAssistLightEnabled` to persisted settings with default `true` to preserve current behavior.

### Testing
- Searched the modified XAML to confirm removal of the hard-coded margin and the muted helper text using `rg -n "Margin=\"112,0,0,0\"|Muted:" ProfilesManagerView.xaml` which found no matches indicating the old artifacts were removed (success).  
- Verified new binding names and AttachCore export via repository search (`rg`) to ensure `ShiftAssistLightEnabled` is present in `ProfilesManagerView.xaml`, `ProfilesManagerViewModel.cs`, and `LalaLaunch.cs` (success).  
- Attempted to run `dotnet build LaunchPlugin.sln` in this environment but `dotnet` is not available here, so a full build could not be executed (environment limitation).  
- All changes were inspected in-place in the files and wiring was added so the new SimHub property updates live when the toggle changes; runtime verification should be performed in a development environment with `dotnet`/SimHub available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f64c2648832f8ab7ef2519fd2afe)