### PR TITLE
docs: refresh PR426 shift-assist documentation set

### DIFF
--- a/Docs/Code_Snapshot.md
+++ b/Docs/Code_Snapshot.md
@@ -2,8 +2,8 @@
 
 # Code Snapshot
 
-- Source commit/PR: 5f3630c (post-PR418 workspace head)
-- Generated date: 2026-02-17
+- Source commit/PR: 7318ff6 (post-PR426 workspace head)
+- Generated date: 2026-02-19
 - Regeneration: manual snapshot; no regen pipeline defined
 - Branch: work
 
@@ -14,7 +14,7 @@ If this conflicts with `Project_Index.md` or canonical contract docs, treat this
 - Shift Assist is now a first-class subsystem: runtime evaluator (`ShiftAssistEngine`), audio resolver/player (`ShiftAssistAudio`), settings plumbing in `LaunchPluginSettings`, per-tick exports, action bindings, and delay telemetry capture for tuning.
 - Canonical signal and log contracts are maintained in `SimHubParameterInventory.md` and `SimHubLogMessages.md`; this file is a quick orientation snapshot only.
 
-## Since PR418 (docs refresh delta)
+## Since PR426 (docs refresh delta)
 - Refreshed canonical docs metadata and validation hashes to the current workspace head/date.
 - Updated Shift Assist subsystem documentation for learning state/samples/lock exports, active-stack reset/lock actions, and per-gear ShiftRPM exports.
 - Synced Shift Assist inventory/log docs with current exports and log lines (including debug CSV toggle and audio-delay telemetry).

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -1,7 +1,7 @@
 # Plugin UI Tooltips
 
-Validated against commit: 5f3630c  
-Last updated: 2026-02-17  
+Validated against commit: 7318ff6
+Last updated: 2026-02-19
 Branch: work
 
 ## CopyProfileDialog.xaml
@@ -268,12 +268,15 @@ Branch: work
 - L775: Computed deltas between wet and dry averages for this track.
 
 ## Shift Assist controls
-- `ProfilesManagerView.xaml` L211: `Enable Shift Assist` toggle exists without a tooltip string.
-- `ProfilesManagerView.xaml` L212-L213: `Learning mode` tooltip enables shift-point learning data mining and learning overlay exports.
-- `ProfilesManagerView.xaml` L223-L224: `Shift Light Duration (ms)` tooltip explains it controls `ShiftAssist.Beep` latch window only.
-- `ProfilesManagerView.xaml` L226-L227: `Lead time (ms)` label/textbox exist without tooltip text.
-- `ProfilesManagerView.xaml` L230: `Beep sound` toggle exists without a tooltip string.
-- `ProfilesManagerView.xaml` L237-L248: `Beep volume` label/slider tooltip notes volume control is not implemented yet (SimHub master volume used).
-- `ProfilesManagerView.xaml` L257-L319: gear stack selection/copy, target grid, and custom sound controls mostly have no tooltip strings.
+- `ProfilesManagerView.xaml` L219: `Enable Shift Assist` toggle exists without a tooltip string.
+- `ProfilesManagerView.xaml` L220-L221: `Learning mode` tooltip explains shift-point data mining and learning-overlay visibility.
+- `ProfilesManagerView.xaml` L234-L238: `Shift Light` toggle has tooltip clarifying it gates `ShiftAssist.Beep` dash visibility/export semantics.
+- `ProfilesManagerView.xaml` L240-L244: `Shift Light Duration (ms)` tooltip clarifies this controls the `ShiftAssist.Beep` latch only, not WAV playback length.
+- `ProfilesManagerView.xaml` L290: `Shift Sound` toggle exists without a tooltip string.
+- `ProfilesManagerView.xaml` L309: `Test Sound` button exists without a tooltip string.
+- `ProfilesManagerView.xaml` L310-L321: `Beep volume` label/slider tooltip notes volume control is not implemented yet (SimHub master volume used).
+- `ProfilesManagerView.xaml` L331-L345: gear stack selector + Add/Save/Delete buttons include tooltips on action buttons, but selector itself has no tooltip.
+- `ProfilesManagerView.xaml` L347-L423: shift target grid and learning/runtime stat panel are mostly label-only with no tooltip strings.
+- `ProfilesManagerView.xaml` L433-L492: custom WAV controls include tooltip on path textbox and browse button, while some adjacent labels/buttons remain tooltip-free.
 - `GlobalSettingsView.xaml` L191-L195: `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
 - `GlobalSettingsView.xaml` L196-L200: `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
