### PR TITLE
Profiles UI tidy-up: CAR/LAUNCH/SHIFT/TRACKS tabs + remove duplicated Global Settings block

### DIFF
--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -1,7 +1,7 @@
 # Plugin UI Tooltips
 
-Validated against commit: b9250e1
-Last updated: 2026-02-24
+Validated against commit: HEAD
+Last updated: 2026-03-18
 Branch: work
 
 ## CopyProfileDialog.xaml
@@ -193,90 +193,52 @@ Branch: work
 - L42: Rename the selected profile.
 - L46: Instantly copies these settings to the active car for this session.
 - L48: Saves all profiles to the JSON file.
-- L60: How long the rejoin warning remains visible after returning to the track (in seconds).
-- L70: The minimum speed (in km/h) above which the rejoin warning automatically clears.
-- L80: Yaw rate (degrees per second) above which a spin event is detected and triggers rejoin assist.
-- L90: How many seconds behind an approaching car must be projected to trigger the overtake alert.
-- L100: Target deceleration for pit entry braking assist (m/s²).
-- L110: Distance before the pit entry trigger point to start the braking assist.
-- L128: The target engine RPM to hold during launch control activation.
-- L138: Allowed deviation (±RPM) from the target launch RPM before the system flags it as out of range.
-- L148: Throttle percentage to apply when holding the launch RPM target.
-- L158: Accepted throttle percentage deviation from target before launch control gives a warning.
-- L168: Clutch engagement percentage considered the ideal bite point for launch.
-- L178: Allowed deviation (±%) around the target bite point during launch setup.
-- L188: Launch performance reduction factor to simulate clutch bog or wheel slip.
-- L198: Throttle or clutch percentage threshold below which an anti-stall warning is triggered.
-- L211: Default contingency amount added to fuel plans.
-- L213: Toggle whether the contingency value represents laps or litres.
-- L215: Fuel burn multiplier for wet conditions (%).
-- L222: How many seconds slower your average race pace is compared to your personal best lap (e.g., 1.2).
-- L229: Adjust the race pace delta used for planning (sec).
-- L242: Average refuel rate (L/s). Updates after a live refuel event if available.
-- L249: Set the refuel rate (L/s). Live refuel events can update this value.
-- L255: Base tank capacity for this car. Use Learn from Live to pull from live max fuel.
-- L265: Base tank size (L). Leave blank to use the default.
-- L270: Capture the current live max fuel as the base tank size.
-- L287: Tracks with saved data for this profile.
-- L290: Delete the selected track data from this profile.
-- L293: Select a track to edit its saved data.
-- L299: Edit saved data for the selected track.
-- L307: Pit lane loss and pit entry/exit markers for this track.
-- L342: Estimated pit lane loss per stop (sec). Updates from live pits when unlocked.
-- L348: Manual override for pit lane loss (sec).
-- L355: Lock to prevent live pit samples from overwriting this value.
-- L407: Saved pit entry marker as % of lap distance.
-- L417: Lock to prevent live marker updates from overwriting pit entry/exit values.
-- L423: Saved pit exit marker as % of lap distance.
-- L434: Last time these pit markers were updated.
-- L451: Reload LalaLaunch.TrackMarkers.json from disk (for manual edits).
-- L455: Clear pit markers and relearn them from the next live pit cycle.
-- L466: Dry-condition pace and fuel data for this track.
-- L493: Best dry lap time stored for this track.
-- L497: Manual override for best dry lap time (m:ss.fff).
-- L511: Average dry lap time used for planning (m:ss.fff).
-- L516: Manual override for average dry lap time (m:ss.fff).
-- L540: Dry fuel burn values used for planning (L/lap).
-- L548: Lowest observed dry fuel burn (L/lap).
-- L553: Manual override for dry ECO fuel burn (L/lap).
-- L561: Average observed dry fuel burn (L/lap).
-- L565: Manual override for dry AVG fuel burn (L/lap).
-- L573: Highest observed dry fuel burn (L/lap).
-- L577: Manual override for dry MAX fuel burn (L/lap).
-- L590: Number of dry fuel samples collected for this track.
-- L597: Last time dry fuel data was updated.
-- L608: Lock to prevent live dry data from overwriting these values.
-- L613: Clear dry data and relearn from new live laps (while unlocked).
-- L621: Wet-condition pace and fuel data for this track.
-- L648: Best wet lap time stored for this track.
-- L652: Manual override for best wet lap time (m:ss.fff).
-- L666: Average wet lap time used for planning (m:ss.fff).
-- L671: Manual override for average wet lap time (m:ss.fff).
-- L695: Wet fuel burn values used for planning (L/lap).
-- L703: Lowest observed wet fuel burn (L/lap).
-- L708: Manual override for wet ECO fuel burn (L/lap).
-- L716: Average observed wet fuel burn (L/lap).
-- L720: Manual override for wet AVG fuel burn (L/lap).
-- L728: Highest observed wet fuel burn (L/lap).
-- L732: Manual override for wet MAX fuel burn (L/lap).
-- L745: Number of wet fuel samples collected for this track.
-- L752: Last time wet fuel data was updated.
-- L763: Lock to prevent live wet data from overwriting these values.
-- L768: Clear wet data and relearn from new live laps (while unlocked).
-- L775: Computed deltas between wet and dry averages for this track.
+- L52: `CAR` tab header replaces the old `DASH` tab.
+- L64: Average refuel rate (L/s). Updates after a live refuel event if available.
+- L70: Set the refuel rate (L/s). Live refuel events can update this value.
+- L77: Base tank capacity for this car. Use Learn from Live to pull from live max fuel.
+- L86: Base tank size (L). Leave blank to use the default.
+- L91: Capture the current live max fuel as the base tank size.
+- L97: How long the rejoin warning remains visible after returning to the track (in seconds).
+- L107: The minimum speed (in km/h) above which the rejoin warning automatically clears.
+- L117: Yaw rate (degrees per second) above which a spin event is detected and triggers rejoin assist.
+- L127: How many seconds behind an approaching car must be projected to trigger the overtake alert.
+- L137: Target deceleration for pit entry braking assist (m/s²).
+- L147: Distance before the pit entry trigger point to start the braking assist.
+- L162: `LAUNCH` tab header for per-profile launch controls.
+- L166: The target engine RPM to hold during launch control activation.
+- L176: Allowed deviation (±RPM) from the target launch RPM before the system flags it as out of range.
+- L186: Throttle percentage to apply when holding the launch RPM target.
+- L196: Accepted throttle percentage deviation from target before launch control gives a warning.
+- L206: Clutch engagement percentage considered the ideal bite point for launch.
+- L216: Allowed deviation (±%) around the target bite point during launch setup.
+- L226: Launch performance reduction factor to simulate clutch bog or wheel slip.
+- L236: Throttle or clutch percentage threshold below which an anti-stall warning is triggered.
+- L775: `TRACKS` tab header now also hosts the moved car-profile planning defaults block.
+- L784: Tracks with saved data for this profile.
+- L788: Delete the selected track data from this profile.
+- L791: Select a track to edit its saved data.
+- L797: Planning defaults shown in the Tracks workflow while still saving to the selected car profile.
+- L799: Default contingency amount added to fuel plans.
+- L801: Toggle whether the contingency value represents laps or litres.
+- L803: Fuel burn multiplier for wet conditions (%).
+- L811: How many seconds slower your average race pace is compared to your personal best lap (e.g., 1.2).
+- L817: Adjust the race pace delta used for planning (sec).
+- L826: Edit saved data for the selected track.
+- L833: Pit lane loss and pit entry/exit markers for this track.
+- The remainder of the `TRACKS` tab continues to expose the existing pit-loss, marker, dry-condition, wet-condition, and delta editors; this tidy-up only moved the four planning-default controls into the top of the tab and did not change their bindings or track-data editors.
 
 ## Shift Assist controls
