### PR TITLE
Dark Mode: remove Set On/Off dash bindings, evaluate exports when no telemetry, and update Lovely keys

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -31,8 +31,6 @@
                         <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode" FriendlyName="Change Primary Dash Mode" ToolTip="Assign a button to cycle primary dash modes (main screen views)." />
                         <ui:ControlsEditor ActionName="LalaLaunch.DeclutterMode" FriendlyName="Cycle Declutter Mode" ToolTip="Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings." />
                         <ui:ControlsEditor ActionName="LalaLaunch.ToggleDarkMode" FriendlyName="Toggle Dark Mode" ToolTip="Assign a button to flip the Dark Mode manual toggle state." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.SetDarkModeOn" FriendlyName="Set Dark Mode On" ToolTip="Assign a button to force Dark Mode manual toggle on." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.SetDarkModeOff" FriendlyName="Set Dark Mode Off" ToolTip="Assign a button to force Dark Mode manual toggle off." />
                         <ui:ControlsEditor ActionName="LalaLaunch.EventMarker" FriendlyName="Event Marker" ToolTip="Assign a button to fire a short event marker pulse for dashboards and CSV exports." />
                     </StackPanel>
                 </Grid>

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5681,10 +5681,10 @@ namespace LaunchPlugin
             }
 
             // --- MASTER GUARD CLAUSES ---
-            if (Settings == null) return;
-            if (!data.GameRunning || data.NewData == null) return;
+            if (Settings == null || pluginManager == null) return;
             EnforceHardDebugSettings(Settings);
             EvaluateDarkMode(pluginManager);
+            if (!data.GameRunning || data.NewData == null) return;
 
             _isRefuelSelected = IsRefuelSelected(pluginManager);
             _isTireChangeSelected = IsAnyTireChangeSelected(pluginManager);
@@ -12742,8 +12742,10 @@ namespace LaunchPlugin
             });
 
             lovelyDarkState = false;
-            string[] keys =
+            string[] stateKeys =
             {
+                "LovelyPlugin.Id_TrueDarkModeState",
+                "LovelyPlugin.Id_PWTrueDarkMode",
                 "LovelyPlugin.DarkMode.Active",
                 "LovelyPlugin.TrueDark.Enabled",
                 "LovelyPlugin.Export.TrueDark",
@@ -12751,7 +12753,24 @@ namespace LaunchPlugin
                 "Lovely.TrueDark"
             };
 
-            foreach (string key in keys)
+            foreach (string key in stateKeys)
+            {
+                object raw = pluginManager.GetPropertyValue(key);
+                if (raw == null) continue;
+                lovelyAvailable = true;
+                if (TryCoerceBool(raw, out bool parsed))
+                {
+                    lovelyDarkState = parsed;
+                    return;
+                }
+            }
+
+            string[] capabilityKeys =
+            {
+                "LovelyPlugin.Id_TrueDarkModeEnabled"
+            };
+
+            foreach (string key in capabilityKeys)
             {
                 object raw = pluginManager.GetPropertyValue(key);
                 if (raw == null) continue;


### PR DESCRIPTION
### Motivation
- Simplify the Dash bindings UI to only expose the `ToggleDarkMode` control while keeping underlying actions available for Controls & Events and Dash Studio bindings.
- Ensure changes to Dark Mode settings in the plugin UI immediately update the exported `Dash.DarkMode.*` properties even when SimHub is in a “Waiting for data” state.
- Make Lovely integration robust by probing the actual Lovely property keys that SimHub exposes so the plugin can follow Lovely’s true-dark state when available.

### Description
- Removed the `SetDarkModeOn` and `SetDarkModeOff` `ui:ControlsEditor` rows from `DashesTabView.xaml`, leaving only `ToggleDarkMode` in the dash bindings UI.
- Moved `EvaluateDarkMode(pluginManager)` earlier in `DataUpdate` and changed the master guard to `if (Settings == null || pluginManager == null) return;` so dark-mode exports update whenever `Settings` and `pluginManager` exist, before the `GameRunning/NewData` early return.
- Extended `ProbeLovelyState` in `LalaLaunch.cs` to check additional state keys and prioritize them, adding `LovelyPlugin.Id_TrueDarkModeState` and `LovelyPlugin.Id_PWTrueDarkMode` to the state probe list and treating `LovelyPlugin.Id_TrueDarkModeEnabled` as a capability fallback.
- Left the `AddAction` registrations for `ToggleDarkMode`, `SetDarkModeOn`, and `SetDarkModeOff` unchanged so actions remain available programmatically and via SimHub bindings.

### Testing
- Ran an attempted build with `dotnet build LaunchPlugin.sln`, which failed in this environment because `dotnet` is not installed (build did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc93fa1bc832fa1fe49c67bba1a64)