### PR TITLE
Fix ShiftAssist crossover skip gating and add per-gear diagnostics

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -7173,7 +7173,7 @@ namespace LaunchPlugin
                     if (!File.Exists(_shiftAssistDebugCsvPath))
                     {
                         File.WriteAllText(_shiftAssistDebugCsvPath,
-                            "UtcTime,SessionTimeSec,Gear,MaxForwardGears,Rpm,Throttle01,TargetRpm,EffectiveTargetRpm,RpmRate,LeadTimeMs,BeepTriggered,BeepLatched,EngineState,SuppressDownshift,SuppressUpshift,SpeedMps,AccelDerivedMps2,LonAccelTelemetryMps2,EffectiveGear,LearnEnabled,LearnState,LearnPeakRpm,LearnPeakAccelMps2,LearnSampleAdded,LearnPullAccepted,LearnSamplesForGear,LearnLearnedRpmForGear,LearnMinRpm,LearnRedlineRpm,LearnSamplingRedlineRpm,LearnRedlineSource,LearnCaptureMinRpm,LearnCapturedRpm,LearnSampleRpmFinal,LearnSampleRpmWasClamped,LearnEndReason,LearnEndWasUpshift,LearnRejectedReason,LearnLimiterHoldActive,LearnLimiterHoldMs,LearnValidCurvePointsThisPull,LearnArtifactReset,LearnArtifactReason,LearnCurrentK,LearnCurrentKValid,LearnNextK,LearnNextKValid,LearnCurrentBinIndex,LearnCurrentBinCount,LearnCurrentCurveAccelMps2,LearnCrossoverCandidateRpm,LearnCrossoverComputedRpm,LearnCrossoverInsufficientData,DelayPending,DelayPendingGear,DelayPendingAgeMs,DelayPendingRpmAtCue,DelayPendingTargetGear,DelayPendingDownshiftAgeMs,DelayCapturedMs,DelayCaptureEvent,DelayBeepType,DelayRpmAtBeep,DelayCaptureState,UrgentEnabled,BeepSoundEnabled,BeepVolumePct,UrgentVolumePctDerived,CueActive,MsSincePrimaryAudioIssued,MsSincePrimaryCueTrigger,MsSinceUrgentPlayed,UrgentMinGapMsFixed,UrgentEligible,UrgentSuppressedReason,UrgentAttempted,UrgentPlayed,UrgentPlayError,RedlineRpm,OverRedline,BeepType" + Environment.NewLine);
+                            "UtcTime,SessionTimeSec,Gear,MaxForwardGears,Rpm,Throttle01,TargetRpm,EffectiveTargetRpm,RpmRate,LeadTimeMs,BeepTriggered,BeepLatched,EngineState,SuppressDownshift,SuppressUpshift,SpeedMps,AccelDerivedMps2,LonAccelTelemetryMps2,EffectiveGear,LearnEnabled,LearnState,LearnPeakRpm,LearnPeakAccelMps2,LearnSampleAdded,LearnPullAccepted,LearnSamplesForGear,LearnLearnedRpmForGear,LearnMinRpm,LearnRedlineRpm,LearnSamplingRedlineRpm,LearnRedlineSource,LearnCaptureMinRpm,LearnCapturedRpm,LearnSampleRpmFinal,LearnSampleRpmWasClamped,LearnEndReason,LearnEndWasUpshift,LearnRejectedReason,LearnLimiterHoldActive,LearnLimiterHoldMs,LearnValidCurvePointsThisPull,LearnArtifactReset,LearnArtifactReason,LearnCurrentK,LearnCurrentKValid,LearnNextK,LearnNextKValid,LearnCurrentBinIndex,LearnCurrentBinCount,LearnCurrentCurveAccelMps2,LearnCrossoverCandidateRpm,LearnCrossoverComputedRpm,LearnCrossoverInsufficientData,LearnCrossoverCurrentCurveValid,LearnCrossoverNextCurveValid,LearnCrossoverCurrentKValid,LearnCrossoverNextKValid,LearnCrossoverScanMinRpm,LearnCrossoverScanMaxRpm,LearnCrossoverPredictedNextRpmInRange,LearnCrossoverSkipReason,DelayPending,DelayPendingGear,DelayPendingAgeMs,DelayPendingRpmAtCue,DelayPendingTargetGear,DelayPendingDownshiftAgeMs,DelayCapturedMs,DelayCaptureEvent,DelayBeepType,DelayRpmAtBeep,DelayCaptureState,UrgentEnabled,BeepSoundEnabled,BeepVolumePct,UrgentVolumePctDerived,CueActive,MsSincePrimaryAudioIssued,MsSincePrimaryCueTrigger,MsSinceUrgentPlayed,UrgentMinGapMsFixed,UrgentEligible,UrgentSuppressedReason,UrgentAttempted,UrgentPlayed,UrgentPlayError,RedlineRpm,OverRedline,BeepType" + Environment.NewLine);
                     }
                 }
 
