### PR TITLE
Buffered SHIFT stack editing (Save/Revert) and Learning UI tidy

### DIFF
--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -384,7 +384,13 @@
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <ComboBox Grid.Column="0" ItemsSource="{Binding ShiftStackIds}" SelectedItem="{Binding SelectedShiftStackId, Mode=TwoWay}" Margin="0,0,8,0" MinWidth="130"/>
+                                <ComboBox x:Name="ShiftStackSelector"
+                                          Grid.Column="0"
+                                          ItemsSource="{Binding ShiftStackIds}"
+                                          SelectedItem="{Binding SelectedShiftStackId, Mode=OneWay}"
+                                          SelectionChanged="ShiftStackSelector_SelectionChanged"
+                                          Margin="0,0,8,0"
+                                          MinWidth="130"/>
                                 <TextBlock Grid.Column="0"
                                            Text="(Unsaved)"
                                            Margin="138,0,0,0"

--- a/ProfilesManagerView.xaml.cs
+++ b/ProfilesManagerView.xaml.cs
@@ -1,11 +1,14 @@
 ﻿// In file: ProfilesManagerView.xaml.cs
 using System.Windows.Controls;
 using System.Windows;
+using System;
 
 namespace LaunchPlugin
 {
     public partial class ProfilesManagerView : UserControl
     {
+        private bool _suppressShiftStackSelectionChanged;
+
         public ProfilesManagerView(ProfilesManagerViewModel viewModel)
         {
             InitializeComponent();
@@ -65,6 +68,52 @@ namespace LaunchPlugin
             }
 
             row.SetLockAction?.Invoke(false);
+        }
+
+        private void ShiftStackSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressShiftStackSelectionChanged)
+            {
+                return;
+            }
+
+            var combo = sender as ComboBox;
+            var vm = DataContext as ProfilesManagerViewModel;
+            if (combo == null || vm == null)
+            {
+                return;
+            }
+
+            string targetId = combo.SelectedItem as string;
+            string beforeId = vm.SelectedShiftStackId;
+            if (vm.ConfirmSwitchShiftStackCommand != null && vm.ConfirmSwitchShiftStackCommand.CanExecute(targetId))
+            {
+                vm.ConfirmSwitchShiftStackCommand.Execute(targetId);
+            }
+            else
+            {
+                vm.ConfirmSwitchShiftStack(targetId);
+            }
+            bool changed = string.Equals(vm.SelectedShiftStackId, targetId, StringComparison.OrdinalIgnoreCase)
+                           && !string.Equals(beforeId, vm.SelectedShiftStackId, StringComparison.OrdinalIgnoreCase);
+
+            _suppressShiftStackSelectionChanged = true;
+            try
+            {
+                if (!string.Equals(combo.SelectedItem as string, vm.SelectedShiftStackId, StringComparison.OrdinalIgnoreCase))
+                {
+                    combo.SelectedItem = vm.SelectedShiftStackId;
+                }
+            }
+            finally
+            {
+                _suppressShiftStackSelectionChanged = false;
+            }
+
+            if (!changed)
+            {
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make SHIFT stack edits safe for rapid testing by keeping edits in an in-memory buffer until the user explicitly saves or reverts.
- Prevent accidental mutation of the stored/default stack during quick experiments (e.g. `Save As…` must not change the source). 
- Reduce surprise when switching stacks by prompting on dirty buffers and keep Learning UI unobtrusive when learning is off.

### Description
- Introduced an edit buffer and dirty-tracking in `ProfilesManagerViewModel` with fields ` _shiftStackEditRpm`, `_shiftStackEditLocked`, `_previousShiftStackId`, `_isInternalShiftStackSelectionChange` and `ShiftStackIsDirty`, plus `LoadShiftStackBuffer` and `CommitShiftStackBufferToStored` helper methods to isolate edits from stored data. 
- Changed selection logic for `SelectedShiftStackId` to present a Save / Discard / Cancel prompt when `ShiftStackIsDirty`, to rollback selection without re-prompting, and to use an internal-guard (`_isInternalShiftStackSelectionChange`) to avoid re-entrancy. 
- Reworked shift-row binding so per-row `SaveAction` and `SetLockAction` modify only the buffer and set `ShiftStackIsDirty` (removed `SaveProfiles()` from per-edit handlers). 
- Added explicit commands `SaveShiftStackCommand` and `RevertShiftStackCommand` and wired `Save Stack` / `Revert` buttons in the SHIFT tab; changed `Save As...` to clone from the current edit buffer into a new stored stack (no mutation of the source). 
- Moved the `Learning mode` toggle next to the Active stack / Lead time controls and collapsed learning-only buttons and learned/delay columns when `ShiftAssistLearningModeEnabled` is false via Visibility bindings so the SHIFT grid collapses cleanly. 

### Testing
- Parsed `ProfilesManagerView.xaml` with Python `xml.etree.ElementTree` to confirm the modified XAML is well-formed (succeeded). 
- Attempted `dotnet build LaunchPlugin.sln` but `dotnet` is not available in this environment (build not executed). 
- Verified through static inspection that row edits now update buffer-only, `Save As` copies from buffer, and the dirty prompt / revert guard logic is present in `ProfilesManagerViewModel` (code-level checks performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49fc03a90832fb413912a790e9275)