-- `ProfilesManagerView.xaml` L219: `Enable Shift Assist` toggle exists without a tooltip string.
-- `ProfilesManagerView.xaml` L220-L221: `Learning mode` tooltip explains shift-point data mining and learning-overlay visibility.
-- `ProfilesManagerView.xaml` L234-L238: `Shift Light` toggle tooltip clarifies it gates canonical `ShiftAssist.ShiftLight` visibility/export semantics (legacy alias `ShiftAssist.BeepLight`).
-- `ProfilesManagerView.xaml` L240-L244: `Shift Light Duration (ms)` tooltip clarifies this controls the Shift Light latch exports (`ShiftAssist.ShiftLight` / `ShiftLightPrimary` / `ShiftLightUrgent`) only, not WAV playback length.
-- `ProfilesManagerView.xaml` L282-L312: `Shift Light Mode` label/selector tooltip: "Choose which cue types drive the shift light latch/export. Audio is controlled separately by Shift Sound / Urgent sound."
-- `ProfilesManagerView.xaml` L290: `Shift Sound` toggle exists without a tooltip string.
-- `ProfilesManagerView.xaml` L309: `Test Sound` button exists without a tooltip string.
-- `ProfilesManagerView.xaml` L310-L321: `Beep volume` label/slider tooltip says it controls primary beep volume and urgent beep derives at 50% of this value.
-- `ProfilesManagerView.xaml` L327-L331: `Urgent sound` tooltip: "Plays a delayed secondary shift beep (1s after primary) at 50% of the main beep volume."
-- `ProfilesManagerView.xaml` L331-L345: gear stack selector + Add/Save/Delete buttons include tooltips on action buttons, but selector itself has no tooltip.
-- `ProfilesManagerView.xaml` L347-L423: shift target grid and learning/runtime stat panel are mostly label-only with no tooltip strings.
-- `ProfilesManagerView.xaml` L433-L492: custom WAV controls include tooltip on path textbox and browse button, while some adjacent labels/buttons remain tooltip-free.
-- `GlobalSettingsView.xaml` L191-L195: `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
-- `GlobalSettingsView.xaml` L196-L200: `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).
+- `ProfilesManagerView.xaml` L251: `SHIFT` tab header for per-profile shift controls.
+- `ProfilesManagerView.xaml` L257: `Enable Shift Assist` toggle exists without a tooltip string.
+- `ProfilesManagerView.xaml` L274-L280: `Shift Light` toggle and duration tooltip clarify canonical `ShiftAssist.ShiftLight` latch/export semantics.
+- `ProfilesManagerView.xaml` L320-L356: `Shift Light Mode` label/selector tooltip says audio is controlled separately by Shift Sound / Urgent sound.
+- `ProfilesManagerView.xaml` L373: `Shift Sound` toggle exists without a tooltip string.
+- `ProfilesManagerView.xaml` L394: `Test Sound` button exists without a tooltip string.
+- `ProfilesManagerView.xaml` L395-L411: `Beep volume` label/slider tooltip says it controls primary beep volume and urgent beep derives at 50% of this value.
+- `ProfilesManagerView.xaml` L411-L417: `Urgent sound` tooltip says it plays a delayed secondary shift beep at 50% of the main beep volume.
+- `ProfilesManagerView.xaml` L522: `Learning mode` tooltip explains shift-point data mining and learning-overlay visibility.
+- `ProfilesManagerView.xaml` L751-L768: custom WAV controls include the existing path/browse affordance while some adjacent labels remain tooltip-free.
+- `GlobalSettingsView.xaml` no longer contains the duplicated per-profile `USER VARIABLES` block; true global sections now begin with `DRIVER TAGS`.
+- `GlobalSettingsView.xaml` L154-L158: `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
+- `GlobalSettingsView.xaml` L158-L162: `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
-Validated against commit: dce8db8
-Last updated: 2026-03-07
+Validated against commit: HEAD
+Last updated: 2026-03-18
 Branch: work
 
 ## What this repo is
