### PR TITLE
Reduce MinBinsWithData from 6 to 4 to speed up ShiftAssist learning

### DIFF
--- a/ShiftAssistLearningEngine.cs
+++ b/ShiftAssistLearningEngine.cs
@@ -76,7 +76,7 @@ namespace LaunchPlugin
         private const double NearRedlineRatio = 0.99;
         private const int BinSizeRpm = 50;
         private const int MinBinSamples = 3;
-        private const int MinBinsWithData = 6;
+        private const int MinBinsWithData = 4;
         private const int MinRatioSamples = 12;
         private const double MaxPlausibleAccelMps2 = 30.0;
         private const double CrossoverMarginMps2 = 0.10;


### PR DESCRIPTION
### Motivation
- Reduce the per-gear curve validity threshold so adjacent gear curves become valid sooner and learned RPMs can populate from fewer clean pulls while preserving all other learning behavior.

### Description
- Change the `MinBinsWithData` constant from `6` to `4` in `ShiftAssistLearningEngine.cs` as a single-line, minimal diff, with bin size, crossover math, stability buffer, and throttle/brake/limiter acceptance logic left unchanged.

### Testing
- Executed `git diff -- ShiftAssistLearningEngine.cs`, `git status --short`, and inspected the updated lines with `nl`; the diff shows the single constant modification and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab3753d80832f9c3337020bc7953d)