@@ -7210,6 +7210,15 @@ namespace LaunchPlugin
                 int learnCrossoverCandidateRpm = learningTick?.CrossoverCandidateRpm ?? 0;
                 int learnCrossoverComputedRpm = learningTick?.CrossoverComputedRpmForGear ?? 0;
                 int learnCrossoverInsufficientData = learningTick?.CrossoverInsufficientData ?? 0;
+                int learnCrossoverCurrentCurveValid = learningTick?.CrossoverCurrentCurveValid ?? 0;
+                int learnCrossoverNextCurveValid = learningTick?.CrossoverNextCurveValid ?? 0;
+                int learnCrossoverCurrentKValid = learningTick?.CrossoverCurrentKValid ?? 0;
+                int learnCrossoverNextKValid = learningTick?.CrossoverNextKValid ?? 0;
+                int learnCrossoverScanMinRpm = learningTick?.CrossoverScanMinRpm ?? 0;
+                int learnCrossoverScanMaxRpm = learningTick?.CrossoverScanMaxRpm ?? 0;
+                int learnCrossoverPredictedNextRpmInRange = learningTick?.CrossoverPredictedNextRpmInRange ?? 0;
+                string learnCrossoverSkipReason = !string.IsNullOrWhiteSpace(learningTick?.CrossoverSkipReason) ? learningTick.CrossoverSkipReason : "NONE";
+                learnCrossoverSkipReason = SanitizeShiftAssistDebugCsvText(learnCrossoverSkipReason);
                 long delayNowTs = Stopwatch.GetTimestamp();
                 int delayPending = _shiftAssistPendingDelayActive ? 1 : 0;
                 int delayPendingGear = _shiftAssistPendingDelayGear;
@@ -7248,7 +7257,7 @@ namespace LaunchPlugin
 
                 var line = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0:o},{1},{2},{3},{4},{5:F4},{6},{7},{8},{9},{10},{11},{12},{13},{14},{15:F4},{16:F4},{17:F4},{18},{19},{20},{21},{22:F4},{23},{24},{25},{26},{27},{28},{29},{30},{31},{32},{33},{34},{35},{36},{37},{38},{39},{40},{41},{42},{43:F6},{44},{45:F6},{46},{47},{48},{49:F4},{50},{51},{52},{53},{54},{55},{56},{57},{58},{59},{60},{61},{62},{63},{64},{65},{66},{67},{68},{69},{70},{71},{72},{73},{74},{75},{76},{77},{78},{79},{80}",
+                    "{0:o},{1},{2},{3},{4},{5:F4},{6},{7},{8},{9},{10},{11},{12},{13},{14},{15:F4},{16:F4},{17:F4},{18},{19},{20},{21},{22:F4},{23},{24},{25},{26},{27},{28},{29},{30},{31},{32},{33},{34},{35},{36},{37},{38},{39},{40},{41},{42},{43:F6},{44},{45:F6},{46},{47},{48},{49:F4},{50},{51},{52},{53},{54},{55},{56},{57},{58},{59},{60},{61},{62},{63},{64},{65},{66},{67},{68},{69},{70},{71},{72},{73},{74},{75},{76},{77},{78},{79},{80},{81},{82},{83},{84},{85},{86},{87},{88}",
                     nowUtc,
                     sessionTimeSec.ToString("F3", CultureInfo.InvariantCulture),
                     gear,