-Validated against commit: 5f3630c  
-Last updated: 2026-02-17  
+Validated against commit: 7318ff6
+Last updated: 2026-02-19
 Branch: work
 
 ## What this repo is
@@ -36,6 +36,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 | Dash integration | Main/message/overlay visibility and screen state exports | [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## Freshness
-- Validated against commit: 5f3630c  
-- Date: 2026-02-17  
+- Validated against commit: 7318ff6
+- Date: 2026-02-19
 - Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,13 +1,13 @@
 # Repository status
 
-Validated against commit: 5f3630c  
-Last updated: 2026-02-17  
+Validated against commit: 7318ff6
+Last updated: 2026-02-19
 Branch: work
 
 ## Current repo/link status
 - Local branch present: `work`.
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
-- HEAD includes post-PR418 updates, including Shift Assist learning controls, lock/reset actions, per-gear ShiftRPM exports, and debug visibility toggles.
+- HEAD includes post-PR426 updates, including Shift Assist learning controls, lock/reset actions, per-gear ShiftRPM exports, and debug visibility toggles.
 
 ## Documentation sync status (requested set)
 - `SimHubParameterInventory.md` — refreshed to current head/date and includes Shift Assist export inventory.
@@ -15,12 +15,12 @@ Branch: work
 - `Code_Snapshot.md` — regenerated as non-canonical orientation snapshot for current head.
 - `Plugin_UI_Tooltips.md` — refreshed in-repo tooltip inventory (line references + Shift Assist control section).
 - `Project_Index.md` — updated subsystem map and canonical entry points with Shift Assist subsystem doc link.
-- `Subsystems/Shift_Assist.md` — added in the standard subsystem format.
+- `Subsystems/Shift_Assist.md` — refreshed in the standard subsystem format with latest export/log coverage.
 
 ## Delivery status highlights
 - Shift Assist subsystem: **INTEGRATED** (settings, evaluation, audio, exports, logs, delay telemetry).
 - Declutter mode + event marker actions: **COMPLETE** (post-PR381 baseline retained).
-- Canonical docs listed above: **SYNCED** to `5f3630c`.
+- Canonical docs listed above: **SYNCED** to `7318ff6`.
 
 ## Notes
 - `Code_Snapshot.md` remains intentionally non-canonical; contract truth lives in parameter/log inventories and subsystem docs.

--- a/Docs/SimHubLogMessages.md
+++ b/Docs/SimHubLogMessages.md
@@ -2,9 +2,9 @@
 
 **CANONICAL OBSERVABILITY MAP**
 
-Validated against: 5f3630c  
-Last reviewed: 2026-02-17  
-Last updated: 2026-02-17  
+Validated against: 7318ff6
+Last reviewed: 2026-02-19
+Last updated: 2026-02-19
 Branch: work
 
 Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
@@ -177,17 +177,18 @@ Scope: Info-level logs emitted via `SimHub.Logging.Current.Info(...)`. Use the t
 - **`[LalaPlugin:ShiftAssist] Learning samples reset for stack '...'.`** — Action binding cleared retained learning samples for the active stack and re-armed learning state where applicable.【F:LalaLaunch.cs†L3834-L3845】
 - **`[LalaPlugin:ShiftAssist] ShiftAssist_ResetTargets_ActiveStack stack='...' changed=true/false`** — Action binding reset active-stack targets to defaults (without clearing learning samples); reports whether any profile row changed.【F:LalaLaunch.cs†L1029-L1062】【F:LalaLaunch.cs†L3847-L3848】
 - **`[LalaPlugin:ShiftAssist] ShiftAssist_ResetTargets_ActiveStack_AndSamples stack='...' changed=true/false`** — Action binding reset active-stack targets and then cleared learning samples for that stack.【F:LalaLaunch.cs†L1029-L1062】【F:LalaLaunch.cs†L3849-L3858】
+- **`[LalaPlugin:ShiftAssist] ShiftAssist_ApplyLearnedToTargets_ActiveStack_OverrideLocks stack='...' changed=true/false`** — Action binding writes learned RPM values into active-stack targets (ignoring lock state) and reports whether profile rows changed.
 - **`[LalaPlugin:ShiftAssist] ShiftAssist_Lock_G1..G8/ShiftAssist_Unlock_G1..G8/ShiftAssist_ToggleLock_G1..G8 stack='...' gear=G# locked=true/false`** — Lock actions force or toggle per-gear learning lock state on the active gear stack profile row.【F:LalaLaunch.cs†L997-L1015】【F:LalaLaunch.cs†L3859-L3882】
 - **`[LalaPlugin:ShiftAssist] Test beep triggered (duration=...ms)`** — UI test button fired a manual confirmation beep and latch window.【F:LalaLaunch.cs†L5844-L5871】
 - **`[LalaPlugin:ShiftAssist] Beep type=primary/urgent gear=... rawGear=... maxForwardGears=... target=... redline=... effectiveTarget=... rpm=... rpmRate=... leadMs=... throttle=... suppressDown=... suppressUp=...`** — Normal runtime shift cue fired and includes full trigger context for tuning lead-time, gear interpretation, and suppression behavior.【F:LalaLaunch.cs†L6072-L6110】
 - **`[LalaPlugin:ShiftAssist] Delay sample captured gear=... delayMs=... avgMs=...`** — Beep-to-upshift timing sample accepted into the rolling per-gear delay averages.【F:LalaLaunch.cs†L5957-L5975】
 - **`[LalaPlugin:ShiftAssist] AudioDelayMs=... backend=SoundPlayer`** — Optional telemetry log (when debug CSV mode is enabled) recording trigger-to-audio-issue latency.【F:LalaLaunch.cs†L6082-L6089】
 - **`[LalaPlugin:ShiftAssist] Debug CSV disabled for session after write failure path='...' error='...'`** — Debug CSV writer hit an IO/write error and self-disabled for the remainder of the session.【F:LalaLaunch.cs†L6306-L6310】
-- **`[LalaPlugin:ShiftAssist] Delay stats reset via action.`** — Manual reset of all runtime delay statistics from the action binding/UI control.【F:LalaLaunch.cs†L3624-L3632】
+- **`[LalaPlugin:ShiftAssist] Delay stats reset.`** — Manual reset of all runtime delay statistics from the action binding/UI control.【F:LalaLaunch.cs†L3624-L3632】
 - **`[LalaPlugin:ShiftAssist] Sound=Custom path='...'`** — Beep playback currently resolved to a valid custom WAV file path.【F:ShiftAssistAudio.cs†L261-L264】
 - **`[LalaPlugin:ShiftAssist] Sound=EmbeddedDefault path='...'`** — Beep playback resolved to the extracted embedded default WAV.【F:ShiftAssistAudio.cs†L265-L268】
 - **`[LalaPlugin:ShiftAssist] WARNING custom wav missing/invalid, falling back to embedded default`** — Custom WAV was enabled but missing/invalid; warning is emitted once per session and playback falls back to embedded default sound.【F:ShiftAssistAudio.cs†L233-L241】
-- **`[LalaPlugin:ShiftAssist] Embedded default beep resource stream missing.`** — Embedded WAV resource was unavailable in the assembly; default extraction cannot proceed.【F:ShiftAssistAudio.cs†L105-L110】
+- **`[LalaPlugin:ShiftAssist] Embedded default beep resource stream missing.`** / **`[LalaPlugin:ShiftAssist] Embedded default beep resource missing.`** — Embedded WAV resource was unavailable in the assembly; default extraction cannot proceed.
 - **`[LalaPlugin:ShiftAssist] Failed to extract embedded beep: ...`** — IO/extraction error while writing the default WAV to disk.【F:ShiftAssistAudio.cs†L72-L85】
 - **`[LalaPlugin:ShiftAssist] Failed to play sound '...': ...`** — Sound playback failed for selected path; shift cue remains logically triggered but audio output failed.【F:ShiftAssistAudio.cs†L175-L182】
 - **`[LalaPlugin:ShiftAssist] HardStop failed: ...`** — Audio stop attempt failed while disabling/muting beeps; logged as warning.【F:ShiftAssistAudio.cs†L192-L200】

--- a/Docs/SimHubParameterInventory.md
+++ b/Docs/SimHubParameterInventory.md
@@ -2,9 +2,9 @@
 
 **CANONICAL CONTRACT**
 
-Validated against: 5f3630c  
-Last reviewed: 2026-02-17  
-Last updated: 2026-02-17  
+Validated against: 7318ff6
+Last reviewed: 2026-02-19
+Last updated: 2026-02-19
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -218,6 +218,7 @@ Branch: work
 | ShiftAssist.EffectiveTargetRPM_CurrentGear | int | Effective target RPM after predictive lead-time adjustment, using the same chosen target source as `ShiftAssist.TargetRPM_CurrentGear` (profile target or redline fallback). | Per tick. | `ShiftAssistEngine.cs` predictive evaluator + `LalaLaunch.cs` export. |
 | ShiftAssist.RpmRate | int | RPM/sec estimate used by predictive cueing; `0` when unavailable/guarded. | Per tick. | `ShiftAssistEngine.cs` predictive evaluator + `LalaLaunch.cs` export. |
 | ShiftAssist.Beep | bool | True during configurable beep latch window (default 250 ms, clamp 100..1000 ms; dash flash fallback/testing). | Per tick. | `LalaLaunch.cs` — beep latch update in `EvaluateShiftAssist` + `AttachCore`. |
+| ShiftAssist.ShiftLightEnabled | int | `1` when Shift Light visibility/export is enabled in profile settings, else `0`; used by dashboards to gate ShiftAssist flash cues independently of audio. | Per tick. | `LalaLaunch.cs` settings bridge + `AttachCore`. |
 | ShiftAssist.Learn.Enabled | int | Learning mode state exported as `1`/`0` for dash overlays and learning workflows. | Per tick. | `LalaLaunch.cs` settings bridge + `AttachCore`. |
 | ShiftAssist.Learn.State | string | Learning state machine state (`Off`, `Armed`, `Sampling`, `Complete`, `Rejected`). | Per tick. | `ShiftAssistLearningEngine.cs` tick state + `LalaLaunch.cs` export. |
 | ShiftAssist.Learn.ActiveGear | int | Source gear currently being sampled by learning mode (`0` when inactive). | Per tick. | `ShiftAssistLearningEngine.cs` tick output + `LalaLaunch.cs` export. |
@@ -236,6 +237,12 @@ Branch: work
 | ShiftAssist.Debug.CsvEnabled | int | Reflects runtime debug CSV toggle state (`1`/`0`) for dashboard visibility and quick troubleshooting. | Per tick. | `LalaLaunch.cs` settings bridge + `AttachCore`. |
 | ShiftAssist.DelayAvg_G1..ShiftAssist.DelayAvg_G8 | int | Runtime rolling average beep→upshift delay (ms) per source gear, over last 5 valid samples. | Per tick. | `LalaLaunch.cs` runtime delay tracker + `AttachCore`. |
 | ShiftAssist.DelayN_G1..ShiftAssist.DelayN_G8 | int | Runtime sample count currently included in each per-gear rolling average (0..5). | Per tick. | `LalaLaunch.cs` runtime delay tracker + `AttachCore`. |
+| ShiftAssist.Delay.Pending | int | `1` while a primary-beep delay capture window is armed awaiting a qualifying upshift sample; otherwise `0`. | Per tick. | `LalaLaunch.cs` pending delay tracker + `AttachCore`. |
+| ShiftAssist.Delay.PendingGear | int | Source gear currently armed for pending delay capture (`0` when no capture is armed). | Per tick. | `LalaLaunch.cs` pending delay tracker + `AttachCore`. |
+| ShiftAssist.Delay.PendingAgeMs | int | Elapsed milliseconds since pending delay capture was armed (`-1` when inactive). | Per tick. | `LalaLaunch.cs` pending delay timer helper + `AttachCore`. |
+| ShiftAssist.Delay.PendingRpmAtCue | int | RPM captured at the moment the pending delay window was armed. | Per tick. | `LalaLaunch.cs` pending delay tracker + `AttachCore`. |
+| ShiftAssist.Delay.RpmAtBeep | int | Last latched RPM at beep trigger time (primary beep path). | Per tick. | `LalaLaunch.cs` beep/delay diagnostics latch + `AttachCore`. |
+| ShiftAssist.Delay.CaptureState | int | Encoded capture state for delay diagnostics (`0` none, `1` arm, `2` capture, `3` timeout, `4` cancelled/downshift). | Per tick. | `LalaLaunch.cs` delay diagnostics mapper + `AttachCore`. |
 | ShiftAssist UI gear rows | n/a | Profile storage remains 8 slots, but UI only shows up-shiftable gears `1..(maxForwardGears-1)` where max forward gears comes from `DataCorePlugin.GameData.CarSettings_MaxGears`, then `DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverCarGearNumForward`, then defaults to `8`. | On profile/UI refresh. | `ProfilesManagerViewModel.cs` — `ShiftAssistMaxTargetGears` + `ShiftGearRows`. |
 
 ## Session / Identity

--- a/Docs/Subsystems/Shift_Assist.md
+++ b/Docs/Subsystems/Shift_Assist.md
@@ -1,7 +1,7 @@
 # Shift Assist
 
-Validated against commit: 5f3630c  
-Last updated: 2026-02-17  
+Validated against commit: 7318ff6
+Last updated: 2026-02-19
 Branch: work
 
 ## Purpose
@@ -29,8 +29,8 @@ Branch: work
 6) On subsequent upshift, compute beep→shift delay sample and update rolling per-gear averages.
 
 ## Outputs (exports + logs)
