### PR TITLE
UI: Tidy Dashes tab layout, move launch bindings, surface Event Marker in Global Debug, update docs

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -8,83 +8,110 @@
              xmlns:ui="clr-namespace:SimHub.Plugins.UI;assembly=SimHub.Plugins"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="1200" x:Name="DashSettingsPage">
 
-
     <ScrollViewer
         VerticalScrollBarVisibility="Auto"
         HorizontalScrollBarVisibility="Disabled">
-        <Grid>
-            <StackPanel Margin="10">
-                <TextBlock Text="DASH BINDINGS" FontSize="16" FontWeight="Bold" Margin="0,5,0,0"/>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0" Margin="0,0,10,0">
-                        <ui:ControlsEditor ActionName="LalaLaunch.MsgCx" FriendlyName="Cancel Msg Button" ToolTip="Assign a button to cancel the current popup message." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.TogglePitScreen" FriendlyName="Toggle Pit Screen Popup" ToolTip="Assign a button to show or hide the pit screen popup." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.LaunchMode"
-                       FriendlyName="Launch Mode" ToolTip="Manual prime/abort launch mode (useful for testing and non-standing-start sessions)." />
+        <StackPanel Margin="10" MaxWidth="820" HorizontalAlignment="Left">
+            <GroupBox Header="BINDINGS" Margin="0,0,0,12">
+                <StackPanel Margin="12,10,12,12">
+                    <ui:ControlsEditor ActionName="LalaLaunch.MsgCx"
+                                       FriendlyName="Cancel Msg Button"
+                                       ToolTip="Assign a button to cancel the current popup message." />
+                    <ui:ControlsEditor ActionName="LalaLaunch.TogglePitScreen"
+                                       FriendlyName="Toggle Pit Screen Popup"
+                                       Margin="0,8,0,0"
+                                       ToolTip="Assign a button to show or hide the pit screen popup." />
+                    <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode"
+                                       FriendlyName="Change Primary Dash Mode"
+                                       Margin="0,8,0,0"
+                                       ToolTip="Assign a button to cycle primary dash modes (main screen views)." />
+                    <ui:ControlsEditor ActionName="LalaLaunch.DeclutterMode"
+                                       FriendlyName="Cycle Declutter Mode"
+                                       Margin="0,8,0,0"
+                                       ToolTip="Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings." />
+                </StackPanel>
+            </GroupBox>
 
+            <GroupBox Header="GLOBAL DASH FUNCTIONS" Margin="0,0,0,12">
+                <StackPanel Margin="12,10,12,12">
+                    <TextBlock Text="General" FontWeight="Bold" Margin="0,0,0,6"/>
+                    <styles:SHToggleCheckbox Content="Auto screen selection at session start"
+                                             IsChecked="{Binding Settings.EnableAutoDashSwitch, Mode=TwoWay}"
+                                             ToolTip="Automatically switch dash screens when a session starts based on context." />
+
+                    <Separator Margin="0,12,0,12" />
+
+                    <TextBlock Text="Dark Mode" FontWeight="Bold" Margin="0,0,0,6"/>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="Dark Mode:"
+                                   Width="150"
+                                   VerticalAlignment="Center"
+                                   ToolTip="Select Dark Mode behavior: Off, Manual, or Auto."/>
+                        <ComboBox Width="180"
+                                  SelectedValue="{Binding Settings.DarkModeMode, Mode=TwoWay}"
+                                  SelectedValuePath="Tag"
+                                  ToolTip="0=Off (forced off), 1=Manual, 2=Auto solar dimming.">
+                            <ComboBoxItem Content="Off" Tag="0" />
+                            <ComboBoxItem Content="Manual" Tag="1" />
+                            <ComboBoxItem Content="Auto" Tag="2" />
+                        </ComboBox>
                     </StackPanel>