@@ -7302,6 +7311,14 @@ namespace LaunchPlugin
                     learnCrossoverCandidateRpm,
                     learnCrossoverComputedRpm,
                     learnCrossoverInsufficientData,
+                    learnCrossoverCurrentCurveValid,
+                    learnCrossoverNextCurveValid,
+                    learnCrossoverCurrentKValid,
+                    learnCrossoverNextKValid,
+                    learnCrossoverScanMinRpm,
+                    learnCrossoverScanMaxRpm,
+                    learnCrossoverPredictedNextRpmInRange,
+                    learnCrossoverSkipReason,
                     delayPending,
                     delayPendingGear,
                     delayPendingAgeMs,

--- a/ShiftAssistLearningEngine.cs
+++ b/ShiftAssistLearningEngine.cs
@@ -52,6 +52,14 @@ namespace LaunchPlugin
         public int CrossoverComputedRpmForGear { get; set; }
         public int CrossoverInsufficientData { get; set; }
         public int ValidCurvePointsThisPull { get; set; }
+        public int CrossoverCurrentCurveValid { get; set; }
+        public int CrossoverNextCurveValid { get; set; }
+        public int CrossoverCurrentKValid { get; set; }
+        public int CrossoverNextKValid { get; set; }
+        public int CrossoverScanMinRpm { get; set; }
+        public int CrossoverScanMaxRpm { get; set; }
+        public int CrossoverPredictedNextRpmInRange { get; set; }
+        public string CrossoverSkipReason { get; set; }
     }
 
     public class ShiftAssistLearningEngine
@@ -482,6 +490,14 @@ namespace LaunchPlugin
             tick.CrossoverCandidateRpm = current.LastCrossoverCandidateRpm;
             tick.CrossoverComputedRpmForGear = current.CrossoverRpm;
             tick.CrossoverInsufficientData = current.CrossoverInsufficientData ? 1 : 0;
+            tick.CrossoverCurrentCurveValid = current.LastCurrentCurveValid ? 1 : 0;
+            tick.CrossoverNextCurveValid = current.LastNextCurveValid ? 1 : 0;
+            tick.CrossoverCurrentKValid = current.LastCurrentKValid ? 1 : 0;
+            tick.CrossoverNextKValid = current.LastNextKValid ? 1 : 0;
+            tick.CrossoverScanMinRpm = current.LastScanMinRpm;
+            tick.CrossoverScanMaxRpm = current.LastScanMaxRpm;
+            tick.CrossoverPredictedNextRpmInRange = current.LastPredictedNextRpmInRange ? 1 : 0;
+            tick.CrossoverSkipReason = current.LastCrossoverSkipReason;
         }
 
         private void FinalizeSample(StackRuntime stack, ShiftAssistLearningTick tick, int windowMs, string endReason, bool endWasUpshift, bool fromGraceTimeout)
@@ -569,31 +585,61 @@ namespace LaunchPlugin
             var next = stack.Gears[sourceGear];
             curr.CrossoverInsufficientData = true;
             curr.LastCrossoverCandidateRpm = 0;
+            curr.LastCurrentCurveValid = curr.HasCoverage;
+            curr.LastNextCurveValid = next.HasCoverage;
+            curr.LastCurrentKValid = curr.HasValidRatio;
+            curr.LastNextKValid = next.HasValidRatio;
+            curr.LastScanMinRpm = 0;
+            curr.LastScanMaxRpm = 0;
+            curr.LastPredictedNextRpmInRange = false;
+            curr.LastCrossoverSkipReason = string.Empty;
 