@@ -21,6 +21,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 - [CODEX_CONTRACT.txt](CODEX_CONTRACT.txt) - mandatory Codex/global engineering policy.
 - [Architecture_Guardrails.md](Architecture_Guardrails.md) - practical architecture boundaries and subsystem ownership guidance.
 - [CODEX_TASK_TEMPLATE.txt](CODEX_TASK_TEMPLATE.txt) - reusable task skeleton for analysis-first Codex work.
+- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls.
 - [SimHubParameterInventory.md](SimHubParameterInventory.md) - canonical SimHub export contract.
 - [SimHubLogMessages.md](SimHubLogMessages.md) - canonical Info/Warn/Error log catalogue.
 - [Subsystems/Shift_Assist.md](Subsystems/Shift_Assist.md) - Shift Assist purpose, inputs/state, outputs, and validation checklist.
@@ -49,6 +50,6 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 | Dash integration | Main/message/overlay visibility, screen state exports, and global dark-mode controls (`LalaLaunch.Dash.DarkMode.*`) | [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## Freshness
-- Validated against commit: dce8db8
-- Date: 2026-03-07
+- Validated against commit: HEAD
+- Date: 2026-03-18
 - Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-03-17
+Last updated: 2026-03-18
 Branch: work
 
 ## Current repo/link status
@@ -9,25 +9,16 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/SimHubParameterInventory.md` updated for the revised `LalaLaunch.PreRace.*` public contract (Auto delta basis fix + new `StatusText` export).
-- `Docs/Plugin_UI_Tooltips.md` updated to describe pit mode selection as a PreRace on-grid info layer control.
-- `Docs/Subsystems/Fuel_Model.md` updated to replace Strategy export guidance with the PreRace adapter/export contract and source-label behavior.
-- `Docs/Subsystems/Fuel_Planner_Tab.md` updated to clarify planner authority vs PreRace display intent.
+- `Docs/Plugin_UI_Tooltips.md` updated for the Profiles tab tidy-up (`CAR` / `LAUNCH` / `SHIFT` / `TRACKS`) and the Global Settings cleanup.
+- `Docs/Project_Index.md` refreshed to surface `Plugin_UI_Tooltips.md` in the canonical docs list.
+- `Docs/RepoStatus.md` updated with the validation summary for this UI-only tidy-up.
 
 ## Delivery status highlights
-- Decoupled persisted PreRace mode from planner logic: new `SelectedPreRaceMode` (FuelCalcs runtime) with persisted `PreRaceMode` fields in profiles/presets; legacy `PitStrategyMode` JSON keys map into the PreRace-only field for compatibility.
-- Removed PreRace mode influence from planner calculations (`CalculateSingleStrategy` no longer branches on mode intent), so mode changes no longer trigger planner recalculation side effects.
-- Refactored race-start dash-facing outputs from `LalaLaunch.Strategy.*` to `LalaLaunch.PreRace.*` in `LalaLaunch.cs`.
-- Implemented unified PreRace outputs with one stints value, one total-fuel value, and one delta value; Auto now mirrors planner outputs when planner values are available and falls back at runtime when unavailable.
-- Preserved selected mode persistence/label behavior (0 No Stop, 1 Single Stop, 2 Multi Stop, 3 Auto).
-- PreRace race distance basis remains `DataCorePlugin.GameRawData.CurrentSessionInfo._SessionTime` (+ after-zero allowance).
-- Implemented explicit source ordering for pre-race manual-mode inputs and a fixed +2-lap manual allowance:
-  - Fuel burn: planner/profile value -> SimHub computed burn -> hard fallback (3.0 L/lap).
-  - Lap time: planner/profile value -> SimHub/iRacing predicted value chain -> hard fallback (120.0 s).
-- `Single Stop` PreRace delta continues to use current fuel + pit-menu refuel intent (`PitSvFuel`) for live on-grid response.
-- `Auto` PreRace totals/stints remain planner-first; Auto delta uses live pit-menu add intent only when planner-required next add (`PlannerNextAddLitres`) is greater than zero, and otherwise falls back to planner fuel-basis delta without pit-menu add intent.
-- Added `LalaLaunch.PreRace.StatusText` export (`STRATEGY OKAY` / `STRATEGY MARGINAL` / `UNABLE STRATEGY`) with initial mode+stints thresholding and explicit +0.2 stints marginal tolerance for No Stop and Single Stop.
-- Planner and continuous live `Fuel.*` model behavior remain unchanged beyond read-only reuse of existing inputs.
+- Profiles UI sub-tabs now read `CAR`, `LAUNCH`, `SHIFT`, and `TRACKS`; the old `DASH` and `FUEL` tabs were removed.
+- The `CAR` tab now contains the existing car-profile-backed refuel, base-tank, rejoin, overtake, spin, and pit-entry controls without changing their bindings or persistence scope.
+- The `TRACKS` tab now hosts the existing `Wet Fuel Multiplier`, `Race Pace Delta`, and contingency controls at the top of the workflow, but they still bind to the same existing car-profile properties as before.
+- Global Settings no longer shows the duplicated per-profile `USER VARIABLES` block; the remaining sections continue to cover true global settings only.
+- No persistence/schema/runtime behavior changed in this tidy-up: car-profile save/load, default-profile copy seeding, fuel planner/runtime math, launch behavior, shift behavior, pit-entry math, and telemetry behavior remain as before.
 
 ## Notes
 - `Docs/Code_Snapshot.md` remains non-canonical orientation-only documentation.

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -21,44 +21,6 @@
     </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10">
-            <TextBlock Text="USER VARIABLES (PER-PROFILE)" FontSize="16" FontWeight="Bold" Margin="0,5,10,0"/>
-            <StackPanel Orientation="Horizontal" Margin="5,0,0,10">
-                <TextBlock Text="{Binding ActiveProfile.ProfileName, StringFormat='Current Profile: {0}'}"
-                           HorizontalAlignment="Left" FontSize="13" Foreground="DarkGray" VerticalAlignment="Center"/>
-
-                <styles:SHButtonPrimary Content="Save to Profile" Margin="15,0,0,0"
-                                        Command="{Binding SaveActiveProfileCommand}"
-                                        ToolTip="Save the current dash user variables to this profile."
-                                        Visibility="{Binding IsActiveProfileDirty, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-
-                <styles:SHButtonPrimary Content="Return to Defaults" Margin="5,0,0,0"
-                                        Command="{Binding ReturnToDefaultsCommand}"
-                                        ToolTip="Resets the view to the 'Default Settings' profile."
-                                        Visibility="{Binding CanReturnToDefaults, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            </StackPanel>
-            <Grid Margin="0,0,0,0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-
-                <StackPanel Grid.Column="0">
-                    <ui:TitledSlider Title="Rejoin Assist Linger Time (sec): " Minimum="1" Maximum="30" Value="{Binding ActiveProfile.RejoinWarningLingerTime, Mode=TwoWay}"
-                                     ToolTip="How long the rejoin warning remains after you return to the track (sec)." />
-                    <ui:TitledSlider Title="Rejoin Assist Clear Speed (kph): " Minimum="10" Maximum="250" Value="{Binding ActiveProfile.RejoinWarningMinSpeed, Mode=TwoWay}"
-                                     ToolTip="Speed (kph) above which the rejoin warning clears automatically." />
-                    <ui:TitledSlider Title="Spin Yaw Rate Threshold: " Minimum="10" Maximum="100" Value="{Binding ActiveProfile.SpinYawRateThreshold, Mode=TwoWay}"
-                                     ToolTip="Yaw rate (deg/s) above which a spin is detected." />
-                    <ui:TitledSlider Title="Overtake Alert activation (sec): " Minimum="1" Maximum="20" Value="{Binding ActiveProfile.TrafficApproachWarnSeconds, Mode=TwoWay}"
-                                     ToolTip="Seconds to impact for an approaching car before an overtake alert triggers." />
-                    <ui:TitledSlider Title="Pit Entry Decel (m/s²): " Minimum="8" Maximum="22" Value="{Binding ActiveProfile.PitEntryDecelMps2, Mode=TwoWay}"
-                                     ToolTip="Target braking deceleration for pit entry assist (m/s²)." />
-                    <ui:TitledSlider Title="Pit Entry Buffer (m): " Minimum="0" Maximum="40" Value="{Binding ActiveProfile.PitEntryBufferM, Mode=TwoWay}"
-                                     ToolTip="Distance before pit entry to start the braking assist (m)." />
-                </StackPanel>
-            </Grid>
- 
-            <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" Height="2" />
             <styles:SHSection Title="DRIVER TAGS" ShowSeparator="True">
                 <StackPanel>
                     <TextBlock Margin="0,0,0,5" Foreground="LightGray"

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -49,8 +49,50 @@
             </StackPanel>
 
             <TabControl>
-                <styles:SHTabItem Header="DASH">
-                    <StackPanel Margin="10" DataContext="{Binding SelectedProfile}">
+                <styles:SHTabItem Header="CAR">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="10" DataContext="{Binding SelectedProfile}">
+
+                            <Grid Margin="0,0,0,15">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="20" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Text="Refuel Rate (L/s):" ToolTip="Average refuel rate (L/s). Updates after a live refuel event if available."/>
+                                    <Grid Margin="0,4,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RefuelRate, Mode=TwoWay}" Minimum="1" Maximum="10" SmallChange="0.05" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                                ToolTip="Set the refuel rate (L/s). Live refuel events can update this value."/>
+                                        <TextBlock Grid.Column="1" Text="{Binding RefuelRate, StringFormat=N2}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
+                                    </Grid>
+                                </StackPanel>
+
+                                <StackPanel Grid.Column="2">
+                                    <TextBlock Text="Base Tank (L):" ToolTip="Base tank capacity for this car. Use Learn from Live to pull from live max fuel."/>
+                                    <Grid Margin="0,4,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBox Grid.Column="0"
+                                                 Margin="0,0,0,0"
+                                                 TextAlignment="Right"
+                                                 Text="{Binding BaseTankLitres, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"
+                                                 ToolTip="Base tank size (L). Leave blank to use the default."/>
+                                        <styles:SHButtonSecondary Grid.Column="1"
+                                                                  Content="Learn from Live"
+                                                                  Margin="8,0,0,0"
+                                                                  Command="{Binding DataContext.LearnBaseTankCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                  ToolTip="Capture the current live max fuel as the base tank size."/>
+                                    </Grid>
+                                </StackPanel>
+                            </Grid>
 
                         <ui:TitledSlider Title="Rejoin Assist Linger Time (sec)"
                          Minimum="1" Maximum="30"
@@ -112,7 +154,8 @@
                             </ui:TitledSlider.ToolTip>
                         </ui:TitledSlider>
 
-                    </StackPanel>
+                        </StackPanel>
+                    </ScrollViewer>
                 </styles:SHTabItem>
 
 
@@ -729,76 +772,6 @@
                     </ScrollViewer>
                 </styles:SHTabItem>
 
-
-                <styles:SHTabItem Header="FUEL">
-                    <StackPanel Margin="10" DataContext="{Binding SelectedProfile}">
-                        <ui:TitledSlider Title="Contingency Laps/Litres" Minimum="0" Maximum="10" Value="{Binding FuelContingencyValue, Mode=TwoWay}"
-                                         ToolTip="Default contingency amount added to fuel plans." />
-                        <styles:SHToggleCheckbox Content="Contingency is in Laps (otherwise Litres)" IsChecked="{Binding IsContingencyInLaps, Mode=TwoWay}" Margin="5,10,0,0"
-                                                 ToolTip="Toggle whether the contingency value represents laps or litres."/>
-                        <ui:TitledSlider Title="Wet Fuel Multiplier (%)" Minimum="70" Maximum="130" Value="{Binding WetFuelMultiplier, Mode=TwoWay}" Margin="0,15,0,0"
-                                         ToolTip="Fuel burn multiplier for wet conditions (%)."/>
-
-                        <Grid Margin="0,15,0,0">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Text="Race Pace Delta (seconds):" ToolTip="How many seconds slower your average race pace is compared to your personal best lap (e.g., 1.2)."/>
-                            <Grid Grid.Row="1">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RacePaceDeltaSeconds, Mode=TwoWay}" Minimum="0" Maximum="5" SmallChange="0.1" TickFrequency="0.1" IsSnapToTickEnabled="True"
-                                        ToolTip="Adjust the race pace delta used for planning (sec)."/>
-                                <TextBlock Grid.Column="1" Text="{Binding RacePaceDeltaSeconds, StringFormat=N1}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
-                            </Grid>
-                        </Grid>
-
-                        <Grid Margin="0,15,0,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="20" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-
-                            <StackPanel Grid.Column="0">
-                                <TextBlock Text="Refuel Rate (L/s):" ToolTip="Average refuel rate (L/s). Updates after a live refuel event if available."/>
-                                <Grid Margin="0,4,0,0">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RefuelRate, Mode=TwoWay}" Minimum="1" Maximum="10" SmallChange="0.05" TickFrequency="0.05" IsSnapToTickEnabled="True"
-                                            ToolTip="Set the refuel rate (L/s). Live refuel events can update this value."/>
-                                    <TextBlock Grid.Column="1" Text="{Binding RefuelRate, StringFormat=N2}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
-                                </Grid>
-                            </StackPanel>
-
-                            <StackPanel Grid.Column="2">
-                                <TextBlock Text="Base Tank (L):" ToolTip="Base tank capacity for this car. Use Learn from Live to pull from live max fuel."/>
-                                <Grid Margin="0,4,0,0">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <TextBox Grid.Column="0"
-                                             Margin="0,0,0,0"
-                                             TextAlignment="Right"
-                                             Text="{Binding BaseTankLitres, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"
-                                             ToolTip="Base tank size (L). Leave blank to use the default."/>
-                                    <styles:SHButtonSecondary Grid.Column="1"
-                                                              Content="Learn from Live"
-                                                              Margin="8,0,0,0"
-                                                              Command="{Binding DataContext.LearnBaseTankCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                              ToolTip="Capture the current live max fuel as the base tank size."/>
-                                </Grid>
-                            </StackPanel>
-                        </Grid>
-                    </StackPanel>
-                </styles:SHTabItem>
-
                 <styles:SHTabItem Header="TRACKS">
                     <Grid Margin="10">
                         <Grid.ColumnDefinitions>
@@ -820,6 +793,35 @@
 
                         <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                             <StackPanel DataContext="{Binding SelectedTrack}" Grid.IsSharedSizeScope="True" IsEnabled="{Binding DataContext.IsTrackSelected, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                <GroupBox Header="Planning Defaults" Margin="0,0,0,10"
+                                          ToolTip="Car-profile planning defaults shown here for track workflow, while continuing to save to the selected car profile.">
+                                    <StackPanel Margin="8,6,8,8" DataContext="{Binding DataContext.SelectedProfile, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                        <ui:TitledSlider Title="Contingency Laps/Litres" Minimum="0" Maximum="10" Value="{Binding FuelContingencyValue, Mode=TwoWay}"
+                                                         ToolTip="Default contingency amount added to fuel plans." />
+                                        <styles:SHToggleCheckbox Content="Contingency is in Laps (otherwise Litres)" IsChecked="{Binding IsContingencyInLaps, Mode=TwoWay}" Margin="5,10,0,0"
+                                                                 ToolTip="Toggle whether the contingency value represents laps or litres."/>
+                                        <ui:TitledSlider Title="Wet Fuel Multiplier (%)" Minimum="70" Maximum="130" Value="{Binding WetFuelMultiplier, Mode=TwoWay}" Margin="0,15,0,0"
+                                                         ToolTip="Fuel burn multiplier for wet conditions (%)."/>
+
+                                        <Grid Margin="0,15,0,0">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <TextBlock Grid.Row="0" Text="Race Pace Delta (seconds):" ToolTip="How many seconds slower your average race pace is compared to your personal best lap (e.g., 1.2)."/>
+                                            <Grid Grid.Row="1">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <Slider Grid.Column="0" VerticalAlignment="Center" Value="{Binding RacePaceDeltaSeconds, Mode=TwoWay}" Minimum="0" Maximum="5" SmallChange="0.1" TickFrequency="0.1" IsSnapToTickEnabled="True"
+                                                        ToolTip="Adjust the race pace delta used for planning (sec)."/>
+                                                <TextBlock Grid.Column="1" Text="{Binding RacePaceDeltaSeconds, StringFormat=N1}" VerticalAlignment="Center" Margin="10,0,0,0" MinWidth="35" TextAlignment="Right"/>
+                                            </Grid>
+                                        </Grid>
+                                    </StackPanel>
+                                </GroupBox>
+
                                 <TextBlock FontWeight="Bold"
                                            ToolTip="Edit saved data for the selected track.">
                                     <Run Text="Editing Data for: "/>


### PR DESCRIPTION
### Motivation
- Clean up duplicated and mis-homed per-profile controls by reorganising the Profiles tab into `CAR` / `LAUNCH` / `SHIFT` / `TRACKS` for clearer workflow and to remove redundant UI in Global Settings.
- Keep all moved controls bound to the same existing car-profile properties and preserve current persistence/behaviour invariants (no schema or runtime changes).
- Update the documentation inventory so tooltips/index/status reflect the new UI layout.

### Description
- Renamed the previous `DASH` tab to `CAR` and moved `Refuel Rate` and `Base Tank` controls into the `CAR` tab while leaving bindings unchanged (`RefuelRate`, `BaseTankLitres`).
- Removed the `FUEL` tab and added a `Planning Defaults` block at the top of the `TRACKS` tab that hosts `Contingency Laps/Litres`, `Contingency mode`, `Wet Fuel Multiplier`, and `Race Pace Delta`, still bound to the same car-profile properties (`FuelContingencyValue`, `IsContingencyInLaps`, `WetFuelMultiplier`, `RacePaceDeltaSeconds`).
- Deleted the duplicated per-profile `USER VARIABLES` block from `GlobalSettingsView.xaml` so the global settings page now starts with true global sections (e.g. `DRIVER TAGS` and debug options).
- Updated docs: `Docs/Plugin_UI_Tooltips.md` to reflect the new tab layout and control locations, and refreshed `Docs/Project_Index.md` and `Docs/RepoStatus.md` to record the UI tidy-up and documentation sync.
- Files changed: `ProfilesManagerView.xaml`, `GlobalSettingsView.xaml`, `Docs/Plugin_UI_Tooltips.md`, `Docs/Project_Index.md`, and `Docs/RepoStatus.md`.

### Testing
- Parsed `ProfilesManagerView.xaml` and `GlobalSettingsView.xaml` with Python `xml.etree.ElementTree` and parsing succeeded for both files (XML well-formed).
- Ran targeted text checks to confirm the removed tab headers and duplicated block are absent and that moved controls still bind to the original properties; these searches succeeded (pattern checks for tab headers and binding names found expected new locations).
- Attempted a project build with `msbuild`, but `msbuild`/build tooling was not available in the execution container so a full compile could not be run (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf8c20a60832f8144ba86dacb273e)