### PR TITLE
Tighten shift-assist learning RPM gating, add per-gear learnMinRpm and debug fields

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -6894,7 +6894,7 @@ namespace LaunchPlugin
                     if (!File.Exists(_shiftAssistDebugCsvPath))
                     {
                         File.WriteAllText(_shiftAssistDebugCsvPath,
-                            "UtcTime,SessionTimeSec,Gear,MaxForwardGears,Rpm,Throttle01,TargetRpm,EffectiveTargetRpm,RpmRate,LeadTimeMs,BeepTriggered,BeepLatched,EngineState,SuppressDownshift,SuppressUpshift,SpeedMps,AccelDerivedMps2,LonAccelTelemetryMps2,EffectiveGear,LearnEnabled,LearnState,LearnPeakRpm,LearnPeakAccelMps2,LearnSampleAdded,LearnSamplesForGear,LearnLearnedRpmForGear,LearnMinRpm,LearnCapturedRpm,LearnEndReason,LearnRejectedReason,DelayPending,DelayPendingGear,DelayPendingAgeMs,DelayPendingRpmAtCue,DelayPendingTargetGear,DelayPendingDownshiftAgeMs,DelayCapturedMs,DelayCaptureEvent,DelayBeepType,DelayRpmAtBeep,DelayCaptureState" + Environment.NewLine);
+                            "UtcTime,SessionTimeSec,Gear,MaxForwardGears,Rpm,Throttle01,TargetRpm,EffectiveTargetRpm,RpmRate,LeadTimeMs,BeepTriggered,BeepLatched,EngineState,SuppressDownshift,SuppressUpshift,SpeedMps,AccelDerivedMps2,LonAccelTelemetryMps2,EffectiveGear,LearnEnabled,LearnState,LearnPeakRpm,LearnPeakAccelMps2,LearnSampleAdded,LearnSamplesForGear,LearnLearnedRpmForGear,LearnMinRpm,LearnCaptureMinRpm,LearnCapturedRpm,LearnEndReason,LearnRejectedReason,DelayPending,DelayPendingGear,DelayPendingAgeMs,DelayPendingRpmAtCue,DelayPendingTargetGear,DelayPendingDownshiftAgeMs,DelayCapturedMs,DelayCaptureEvent,DelayBeepType,DelayRpmAtBeep,DelayCaptureState" + Environment.NewLine);
                     }
                 }
 
@@ -6905,6 +6905,7 @@ namespace LaunchPlugin
                 int learnSamplesForGear = learningTick?.SamplesForGear ?? 0;
                 int learnLearnedRpmForGear = learningTick?.LearnedRpmForGear ?? 0;
                 int learnMinRpm = learningTick?.LearnMinRpm ?? 0;
+                int learnCaptureMinRpm = learningTick?.LearnCaptureMinRpm ?? 0;
                 int learnCapturedRpm = learningTick?.LearnCapturedRpm ?? 0;
                 string learnEndReason = !string.IsNullOrWhiteSpace(learningTick?.LearnEndReason) ? learningTick.LearnEndReason : "NONE";
                 string learnRejectedReason = !string.IsNullOrWhiteSpace(learningTick?.LearnRejectedReason) ? learningTick.LearnRejectedReason : "NONE";
@@ -6927,7 +6928,7 @@ namespace LaunchPlugin
 
                 var line = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0:o},{1},{2},{3},{4},{5:F4},{6},{7},{8},{9},{10},{11},{12},{13},{14},{15:F4},{16:F4},{17:F4},{18},{19},{20},{21},{22:F4},{23},{24},{25},{26},{27},{28},{29},{30},{31},{32},{33},{34},{35},{36},{37},{38},{39},{40}",
+                    "{0:o},{1},{2},{3},{4},{5:F4},{6},{7},{8},{9},{10},{11},{12},{13},{14},{15:F4},{16:F4},{17:F4},{18},{19},{20},{21},{22:F4},{23},{24},{25},{26},{27},{28},{29},{30},{31},{32},{33},{34},{35},{36},{37},{38},{39},{40},{41}",
                     nowUtc,
                     sessionTimeSec.ToString("F3", CultureInfo.InvariantCulture),
                     gear,
@@ -6955,6 +6956,7 @@ namespace LaunchPlugin
                     learnSamplesForGear,
                     learnLearnedRpmForGear,
                     learnMinRpm,
+                    learnCaptureMinRpm,
                     learnCapturedRpm,
                     learnEndReason,
                     learnRejectedReason,

--- a/ShiftAssistLearningEngine.cs
+++ b/ShiftAssistLearningEngine.cs
@@ -27,6 +27,7 @@ namespace LaunchPlugin
         public int ApplyGear { get; set; }
         public int ApplyRpm { get; set; }
         public int LearnMinRpm { get; set; }