-                    <StackPanel Grid.Column="1" Margin="0,0,0,0">
-                        <ui:ControlsEditor ActionName="LalaLaunch.PrimaryDashMode" FriendlyName="Change Primary Dash Mode" ToolTip="Assign a button to cycle primary dash modes (main screen views)." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.DeclutterMode" FriendlyName="Cycle Declutter Mode" ToolTip="Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.ToggleDarkMode" FriendlyName="Toggle Dark Mode" ToolTip="Assign a button to cycle LalaLaunch Dark Mode mode (Off → Manual → Auto). Warning: don’t bind this to the same button as Lovely’s True Dark toggle. If ‘Use Lovely True Dark’ is enabled and Lovely is available, LalaLaunch toggle is ignored." />
-                        <ui:ControlsEditor ActionName="LalaLaunch.EventMarker" FriendlyName="Event Marker" ToolTip="Assign a button to fire a short event marker pulse for dashboards and CSV exports." />
-                    </StackPanel>
-                </Grid>
-                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="0,10,0,5" />
+                    <ui:TitledSlider Title="Dark Mode Brightness (%): "
+                                     Margin="0,8,0,0"
+                                     Minimum="0"
+                                     Maximum="100"
+                                     TickFrequency="1"
+                                     IsSnapToTickEnabled="True"
+                                     Value="{Binding Settings.DarkModeBrightnessPct, Mode=TwoWay}"
+                                     ToolTip="Base Dark Mode brightness percent (0-100). 100 is brightest." />
+                    <styles:SHToggleCheckbox Content="Use Lovely True Dark"
+                                             Margin="0,8,0,0"
+                                             IsChecked="{Binding Settings.UseLovelyTrueDark, Mode=TwoWay}"
+                                             IsEnabled="{Binding IsLovelyAvailableForDarkMode}"
+                                             ToolTip="When Lovely is available, Dark Mode active state can follow Lovely True Dark." />
+                    <ui:ControlsEditor ActionName="LalaLaunch.ToggleDarkMode"
+                                       FriendlyName="Toggle Dark Mode"
+                                       Margin="0,8,0,0"
+                                       ToolTip="Assign a button to cycle LalaLaunch Dark Mode mode (Off → Manual → Auto). Warning: don’t bind this to the same button as Lovely’s True Dark toggle. If ‘Use Lovely True Dark’ is enabled and Lovely is available, LalaLaunch toggle is ignored." />
+                    <TextBlock Text="If using Lovely True Dark, bind only one toggle (Lovely OR LalaLaunch)."
+                               Margin="0,4,0,0"
+                               Opacity="0.85"
+                               TextWrapping="Wrap" />
 
-                <Grid Margin="0,0,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="2*"/>
-                    </Grid.ColumnDefinitions>
+                    <Separator Margin="0,12,0,12" />
 
-                    <StackPanel Grid.Column="0">
-                        <TextBlock Text="GLOBAL DASH FUNCTIONS" FontSize="16" FontWeight="Bold" Margin="0,0,0,5"/>
-                        <styles:SHToggleCheckbox Content="Auto screen selection at session start" IsChecked="{Binding Settings.EnableAutoDashSwitch, Mode=TwoWay}"
-                                                 ToolTip="Automatically switch dash screens when a session starts based on context." />
+                    <TextBlock Text="Fuel" FontWeight="Bold" Margin="0,0,0,6"/>
+                    <ui:TitledSlider Title="Fuel Ready Confidence: "
+                                     Minimum="0"
+                                     Maximum="100"
+                                     Value="{Binding Settings.FuelReadyConfidence, Mode=TwoWay}"
+                                     ToolTip="Minimum confidence (%) before pit strategy uses live fuel. Below this, profile estimates may be used." />
+                    <TextBlock Text="Below 20%, profile fuel may be used for early estimates. Above 20%, pit strategy waits for live fuel data."
+                               FontSize="11"
+                               Opacity="0.7"
+                               TextWrapping="Wrap"
+                               Margin="0,2,0,0"/>
+                    <ui:TitledSlider Title="Pit-in Fuel Reserve (% lap): "
+                                     Margin="0,8,0,0"
+                                     Minimum="0"
+                                     Maximum="30"
+                                     Value="{Binding Settings.StintFuelMarginPct, Mode=TwoWay}"
+                                     ToolTip="Reserve fuel as a percentage of one lap (based on stable fuel burn) when calculating stint burn targets." />
+                </StackPanel>
+            </GroupBox>
 
