### PR TITLE
Relax crossover scan band to current gear usable range

### DIFF
--- a/ShiftAssistLearningEngine.cs
+++ b/ShiftAssistLearningEngine.cs
@@ -607,35 +607,14 @@ namespace LaunchPlugin
                 return false;
             }
 
-            int mappedMinFromNext = (int)Math.Round(nextUsableMinRpm * (curr.RatioK / next.RatioK));
-            int mappedMaxFromNext = (int)Math.Round(nextUsableMaxRpm * (curr.RatioK / next.RatioK));
-
-            int minRpm = Math.Max(curr.MinObservedRpm, AbsoluteMinLearnRpm);
-            minRpm = Math.Max(minRpm, currUsableMinRpm);
-            minRpm = Math.Max(minRpm, mappedMinFromNext - BinSizeRpm);
-            int observedUpperRpm = curr.MaxObservedRpm - RedlineHeadroomRpm;
-            int redlineUpperRpm = curr.GetCrossoverUpperRpmCeiling(RedlineHeadroomRpm);
-            int maxRpm = redlineUpperRpm > 0
-                ? Math.Min(observedUpperRpm, redlineUpperRpm)
-                : observedUpperRpm;
-            maxRpm = Math.Min(maxRpm, currUsableMaxRpm);
-            maxRpm = Math.Min(maxRpm, mappedMaxFromNext + BinSizeRpm);
+            int minRpm = currUsableMinRpm;
+            int maxRpm = currUsableMaxRpm;
             curr.LastScanMinRpm = minRpm;
             curr.LastScanMaxRpm = maxRpm;
             if (maxRpm <= minRpm)
             {
-                int observedFallbackUpper = curr.MaxObservedRpm - BinSizeRpm;
-                maxRpm = redlineUpperRpm > 0
-                    ? Math.Min(observedFallbackUpper, redlineUpperRpm)
-                    : observedFallbackUpper;
-                maxRpm = Math.Min(maxRpm, currUsableMaxRpm);
-                maxRpm = Math.Min(maxRpm, mappedMaxFromNext + BinSizeRpm);
-                curr.LastScanMaxRpm = maxRpm;
-                if (maxRpm <= minRpm)
-                {
-                    curr.LastCrossoverSkipReason = "ScanRangeInvalid";
-                    return false;
-                }
+                curr.LastCrossoverSkipReason = "ScanRangeInvalid";
+                return false;
             }
 
             int found = 0;


### PR DESCRIPTION
### Motivation
- The crossover scan band could collapse when strictly intersecting usable ranges between current and next gear, causing `ScanRangeInvalid` or `NoCrossoverFound` even when telemetry shows valid intersections.
- The change aims to keep the scan physically correct while preventing scan-range collapse by anchoring the scan to the current gear usable range and still validating projected next-gear RPMs per-sample.

### Description
- In `RecomputeCrossoverForGear` (in `ShiftAssistLearningEngine.cs`) replaced the previous overlapping/mapped next-gear constraints with a scan range directly set to `currUsableMinRpm`..`currUsableMaxRpm`.
- Removed the fallback narrowing logic and mapped-next upper/lower math that could shrink the band and cause invalid scan ranges.
- Preserved the per-sample projection and validation: the loop still projects `nextRpm` using the gear ratio and skips points where the projected RPM is outside `next` usable bounds (`nextUsableMinRpm`/`nextUsableMaxRpm` ± `BinSizeRpm`).
- Left curve accumulation, candidate stability, and binning unchanged; only the scan band generation was adjusted and `LastScanMinRpm`/`LastScanMaxRpm` and skip reason handling updated accordingly.

### Testing
- Attempted to run `dotnet build LaunchPlugin.sln`, which failed in this environment because `dotnet` is not installed (build not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac44d59d4832f8440dd847e04c6c2)