-- Exports: `ShiftAssist.ActiveGearStackId`, `ShiftAssist.TargetRPM_CurrentGear`, `ShiftAssist.ShiftRPM_G1..G8`, `ShiftAssist.EffectiveTargetRPM_CurrentGear`, `ShiftAssist.RpmRate`, `ShiftAssist.Beep`, `ShiftAssist.Learn.Enabled`, `ShiftAssist.Learn.State`, `ShiftAssist.Learn.ActiveGear`, `ShiftAssist.Learn.WindowMs`, `ShiftAssist.Learn.PeakAccelMps2`, `ShiftAssist.Learn.PeakRpm`, `ShiftAssist.Learn.LastSampleRpm`, `ShiftAssist.Learn.SavedPulse`, `ShiftAssist.Learn.Samples_G1..G8`, `ShiftAssist.Learn.LearnedRpm_G1..G8`, `ShiftAssist.Learn.Locked_G1..G8`, `ShiftAssist.State`, `ShiftAssist.Debug.AudioDelayMs`, `ShiftAssist.Debug.AudioDelayAgeMs`, `ShiftAssist.Debug.AudioIssued`, `ShiftAssist.Debug.AudioBackend`, `ShiftAssist.Debug.CsvEnabled`, `ShiftAssist.DelayAvg_G1..G8`, `ShiftAssist.DelayN_G1..G8`.
-- Logs: enable/toggle/debug-csv transitions, learning reset, active-stack reset/lock action outcomes, beep trigger context (including urgent/primary type and suppression flags), test beep, delay sample capture/reset, optional audio-delay telemetry, custom/default sound choice, and audio warning/error paths.
+- Exports: `ShiftAssist.ActiveGearStackId`, `ShiftAssist.TargetRPM_CurrentGear`, `ShiftAssist.ShiftRPM_G1..G8`, `ShiftAssist.EffectiveTargetRPM_CurrentGear`, `ShiftAssist.RpmRate`, `ShiftAssist.Beep`, `ShiftAssist.ShiftLightEnabled`, `ShiftAssist.Learn.Enabled`, `ShiftAssist.Learn.State`, `ShiftAssist.Learn.ActiveGear`, `ShiftAssist.Learn.WindowMs`, `ShiftAssist.Learn.PeakAccelMps2`, `ShiftAssist.Learn.PeakRpm`, `ShiftAssist.Learn.LastSampleRpm`, `ShiftAssist.Learn.SavedPulse`, `ShiftAssist.Learn.Samples_G1..G8`, `ShiftAssist.Learn.LearnedRpm_G1..G8`, `ShiftAssist.Learn.Locked_G1..G8`, `ShiftAssist.State`, `ShiftAssist.Debug.AudioDelayMs`, `ShiftAssist.Debug.AudioDelayAgeMs`, `ShiftAssist.Debug.AudioIssued`, `ShiftAssist.Debug.AudioBackend`, `ShiftAssist.Debug.CsvEnabled`, `ShiftAssist.DelayAvg_G1..G8`, `ShiftAssist.DelayN_G1..G8`, `ShiftAssist.Delay.Pending`, `ShiftAssist.Delay.PendingGear`, `ShiftAssist.Delay.PendingAgeMs`, `ShiftAssist.Delay.PendingRpmAtCue`, `ShiftAssist.Delay.RpmAtBeep`, `ShiftAssist.Delay.CaptureState`.
+- Logs: enable/toggle/debug-csv transitions, learning reset, active-stack reset/lock/apply-learned action outcomes, beep trigger context (including urgent/primary type and suppression flags), test beep, delay sample capture/reset, optional audio-delay telemetry, custom/default sound choice, and audio warning/error paths.
 
 ## Dependencies / ordering assumptions
 - Runs from `LalaLaunch.DataUpdate` once per tick after settings/profile resolution.