-                        <StackPanel Orientation="Horizontal" Margin="0,6,0,0" VerticalAlignment="Center">
-                            <TextBlock Text="Dark Mode:" Width="130" VerticalAlignment="Center" ToolTip="Select Dark Mode behavior: Off, Manual, or Auto."/>
-                            <ComboBox Width="160" SelectedValue="{Binding Settings.DarkModeMode, Mode=TwoWay}" SelectedValuePath="Tag" ToolTip="0=Off (forced off), 1=Manual, 2=Auto solar dimming.">
-                                <ComboBoxItem Content="Off" Tag="0" />
-                                <ComboBoxItem Content="Manual" Tag="1" />
-                                <ComboBoxItem Content="Auto" Tag="2" />
-                            </ComboBox>
-                        </StackPanel>
-                        <ui:TitledSlider Title="Dark Mode Brightness (%): " Minimum="0" Maximum="100" TickFrequency="1" IsSnapToTickEnabled="True" Value="{Binding Settings.DarkModeBrightnessPct, Mode=TwoWay}"
-                                         ToolTip="Base Dark Mode brightness percent (0-100). 100 is brightest." />
-                        <styles:SHToggleCheckbox Content="Use Lovely True Dark"
-                                                 IsChecked="{Binding Settings.UseLovelyTrueDark, Mode=TwoWay}"
-                                                 IsEnabled="{Binding IsLovelyAvailableForDarkMode}"
-                                                 ToolTip="When Lovely is available, Dark Mode active state can follow Lovely True Dark." />
-                        <TextBlock Text="If using Lovely True Dark, bind only one toggle (Lovely OR LalaLaunch)."
-                                   Margin="0,4,0,0"
-                                   Opacity="0.85"
-                                   TextWrapping="Wrap" />
-                        <ui:TitledSlider Title="Post-Launch Results Display Time: " Minimum="0" Maximum="30" Value="{Binding Settings.ResultsDisplayTime, Mode=TwoWay}"
-                                         ToolTip="How long the post-launch results screen stays visible (sec)." />
-                        <ui:TitledSlider Title="Fuel Ready Confidence: " Minimum="0" Maximum="100" Value="{Binding Settings.FuelReadyConfidence, Mode=TwoWay}"
-                                         ToolTip="Minimum confidence (%) before pit strategy uses live fuel. Below this, profile estimates may be used." />
-                        <TextBlock
-                            Text="Below 20%, profile fuel may be used for early estimates. Above 20%, pit strategy waits for live fuel data."
-                            FontSize="11"
-                            Opacity="0.7"
-                            TextWrapping="Wrap"
-                            Margin="0,2,0,0"/>
-                        <ui:TitledSlider Title="Pit-in Fuel Reserve (% lap): " Minimum="0" Maximum="30" Value="{Binding Settings.StintFuelMarginPct, Mode=TwoWay}"
-                                         ToolTip="Reserve fuel as a percentage of one lap (based on stable fuel burn) when calculating stint burn targets." />
-                    </StackPanel>
-
-                    <Grid Grid.Column="1" HorizontalAlignment="Right">
+            <GroupBox Header="DASH VISIBILITY">
+                <StackPanel Margin="12,10,12,12">
+                    <TextBlock Text="Choose which dash families can show each feature."
+                               Margin="0,0,0,10"
+                               Opacity="0.8"
+                               TextWrapping="Wrap" />
+                    <Grid HorizontalAlignment="Left">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="220" />
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="130" />
+                            <ColumnDefinition Width="90" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -98,85 +125,108 @@
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <TextBlock Text="" Grid.Row="0" Grid.Column="0" />
-                        <TextBlock Text="MAIN DASH" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="1" />
-                        <TextBlock Text="MESSAGE DASH" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="2" />
-                        <TextBlock Text="OVERLAY" FontSize="16" FontWeight="Bold" Margin="15,0,0,5" Grid.Row="0" Grid.Column="3" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="MAIN DASH" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Text="MESSAGE DASH" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center" />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Text="OVERLAY" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center" />
 
-                        <TextBlock Text="Launch Assist" Margin="0,5,0,0" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Launch Assist" Grid.Row="1" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable the Launch screen for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="1" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowLaunchScreen, Mode=TwoWay}"
                                                  ToolTip="Show the Launch screen on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="1" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowLaunchScreen, Mode=TwoWay}"
                                                  ToolTip="Show the Launch screen on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowLaunchScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="1" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="1" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowLaunchScreen, Mode=TwoWay}"
                                                  ToolTip="Show the Launch screen on the Overlay." />
 
-                        <TextBlock Text="Pit Assists" Margin="0,5,0,0" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Pit Assists" Grid.Row="2" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable the Pit Limiter screen for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="2" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowPitLimiter, Mode=TwoWay}"
                                                  ToolTip="Show the Pit Limiter screen on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="2" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowPitLimiter, Mode=TwoWay}"
                                                  ToolTip="Show the Pit Limiter screen on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowPitLimiter, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="2" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="2" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowPitLimiter, Mode=TwoWay}"
                                                  ToolTip="Show the Pit Limiter screen on the Overlay." />
 