-            if (!curr.HasCoverage || !next.HasCoverage || !curr.HasValidRatio || !next.HasValidRatio)
+            if (!curr.LastCurrentCurveValid || !curr.LastNextCurveValid || !curr.LastCurrentKValid || !curr.LastNextKValid)
             {
+                curr.LastCrossoverSkipReason = "PrecheckInvalid";
                 return false;
             }
 
+            if (!curr.TryGetUsableCurveRange(out int currUsableMinRpm, out int currUsableMaxRpm)
+                || !next.TryGetUsableCurveRange(out int nextUsableMinRpm, out int nextUsableMaxRpm))
+            {
+                curr.LastCrossoverSkipReason = "UsableRangeUnavailable";
+                return false;
+            }
+
+            int mappedMinFromNext = (int)Math.Round(nextUsableMinRpm * (curr.RatioK / next.RatioK));
+            int mappedMaxFromNext = (int)Math.Round(nextUsableMaxRpm * (curr.RatioK / next.RatioK));
+
             int minRpm = Math.Max(curr.MinObservedRpm, AbsoluteMinLearnRpm);
+            minRpm = Math.Max(minRpm, currUsableMinRpm);
+            minRpm = Math.Max(minRpm, mappedMinFromNext - BinSizeRpm);
             int observedUpperRpm = curr.MaxObservedRpm - RedlineHeadroomRpm;
             int redlineUpperRpm = curr.GetCrossoverUpperRpmCeiling(RedlineHeadroomRpm);
             int maxRpm = redlineUpperRpm > 0
                 ? Math.Min(observedUpperRpm, redlineUpperRpm)
                 : observedUpperRpm;
+            maxRpm = Math.Min(maxRpm, currUsableMaxRpm);
+            maxRpm = Math.Min(maxRpm, mappedMaxFromNext + BinSizeRpm);
+            curr.LastScanMinRpm = minRpm;
+            curr.LastScanMaxRpm = maxRpm;
             if (maxRpm <= minRpm)
             {
                 int observedFallbackUpper = curr.MaxObservedRpm - BinSizeRpm;
                 maxRpm = redlineUpperRpm > 0
                     ? Math.Min(observedFallbackUpper, redlineUpperRpm)
                     : observedFallbackUpper;
+                maxRpm = Math.Min(maxRpm, currUsableMaxRpm);
+                maxRpm = Math.Min(maxRpm, mappedMaxFromNext + BinSizeRpm);
+                curr.LastScanMaxRpm = maxRpm;
                 if (maxRpm <= minRpm)
                 {
+                    curr.LastCrossoverSkipReason = "ScanRangeInvalid";
                     return false;
                 }
             }
 
             int found = 0;
+            bool predictedInRange = false;
             for (int r = minRpm; r <= maxRpm; r += BinSizeRpm)
             {
                 double aCurr = curr.GetCurveAccel(r);
@@ -603,7 +649,20 @@ namespace LaunchPlugin
                 }
 
                 double r2 = r * (next.RatioK / curr.RatioK);
-                double aNext = next.GetCurveAccel((int)Math.Round(r2));
+                int nextRpm = (int)Math.Round(r2);
+                bool nextRpmInRange = nextRpm >= (nextUsableMinRpm - BinSizeRpm) && nextRpm <= (nextUsableMaxRpm + BinSizeRpm);
+                if (!nextRpmInRange)
+                {
+                    continue;
+                }
+
+                predictedInRange = true;
+                double aNext = next.GetCurveAccel(nextRpm);
+                if (!IsFinite(aNext))
+                {
+                    aNext = next.GetCurveAccelAtNearestBin(nextRpm, 2);
+                }
+
                 if (!IsFinite(aNext))
                 {
                     continue;
@@ -616,23 +675,29 @@ namespace LaunchPlugin
                 }
             }
 
