### PR TITLE
Dark mode: add minimum brightness floor for Auto mode

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -790,6 +790,7 @@ namespace LaunchPlugin
         internal const double CarSANotRelevantGapSecDefault = 10.0;
         private const int DarkModeManual = 1;
         private const int DarkModeAuto = 2;
+        private const int DarkModeAutoMinBrightnessPct = 30;
         private const double DarkModeAutoOnAltitudeDeg = 2.0;
         private const double DarkModeAutoOffAltitudeDeg = 4.0;
         private bool _darkModeAutoActiveLatched = false;
@@ -12710,6 +12711,10 @@ namespace LaunchPlugin
             {
                 double factor = (mode == DarkModeAuto && solarValid) ? f : 1.0;
                 effectiveBrightnessPct = ClampInt((int)Math.Round(userBrightnessPct * factor), 0, 100);
+                if (mode == DarkModeAuto)
+                {
+                    effectiveBrightnessPct = ClampInt(effectiveBrightnessPct, DarkModeAutoMinBrightnessPct, 100);
+                }
             }
 
             int brightnessPct = active ? effectiveBrightnessPct : userBrightnessPct;


### PR DESCRIPTION
### Motivation
- Ensure Auto dark mode never reduces the effective brightness below 30% while preserving existing manual behavior and exports.

### Description
- Added `private const int DarkModeAutoMinBrightnessPct = 30` and updated `EvaluateDarkMode()` so that when `active` and `mode == DarkModeAuto` the computed `effectiveBrightnessPct` is clamped to the new minimum after factor scaling, while leaving `brightnessPct`, `opacityPct`, and manual-mode behavior unchanged.

### Testing
- Attempted to run `dotnet build LaunchPlugin.sln` but `dotnet` is not available in this execution environment so the automated build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a053fde160832fa7518d1f4b975e70)