-                        <TextBlock Text="Show Automatic Pit Screen" Margin="0,5,0,0" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Show Automatic Pit Screen" Grid.Row="3" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable the automatic pit screen for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="3" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowPitScreen, Mode=TwoWay}"
                                                  ToolTip="Show the automatic pit screen on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="3" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowPitScreen, Mode=TwoWay}"
                                                  ToolTip="Show the automatic pit screen on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowPitScreen, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="3" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="3" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowPitScreen, Mode=TwoWay}"
                                                  ToolTip="Show the automatic pit screen on the Overlay." />
 
-                        <TextBlock Text="Rejoin Assist" Margin="0,5,0,0" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Rejoin Assist" Grid.Row="4" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable track rejoin assist for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="4" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowRejoinAssist, Mode=TwoWay}"
                                                  ToolTip="Show track rejoin assist on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="4" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowRejoinAssist, Mode=TwoWay}"
                                                  ToolTip="Show track rejoin assist on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowRejoinAssist, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="4" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="4" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowRejoinAssist, Mode=TwoWay}"
                                                  ToolTip="Show track rejoin assist on the Overlay." />
 
-                        <TextBlock Text="Verbose Race Messages" Margin="0,5,0,0" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Verbose Race Messages" Grid.Row="5" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable detailed race messages for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="5" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowVerboseMessaging, Mode=TwoWay}"
                                                  ToolTip="Show verbose race messages on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="5" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowVerboseMessaging, Mode=TwoWay}"
                                                  ToolTip="Show verbose race messages on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowVerboseMessaging, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="5" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="5" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowVerboseMessaging, Mode=TwoWay}"
                                                  ToolTip="Show verbose race messages on the Overlay." />
 
-                        <TextBlock Text="Race Flags" Margin="0,5,0,0" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Race Flags" Grid.Row="6" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable race flag notifications for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="6" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowRaceFlags, Mode=TwoWay}"
                                                  ToolTip="Show race flags on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="6" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowRaceFlags, Mode=TwoWay}"
                                                  ToolTip="Show race flags on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowRaceFlags, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="6" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="6" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowRaceFlags, Mode=TwoWay}"
                                                  ToolTip="Show race flags on the Overlay." />
 
-                        <TextBlock Text="Radio Messages" Margin="0,5,0,0" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Radio Messages" Grid.Row="7" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable radio message popups for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="7" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowRadioMessages, Mode=TwoWay}"
                                                  ToolTip="Show radio messages on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="7" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowRadioMessages, Mode=TwoWay}"
                                                  ToolTip="Show radio messages on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowRadioMessages, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="7" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="7" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowRadioMessages, Mode=TwoWay}"
                                                  ToolTip="Show radio messages on the Overlay." />
 
-                        <TextBlock Text="Show Traffic Alerts" Margin="0,5,0,0" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"
+                        <TextBlock Text="Show Traffic Alerts" Grid.Row="8" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable traffic alert warnings for this dash type." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.LalaDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="1"
+                        <styles:SHToggleCheckbox Grid.Row="8" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.LalaDashShowTraffic, Mode=TwoWay}"
                                                  ToolTip="Show traffic alerts on the Main Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.MsgDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="2"
+                        <styles:SHToggleCheckbox Grid.Row="8" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.MsgDashShowTraffic, Mode=TwoWay}"
                                                  ToolTip="Show traffic alerts on the Message Dash." />
-                        <styles:SHToggleCheckbox Content="" IsChecked="{Binding Settings.OverlayDashShowTraffic, Mode=TwoWay}" Margin="15,5,0,0" Grid.Row="8" Grid.Column="3"
+                        <styles:SHToggleCheckbox Grid.Row="8" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
+                                                 IsChecked="{Binding Settings.OverlayDashShowTraffic, Mode=TwoWay}"
                                                  ToolTip="Show traffic alerts on the Overlay." />
                     </Grid>
-                </Grid>
-            </StackPanel>
-        </Grid>
+                </StackPanel>
+            </GroupBox>
+        </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -1,4 +1,4 @@
-# Plugin UI Tooltips
+﻿# Plugin UI Tooltips
 
 Validated against commit: HEAD
 Last updated: 2026-03-18