+            curr.LastPredictedNextRpmInRange = predictedInRange;
+
             curr.LastCrossoverCandidateRpm = found;
 
             if (found <= 0)
             {
+                curr.LastCrossoverSkipReason = predictedInRange ? "NoCrossoverFound" : "PredictedNextRpmOutOfRange";
                 return false;
             }
 
             curr.CrossoverInsufficientData = false;
             curr.CrossoverRpm = found;
             curr.PushCrossoverCandidate(found, StableCrossoverBufferSize);
+            curr.LastCrossoverSkipReason = "Solved";
 
             if (curr.TryGetStableLearnedRpm(StableCrossoverToleranceRpm, StableCrossoverMinSamples, out stableLearnedRpm))
             {
                 curr.LearnedRpm = stableLearnedRpm;
+                curr.LastCrossoverSkipReason = "StableLearned";
                 return true;
             }
 
+            curr.LastCrossoverSkipReason = "AwaitingStability";
             return false;
         }
 
@@ -822,6 +887,14 @@ namespace LaunchPlugin
             _lastTick.CrossoverComputedRpmForGear = tick.CrossoverComputedRpmForGear;
             _lastTick.CrossoverInsufficientData = tick.CrossoverInsufficientData;
             _lastTick.ValidCurvePointsThisPull = tick.ValidCurvePointsThisPull;
+            _lastTick.CrossoverCurrentCurveValid = tick.CrossoverCurrentCurveValid;
+            _lastTick.CrossoverNextCurveValid = tick.CrossoverNextCurveValid;
+            _lastTick.CrossoverCurrentKValid = tick.CrossoverCurrentKValid;
+            _lastTick.CrossoverNextKValid = tick.CrossoverNextKValid;
+            _lastTick.CrossoverScanMinRpm = tick.CrossoverScanMinRpm;
+            _lastTick.CrossoverScanMaxRpm = tick.CrossoverScanMaxRpm;
+            _lastTick.CrossoverPredictedNextRpmInRange = tick.CrossoverPredictedNextRpmInRange;
+            _lastTick.CrossoverSkipReason = tick.CrossoverSkipReason;
         }
 
         private class StackRuntime
@@ -860,6 +933,14 @@ namespace LaunchPlugin
             public int CrossoverRpm { get; set; }
             public bool CrossoverInsufficientData { get; set; }
             public int LastCrossoverCandidateRpm { get; set; }
+            public bool LastCurrentCurveValid { get; set; }
+            public bool LastNextCurveValid { get; set; }
+            public bool LastCurrentKValid { get; set; }
+            public bool LastNextKValid { get; set; }
+            public int LastScanMinRpm { get; set; }
+            public int LastScanMaxRpm { get; set; }
+            public bool LastPredictedNextRpmInRange { get; set; }
+            public string LastCrossoverSkipReason { get; set; }
 
             public void AddCurveSample(int rpm, double speedMps, double accelMps2, int redlineRpmForGear)
             {
@@ -967,6 +1048,63 @@ namespace LaunchPlugin
                 return ceiling > AbsoluteMinLearnRpm ? ceiling : AbsoluteMinLearnRpm;
             }
 