+        public int LearnCaptureMinRpm { get; set; }
         public int LearnCapturedRpm { get; set; }
         public string LearnEndReason { get; set; }
         public string LearnRejectedReason { get; set; }
@@ -84,6 +85,7 @@ namespace LaunchPlugin
                 PeakRpm = _samplingPeakRpm,
                 LastSampleRpm = _lastTick.LastSampleRpm,
                 LearnMinRpm = learnMinRpm,
+                LearnCaptureMinRpm = captureMinRpm,
                 LearnCapturedRpm = _samplingCapturedRpm
             };
 
@@ -147,6 +149,7 @@ namespace LaunchPlugin
                 tick.ActiveGear = _samplingGear;
 
                 tick.LearnMinRpm = _samplingLearnMinRpm;
+                tick.LearnCaptureMinRpm = _samplingCaptureMinRpm;
                 bool samplingRpmReady = rpm >= _samplingLearnMinRpm;
                 if (samplingRpmReady)
                 {
@@ -267,8 +270,8 @@ namespace LaunchPlugin
             bool validPeak = IsFinite(_samplingPeakAccel) && _samplingPeakAccel > 0.0;
             int sampleRpm = _samplingCapturedRpm > 0 ? _samplingCapturedRpm : _samplingLastObservedRpm;
             bool validRpm = sampleRpm >= MinSaneRpm && sampleRpm <= MaxSaneRpm;
-            bool capturedInLearnWindow = _samplingCapturedRpm >= _samplingLearnMinRpm && _samplingCapturedRpm <= MaxSaneRpm;
-            bool gateEndWithoutValidCapture = string.Equals(endReason, "GateEnd", StringComparison.OrdinalIgnoreCase) && !capturedInLearnWindow;
+            bool capturedInCaptureWindow = _samplingCapturedRpm >= _samplingCaptureMinRpm && _samplingCapturedRpm <= MaxSaneRpm;
+            bool gateEndWithoutValidCapture = string.Equals(endReason, "GateEnd", StringComparison.OrdinalIgnoreCase) && !capturedInCaptureWindow;
 
             var gearData = _samplingGear >= 1 && _samplingGear <= GearCount ? stack.Gears[_samplingGear - 1] : null;
             bool outlierRejected = false;
@@ -400,6 +403,7 @@ namespace LaunchPlugin
             _lastTick.ApplyGear = tick.ApplyGear;
             _lastTick.ApplyRpm = tick.ApplyRpm;
             _lastTick.LearnMinRpm = tick.LearnMinRpm;
+            _lastTick.LearnCaptureMinRpm = tick.LearnCaptureMinRpm;
             _lastTick.LearnCapturedRpm = tick.LearnCapturedRpm;
             _lastTick.LearnEndReason = tick.LearnEndReason;
             _lastTick.LearnRejectedReason = tick.LearnRejectedReason;


### PR DESCRIPTION
### Motivation
- Prevent low-RPM false learning during isolated acceleration pulls by requiring a per-gear minimum RPM and tightening capture gating. 
- Provide richer diagnostics for debugging learning decisions and preserve existing re-arm/reset behaviour (`ReArmRpmDrop`).

### Description
- Added per-gear learn minimum RPM computed as `learnMinRpm = max(LearnMinRpmFloor, round(redlineRpmForGear * LearnMinRpmRedlineRatio))` with constants `LearnMinRpmFloor = 4500` and `LearnMinRpmRedlineRatio = 0.75`, implemented in `ComputeLearnMinRpm` and stored on the tick as `LearnMinRpm`.
- Updated `ShiftAssistLearningEngine.Update(...)` signature to accept `redlineRpmForGear` and wired the current redline from `LalaLaunch` into the call; preserved existing `ReArmRpmDrop` behavior.
- Require `rpm >= learnMinRpm` to arm sampling and to allow any in-sample peak / falloff / capture updates so low-RPM pulls do not activate learning state prematurely.
- Tightened capture gating: require `ticksSincePeak >= 4` (constant `MinTicksSincePeakForCapture`) before capture is allowed and raise delayed-rise threshold to `peakRpm + 250` (constant `DelayedRiseRpmAbovePeak`).
- If sampling ends due to throttle/brake drop (gate end), reject the sample unless a valid captured RPM exists and is within the learn window; added `LearnEndReason` and `LearnRejectedReason` to the tick to explain why a sample was accepted/rejected.
- Exposed new diagnostics on `ShiftAssistLearningTick`: `LearnMinRpm`, `LearnCapturedRpm`, `LearnEndReason`, and `LearnRejectedReason` and extended the shift-assist debug CSV to include `LearnMinRpm`, `LearnCapturedRpm`, `LearnEndReason`, `LearnRejectedReason` while keeping existing columns stable and in order.

### Testing
- Attempted an automated build with `dotnet build LaunchPlugin.sln -v minimal`, but `dotnet` is not available in this environment so a full compile/test could not be run (build attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f692b80c832fa695325d9c447924)