@@ -15,53 +15,12 @@ Branch: work
 - L40: Close without copying.
 
 ## DashesTabView.xaml
-- L24: Assign a button to cancel the current popup message.
-- L25: Assign a button to show or hide the pit screen popup.
-- L27: Manual prime/abort launch mode (useful for testing and non-standing-start sessions).
-- L31: Assign a button to cycle primary dash modes (main screen views).
-- L32: Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings.
-- L33: Assign a button to cycle LalaLaunch Dark Mode mode (Off → Manual → Auto). Warning: don’t bind this to the same button as Lovely’s True Dark toggle. If ‘Use Lovely True Dark’ is enabled and Lovely is available, LalaLaunch toggle is ignored.
-- L34: Assign a button to fire a short event marker pulse for dashboards and CSV exports.
-- L48: Automatically switch dash screens when a session starts based on context.
-- L51: Select Dark Mode behavior: Off, Manual, or Auto.
-- L52: 0=Off (forced off), 1=Manual, 2=Auto solar dimming.
-- L59: Base Dark Mode brightness percent (0-100). 100 is brightest.
-- L63: When Lovely is available, Dark Mode active state can follow Lovely True Dark.
-- L69: How long the post-launch results screen stays visible (sec).
-- L71: Minimum confidence (%) before pit strategy uses live fuel. Below this, profile estimates may be used.
-- L79: Reserve fuel as a percentage of one lap (based on stable fuel burn) when calculating stint burn targets.
-- L107: Enable the Launch screen for this dash type.
-- L109: Show the Launch screen on the Main Dash.
-- L111: Show the Launch screen on the Message Dash.
-- L113: Show the Launch screen on the Overlay.
-- L116: Enable the Pit Limiter screen for this dash type.
-- L118: Show the Pit Limiter screen on the Main Dash.
-- L120: Show the Pit Limiter screen on the Message Dash.
-- L122: Show the Pit Limiter screen on the Overlay.
-- L125: Enable the automatic pit screen for this dash type.
-- L127: Show the automatic pit screen on the Main Dash.
-- L129: Show the automatic pit screen on the Message Dash.
-- L131: Show the automatic pit screen on the Overlay.
-- L134: Enable track rejoin assist for this dash type.
-- L136: Show track rejoin assist on the Main Dash.
-- L138: Show track rejoin assist on the Message Dash.
-- L140: Show track rejoin assist on the Overlay.
-- L143: Enable detailed race messages for this dash type.
-- L145: Show verbose race messages on the Main Dash.
-- L147: Show verbose race messages on the Message Dash.
-- L149: Show verbose race messages on the Overlay.
-- L152: Enable race flag notifications for this dash type.
-- L154: Show race flags on the Main Dash.
-- L156: Show race flags on the Message Dash.
-- L158: Show race flags on the Overlay.
-- L161: Enable radio message popups for this dash type.
-- L163: Show radio messages on the Main Dash.
-- L165: Show radio messages on the Message Dash.
-- L167: Show radio messages on the Overlay.
-- L170: Enable traffic alert warnings for this dash type.
-- L172: Show traffic alerts on the Main Dash.
-- L174: Show traffic alerts on the Message Dash.
-- L176: Show traffic alerts on the Overlay.
+- BINDINGS section: contains only the true dash bindings for `Cancel Msg Button`, `Toggle Pit Screen Popup`, `Change Primary Dash Mode`, and `Cycle Declutter Mode`.
+- GLOBAL DASH FUNCTIONS -> General: `Auto screen selection at session start` automatically switches dash screens when a session starts based on context.
+- GLOBAL DASH FUNCTIONS -> Dark Mode: `Dark Mode` selector uses Off / Manual / Auto, `Dark Mode Brightness` sets base brightness, `Use Lovely True Dark` follows Lovely when available, and `Toggle Dark Mode` remains here as the dark-mode-specific binding row.
+- GLOBAL DASH FUNCTIONS -> Fuel: `Fuel Ready Confidence` sets the live-fuel readiness threshold and `Pit-in Fuel Reserve` sets the stint reserve margin.
+- DASH VISIBILITY section: keeps the existing main/message/overlay visibility matrix for Launch Assist, Pit Assists, Automatic Pit Screen, Rejoin Assist, Verbose Race Messages, Race Flags, Radio Messages, and Traffic Alerts.
+- `Launch Mode`, `Event Marker`, and `Post-Launch Results Display Time` no longer appear in Dash Control after this tidy-up.
 
 ## FuelCalculatorView.xaml
 - L114: Inputs used to calculate the pre-race fuel plan.
