### PR TITLE
Skip gear 1 and low-speed overlap in Shift Assist learning crossover scan

### DIFF
--- a/ShiftAssistLearningEngine.cs
+++ b/ShiftAssistLearningEngine.cs
@@ -470,6 +470,22 @@ namespace LaunchPlugin
                 return false;
             }
 
+            if (sourceGear == 1)
+            {
+                var firstGear = stack.Gears[0];
+                firstGear.CrossoverInsufficientData = true;
+                firstGear.LastCrossoverCandidateRpm = 0;
+                firstGear.LastCurrentCurveValid = firstGear.HasCoverage;
+                firstGear.LastNextCurveValid = stack.Gears[1].HasCoverage;
+                firstGear.LastCurrentKValid = firstGear.HasValidRatio;
+                firstGear.LastNextKValid = stack.Gears[1].HasValidRatio;
+                firstGear.LastScanMinRpm = 0;
+                firstGear.LastScanMaxRpm = 0;
+                firstGear.LastPredictedNextRpmInRange = false;
+                firstGear.LastCrossoverSkipReason = "Gear1Excluded";
+                return false;
+            }
+
             var curr = stack.Gears[sourceGear - 1];
             var next = stack.Gears[sourceGear];
 
@@ -505,13 +521,21 @@ namespace LaunchPlugin
                 return false;
             }
 
-            int minScanRpm = ClampLearnedRpmToSafeCeiling(curr, (int)Math.Round(curr.RatioK * ToMps(minScanSpeedKph)));
+            int overlapSpanKph = maxScanSpeedKph - minScanSpeedKph;
+            int scanStartSpeedKph = minScanSpeedKph + (int)Math.Ceiling(overlapSpanKph * 0.20);
+            if (scanStartSpeedKph > maxScanSpeedKph)
+            {
+                curr.LastCrossoverSkipReason = "NoSpeedOverlap";
+                return false;
+            }
+
+            int minScanRpm = ClampLearnedRpmToSafeCeiling(curr, (int)Math.Round(curr.RatioK * ToMps(scanStartSpeedKph)));
             int maxScanRpm = ClampLearnedRpmToSafeCeiling(curr, (int)Math.Round(curr.RatioK * ToMps(maxScanSpeedKph)));
             curr.LastScanMinRpm = minScanRpm;
             curr.LastScanMaxRpm = maxScanRpm;
 
             int foundSpeedKph = 0;
-            for (int speedKph = minScanSpeedKph; speedKph <= maxScanSpeedKph; speedKph += 1)
+            for (int speedKph = scanStartSpeedKph; speedKph <= maxScanSpeedKph; speedKph += 1)
             {
                 double aCurr = curr.GetCurveAccelAtSpeed(speedKph);
                 double aNext = next.GetCurveAccelAtSpeed(speedKph);


### PR DESCRIPTION
### Motivation
- Reduce noisy early-acceleration influence on crossover solves and prevent gear 1 (highly noisy) from producing learned RPM results.
- Improve stability of solved RPMs so solves do not drift toward redline due to low-speed telemetry noise.

### Description
- Short-circuit `RecomputeCrossoverForGear` when `sourceGear == 1`, clear candidate diagnostics, and set `LastCrossoverSkipReason` to `Gear1Excluded` so gear 1 never publishes a learned RPM.
- Compute the overlap span and set `scanStartSpeedKph = minScanSpeedKph + ceil(overlapSpan * 0.20)`, then scan from `scanStartSpeedKph` to `maxScanSpeedKph` instead of starting at the minimum overlap speed, effectively ignoring the lowest 20% of the overlap band.
- Keep the existing solve rule (`aNext >= aCurr`), stability buffering, ratio estimation, and safe learned-RPM clamping unchanged.
- Change is limited to `ShiftAssistLearningEngine.cs` and preserves the existing external behavior/invariants described in the subsystem contract.

### Testing
- Static code inspection and repository search (`rg`) confirmed the new `sourceGear == 1` guard, `scanStartSpeedKph` computation, and that the solver still uses `aNext >= aCurr`.
- Attempted to run a full build with `dotnet build LaunchPlugin.sln -c Release`, but the `dotnet` tool is not available in this environment so the build was not executed.
- No automated unit tests were run in this environment; recommend running the project build and existing CI tests to validate runtime behavior and confirm gear 1 learned RPM remains 0 and gears 2–6 solves are stable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addef20d50832f976959fbb3341101)