### PR DESCRIPTION
### Motivation
- Bring the documentation set up to date following the PR426 changes so the Shift Assist subsystem, SIMHub contracts, UI tooltips, project index, code snapshot, and repo status reflect the current workspace head and behaviour. 
- Ensure dashboards and integrators can discover the new Shift Assist exports and delay diagnostics added to runtime exports and logging. 
- Consolidate tooltip coverage and log-message entries so observability and UX notes match the XAML/UI and runtime implementations.

### Description
- Updated canonical validation metadata and timestamps across the docs set to reference the current workspace head and date (`7318ff6`, `2026-02-19`).
- Expanded the Shift Assist docs and parameter inventory to publish `ShiftAssist.ShiftLightEnabled` and the new delay diagnostic exports (`ShiftAssist.Delay.Pending`, `ShiftAssist.Delay.PendingGear`, `ShiftAssist.Delay.PendingAgeMs`, `ShiftAssist.Delay.PendingRpmAtCue`, `ShiftAssist.Delay.RpmAtBeep`, `ShiftAssist.Delay.CaptureState`) and retained the per-gear delay averages/counters. 
- Updated the SimHub log-message catalogue to include the apply-learned action entry, consolidated wording for delay-reset logging, and harmonised embedded-resource missing variants and debug CSV log lines. 
- Refreshed `Plugin_UI_Tooltips.md`, `Code_Snapshot.md`, `Project_Index.md`, and `RepoStatus.md` to reflect the current XAML layout, tooltip coverage, and the post-PR426 repository state.

### Testing
- Ran whitespace and diff checks (`git diff --check`) and trimmed trailing whitespace, with the check succeeding after fixes. (pass)
- Validated presence of the new entries using pattern searches (`rg -n "ShiftAssist\.Delay\.Pending|ShiftAssist\.ShiftLightEnabled|ShiftAssist_ApplyLearnedToTargets_ActiveStack_OverrideLocks|post-PR426|Validated against commit: 7318ff6"`) across the refreshed docs, confirming expected text is present. (pass)
- Performed a repo status/verification pass to ensure the modified documentation files are staged and recorded in the working tree; the change is documentation-only and no runtime code paths were modified. (pass)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971f53cd88832fb3a6d857a897a177)