@@ -147,6 +106,9 @@ Branch: work
 - L42: Allowed deviation (±%) around the bite point target.
 - L43: If the engine RPM drops below this percentage of the initial Launch RPM, the run will be flagged as 'Bogged'.
 - L44: Sets the sensitivity for detecting game-assisted anti-stall. % is delta between paddle and in game clutch.
+- LAUNCH UI / BINDINGS section: hosts only the moved `Launch Mode` binding and `Post-Launch Results Display Time` slider from Dash Control; no wider Launch Settings tidy-up was introduced.
+- L26-L27 of the moved block: `Launch Mode` manually primes/aborts launch mode for testing and non-standing-start sessions.
+- L32-L37 of the moved block: `Post-Launch Results Display Time` controls how long the results screen stays visible after a launch.
 - L51: Location for the one-line launch summary CSV. Leave blank to use the default path shown.
 - L66: Enable or disable writing the one-line summary of each launch.
 - L70: Custom path for the summary CSV. Leave blank to use the default path.
@@ -240,5 +202,6 @@ Branch: work
 - `ProfilesManagerView.xaml` L522: `Learning mode` tooltip explains shift-point data mining and learning-overlay visibility.
 - `ProfilesManagerView.xaml` L751-L768: custom WAV controls include the existing path/browse affordance while some adjacent labels remain tooltip-free.
 - `GlobalSettingsView.xaml` no longer contains the duplicated per-profile `USER VARIABLES` block; true global sections now begin with `DRIVER TAGS`.
-- `GlobalSettingsView.xaml` L154-L158: `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
-- `GlobalSettingsView.xaml` L158-L162: `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).
+- `GlobalSettingsView.xaml` DEBUG section continues to host the existing debug toggles and now also hosts the moved `Event Marker` binding under `Debug Actions`.
+- `GlobalSettingsView.xaml` `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
+- `GlobalSettingsView.xaml` `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,4 +1,4 @@
-# Project Index
+﻿# Project Index
 
 Validated against commit: HEAD
 Last updated: 2026-03-18
@@ -21,7 +21,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 - [CODEX_CONTRACT.txt](CODEX_CONTRACT.txt) - mandatory Codex/global engineering policy.
 - [Architecture_Guardrails.md](Architecture_Guardrails.md) - practical architecture boundaries and subsystem ownership guidance.
 - [CODEX_TASK_TEMPLATE.txt](CODEX_TASK_TEMPLATE.txt) - reusable task skeleton for analysis-first Codex work.
-- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls.
+- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls, including the Profiles/Dash/Global tidy-up layout.
 - [SimHubParameterInventory.md](SimHubParameterInventory.md) - canonical SimHub export contract.
 - [SimHubLogMessages.md](SimHubLogMessages.md) - canonical Info/Warn/Error log catalogue.
 - [Subsystems/Shift_Assist.md](Subsystems/Shift_Assist.md) - Shift Assist purpose, inputs/state, outputs, and validation checklist.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,4 +1,4 @@
-# Repository status
+﻿# Repository status
 
 Validated against commit: HEAD
 Last updated: 2026-03-18