+            public bool TryGetUsableCurveRange(out int minRpm, out int maxRpm)
+            {
+                minRpm = 0;
+                maxRpm = 0;
+                int minIndex = int.MaxValue;
+                int maxIndex = int.MinValue;
+
+                foreach (var kv in _bins)
+                {
+                    if (kv.Value == null || kv.Value.Count < MinBinSamples)
+                    {
+                        continue;
+                    }
+
+                    if (kv.Key < minIndex)
+                    {
+                        minIndex = kv.Key;
+                    }
+
+                    if (kv.Key > maxIndex)
+                    {
+                        maxIndex = kv.Key;
+                    }
+                }
+
+                if (minIndex == int.MaxValue || maxIndex == int.MinValue)
+                {
+                    return false;
+                }
+
+                minRpm = minIndex * BinSizeRpm;
+                maxRpm = maxIndex * BinSizeRpm;
+                return maxRpm > minRpm;
+            }
+
+            public double GetCurveAccelAtNearestBin(int rpm, int maxBinDistance)
+            {
+                int center = GetBinIndex(rpm);
+                for (int distance = 0; distance <= maxBinDistance; distance++)
+                {
+                    int lower = center - distance;
+                    int upper = center + distance;
+
+                    if (_bins.TryGetValue(lower, out BinRuntime lowerBin) && lowerBin != null && lowerBin.Count >= MinBinSamples)
+                    {
+                        return lowerBin.Median;
+                    }
+
+                    if (upper != lower && _bins.TryGetValue(upper, out BinRuntime upperBin) && upperBin != null && upperBin.Count >= MinBinSamples)
+                    {
+                        return upperBin.Median;
+                    }
+                }
+
+                return double.NaN;
+            }
+
             private bool IsRpmPlausibleForBounds(int rpm, int redlineRpmForGear)
             {
                 if (rpm <= 0 || rpm > MaxPlausibleEngineRpm)
@@ -1049,6 +1187,14 @@ namespace LaunchPlugin
                 CrossoverRpm = 0;
                 CrossoverInsufficientData = false;
                 LastCrossoverCandidateRpm = 0;
+                LastCurrentCurveValid = false;
+                LastNextCurveValid = false;
+                LastCurrentKValid = false;
+                LastNextKValid = false;
+                LastScanMinRpm = 0;
+                LastScanMaxRpm = 0;
+                LastPredictedNextRpmInRange = false;
+                LastCrossoverSkipReason = string.Empty;
                 MinObservedRpm = 0;
                 MaxObservedRpm = 0;
                 SourceGearRedlineRpm = 0;


### PR DESCRIPTION
### Motivation
- Adjacent gear pairs with accepted pulls and valid curve/ratio data were being skipped by the crossover solver, leaving many gears with N counts but no Learned RPMs.  
- Need low-noise per-gear diagnostics so skip reasons are visible for field validation without noisy logs.  
- Ensure solver uses real usable curve coverage and a tolerant mapped-next-gear lookup so normal straight-line pulls reliably produce crossover candidates.

### Description
- Added per-tick diagnostics to `ShiftAssistLearningTick` (fields for current/next curve/K validity, scan min/max RPM, predicted-next-in-range flag, and a compact `CrossoverSkipReason`) and exposed them in debug CSV export.  
- Instrumented `GearRuntime` with transient fields to record the last solve attempt (`LastCurrentCurveValid`, `LastNextCurveValid`, `LastCurrentKValid`, `LastNextKValid`, `LastScanMinRpm`, `LastScanMaxRpm`, `LastPredictedNextRpmInRange`, `LastCrossoverSkipReason`) and added reset behavior for these.  
- Reworked `RecomputeCrossoverForGear` prechecks and scan-range derivation so solver proceeds when both curves and both K values are valid, computing scan bounds using usable curve coverage from both gears mapped by measured K (with small bin tolerance).  
- Relaxed next-gear accel lookup by checking mapped next-RPM range with a bin tolerance and falling back to nearest-bin accel via `GetCurveAccelAtNearestBin` before giving up; recorded a compact skip reason (`PrecheckInvalid`, `UsableRangeUnavailable`, `ScanRangeInvalid`, `PredictedNextRpmOutOfRange`, `NoCrossoverFound`, `Solved`, `AwaitingStability`, `StableLearned`) for each attempt.  
- Updated `LalaLaunch.cs` debug CSV header and per-row output to include the new fields and sanitize the skip-reason string.

### Testing
- Ran repository grep checks to verify new symbols and CSV header integration: `rg "CrossoverCurrentCurveValid|CrossoverSkipReason|CrossoverScanMinRpm" -n ShiftAssistLearningEngine.cs LalaLaunch.cs` (succeeded).  
- Attempted a build with `dotnet build -nologo` inside the container but `dotnet` is not available in this environment (build unavailable here).  
- Verified source edits and committed the changes locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab98a10dc832fa3ec43026011f6ac)