### PR TITLE
Fix ShiftAssist learning redline feed for replay/live telemetry

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -10210,8 +10210,14 @@ namespace LaunchPlugin
 
             if (targetRpm > 0)
             {
-                source = "TargetRpmFallback";
-                return targetRpm;
+                if (targetRpm >= 5000 && targetRpm <= 15000)
+                {
+                    source = "TargetRpmFallback";
+                    return targetRpm;
+                }
+
+                source = "TargetRpmFallbackRejected";
+                return 0;
             }
 
             return 0;


### PR DESCRIPTION
### Motivation

- Ensure ShiftAssist learning receives a usable redline RPM during both replay and live sessions so `LearnRedlineRpm` is non-zero when data is available and clamping can operate correctly.
- Provide visibility into which telemetry property supplied the redline via debug CSV so diagnostics are easier when values differ between live/replay.

### Description

- Added `ResolveShiftAssistRedlineRpm(PluginManager,int,out string)` that probes telemetry in priority order: `DataCorePlugin.GameData.CarSettings_CurrentGearRedLineRPM`, `DataCorePlugin.GameData.CarSettings_RedLineRPM`, `DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverCarRedLine`, then falls back to the profile `targetRpm` when > 0, and returns a string source marker.
- Compute `targetRpm` earlier and pass the resolved `redlineRpm` into `ShiftAssistLearningEngine.Update(...)` so learning receives the resolved redline value at the time of sampling.
- Extended `TryReadNullableInt` with an overload that accepts `object` and tolerantly parses `int`, `long`, `double`, `float`, `decimal`, and numeric `string` inputs, rounding floating-point values to the nearest `int` and returning `false` for `null`/empty/unparseable inputs.
- Wired `LearnRedlineSource` through `WriteShiftAssistDebugCsv(...)` (header + row) and emit the chosen source alongside `LearnRedlineRpm` to the debug CSV.

### Testing

- Attempted `dotnet build LaunchPlugin.sln` to compile the solution, but the command failed in this environment because `dotnet` is not installed, so no compile was performed.
- Attempted `msbuild -version` to validate tooling, but the command failed because `msbuild` is not available in this environment, so no further automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997325902f8832f8b10eadd3d0f49ff)