@@ -9,15 +9,17 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/Plugin_UI_Tooltips.md` updated for the Profiles tab tidy-up (`CAR` / `LAUNCH` / `SHIFT` / `TRACKS`) and the Global Settings cleanup.
+- `Docs/Plugin_UI_Tooltips.md` updated for the Profiles tab tidy-up (`CAR` / `LAUNCH` / `SHIFT` / `TRACKS`), the Launch Settings host move, the Dash Control regrouping, and the Global Settings cleanup.
 - `Docs/Project_Index.md` refreshed to surface `Plugin_UI_Tooltips.md` in the canonical docs list.
 - `Docs/RepoStatus.md` updated with the validation summary for this UI-only tidy-up.
 
 ## Delivery status highlights
 - Profiles UI sub-tabs now read `CAR`, `LAUNCH`, `SHIFT`, and `TRACKS`; the old `DASH` and `FUEL` tabs were removed.
+- Launch Settings now host only the moved `Launch Mode` binding and `Post-Launch Results Display Time` control from Dash Control; no wider Launch Settings tidy-up was introduced.
 - The `CAR` tab now contains the existing car-profile-backed refuel, base-tank, rejoin, overtake, spin, and pit-entry controls without changing their bindings or persistence scope.
 - The `TRACKS` tab now hosts the existing `Wet Fuel Multiplier`, `Race Pace Delta`, and contingency controls at the top of the workflow, but they still bind to the same existing car-profile properties as before.
-- Global Settings no longer shows the duplicated per-profile `USER VARIABLES` block; the remaining sections continue to cover true global settings only.
+- Global Settings no longer shows the duplicated per-profile `USER VARIABLES` block; the remaining sections continue to cover true global settings only, with `Event Marker` now surfaced in the Debug area.
+- Dash Control now uses a narrower stacked layout with explicit `BINDINGS`, `GLOBAL DASH FUNCTIONS`, and `DASH VISIBILITY` sections while preserving the existing underlying bindings and visibility properties.
 - No persistence/schema/runtime behavior changed in this tidy-up: car-profile save/load, default-profile copy seeding, fuel planner/runtime math, launch behavior, shift behavior, pit-entry math, and telemetry behavior remain as before.
 
 ## Notes

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="LaunchPlugin.GlobalSettingsView"
+﻿<UserControl x:Class="LaunchPlugin.GlobalSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -161,6 +161,10 @@
                                      IsEnabled="{Binding ElementName=ShiftAssistDebugCsvToggle, Path=IsChecked}"
                                      ToolTip="Allowed range: 1 to 60 Hz."/>
                         </StackPanel>
+                        <TextBlock Text="Debug Actions" FontWeight="SemiBold" Margin="0,14,0,6"/>
+                        <ui:ControlsEditor ActionName="LalaLaunch.EventMarker"
+                                           FriendlyName="Event Marker"
+                                           ToolTip="Assign a button to fire a short event marker pulse for dashboards and CSV exports."/>
                     </StackPanel>
                 </Expander>
             </StackPanel>

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -45,6 +45,20 @@
                 </StackPanel>
             </styles:SHSection>
 
+            <styles:SHSection Title="LAUNCH UI / BINDINGS" ShowSeparator="True">
+                <StackPanel>
+                    <ui:ControlsEditor ActionName="LalaLaunch.LaunchMode"
+                                       FriendlyName="Launch Mode"
+                                       ToolTip="Manual prime/abort launch mode (useful for testing and non-standing-start sessions)." />
+                    <ui:TitledSlider Title="Post-Launch Results Display Time: "
+                                     Margin="0,10,0,0"
+                                     Minimum="0"
+                                     Maximum="30"
+                                     Value="{Binding Settings.ResultsDisplayTime, Mode=TwoWay}"
+                                     ToolTip="How long the post-launch results screen stays visible (sec)."/>
+                </StackPanel>
+            </styles:SHSection>
+
             <styles:SHSection Title="TELEMETRY LOGGING SETTINGS" ShowSeparator="True">
                 <StackPanel>
                     <TextBlock Margin="0,5,0,2" Foreground="LightGray"


### PR DESCRIPTION
### Motivation
- Improve the Dash/Launch/global settings UI by regrouping related controls into clearer sections and reducing duplication. 
- Move launch-specific bindings out of the Dash control into the Launch settings area to better reflect ownership. 
- Surface the debug-only `Event Marker` binding in Global Settings so it lives with other debug actions.

### Description
- Reworked `DashesTabView.xaml` into a narrower stacked layout with `BINDINGS`, `GLOBAL DASH FUNCTIONS`, and `DASH VISIBILITY` GroupBoxes and updated spacing/grid sizing while preserving existing bindings. 
- Moved the `Launch Mode` binding and `Post-Launch Results Display Time` slider out of the Dash tab into `LaunchPluginSettingsUI.xaml` under a new `LAUNCH UI / BINDINGS` section. 
- Added the `Event Marker` `ControlsEditor` to `GlobalSettingsView.xaml` under a `Debug Actions` header. 
- Updated documentation files (`Docs/Plugin_UI_Tooltips.md`, `Docs/Project_Index.md`, and `Docs/RepoStatus.md`) to reflect the UI regrouping and the control moves.

### Testing
- Built the solution and verified XAML files compile successfully with no runtime schema changes detected. 
- Ran the documentation validation pass which updated the tooltip/index references and completed without errors. 
- No automated behavior/unit tests were modified and existing tests remained green during the build validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb01f24924832f9d10a6b532114d03)