### PR TITLE
Tighten Dash Control tab layout

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -11,8 +11,14 @@
     <ScrollViewer
         VerticalScrollBarVisibility="Auto"
         HorizontalScrollBarVisibility="Disabled">
-        <StackPanel Margin="10" MaxWidth="820" HorizontalAlignment="Left">
-            <GroupBox Header="BINDINGS" Margin="0,0,0,12">
+        <Grid Margin="10" Width="820" HorizontalAlignment="Left">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <GroupBox Grid.Row="0" Header="BINDINGS" Margin="0,0,0,12">
                 <StackPanel Margin="12,10,12,12">
                     <ui:ControlsEditor ActionName="LalaLaunch.MsgCx"
                                        FriendlyName="Cancel Msg Button"
@@ -32,7 +38,7 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="GLOBAL DASH FUNCTIONS" Margin="0,0,0,12">
+            <GroupBox Grid.Row="1" Header="GLOBAL DASH FUNCTIONS" Margin="0,0,0,12">
                 <StackPanel Margin="12,10,12,12">
                     <TextBlock Text="General" FontWeight="Bold" Margin="0,0,0,6"/>
                     <styles:SHToggleCheckbox Content="Auto screen selection at session start"
@@ -45,8 +51,8 @@
                     <StackPanel>
                         <Grid VerticalAlignment="Center">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="150" />
-                                <ColumnDefinition Width="120" />
+                                <ColumnDefinition Width="100" />
+                                <ColumnDefinition Width="90" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0"
@@ -54,8 +60,8 @@
                                        VerticalAlignment="Center"
                                        ToolTip="Select Dark Mode behavior: Off, Manual, or Auto."/>
                             <ComboBox Grid.Column="1"
-                                      Width="120"
-                                      Margin="0,0,12,0"
+                                      Width="85"
+                                      Margin="0,0,8,0"
                                       HorizontalAlignment="Left"
                                       SelectedValue="{Binding Settings.DarkModeMode, Mode=TwoWay}"
                                       SelectedValuePath="Tag"
@@ -72,11 +78,11 @@
                                                      ToolTip="When Lovely is available, Dark Mode active state can follow Lovely True Dark." />
                         </Grid>
                         <TextBlock Text="If using Lovely True Dark, bind only one toggle (Lovely OR LalaLaunch)."
-                                   Margin="150,4,0,0"
+                                   Margin="100,4,0,0"
                                    Opacity="0.85"
                                    TextWrapping="Wrap" />
                     </StackPanel>
-                    <ui:TitledSlider Title="Dark Mode Brightness (%): "
+                    <ui:TitledSlider Title="Brightness (%): "
                                      Margin="0,8,0,0"
                                      Minimum="0"
                                      Maximum="100"
@@ -111,7 +117,7 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="DASH VISIBILITY" Width="820" HorizontalAlignment="Left">
+            <GroupBox Grid.Row="2" Header="DASH VISIBILITY">
                 <StackPanel Margin="12,10,12,12">
                     <TextBlock Text="Choose which dash families can show each feature."
                                Margin="0,0,0,10"
@@ -238,6 +244,6 @@
                     </Grid>
                 </StackPanel>
             </GroupBox>
-        </StackPanel>
+        </Grid>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Fix two cosmetic/layout issues on the Dash Control tab by keeping changes strictly to `DashesTabView.xaml`: the Dark Mode combo was sitting too far right and the Dash Visibility box had incorrect width/right-edge behaviour.

### Description
- Replace the outer `StackPanel` with a fixed-width `Grid` (`Margin="10"`, `Width="820"`, `HorizontalAlignment="Left"`) and add three `RowDefinition` entries, placing the three `GroupBox` sections into `Grid.Row="0"/"1"/"2"` so they share a common container width.
- Compact the Dark Mode control row by changing the inner Grid columns to `100 / 90 / Auto`, reducing the combo box to `Width="85"` with `Margin="0,0,8,0"`, moving the helper text left so it sits under the compact row, and optionally shortening the slider title to `"Brightness (%):"` for visual clarity.
- Remove the `Width="820"` and explicit `HorizontalAlignment="Left"` from the `DASH VISIBILITY` `GroupBox` so it stretches within the parent Grid and visually aligns with `GLOBAL DASH FUNCTIONS`, while keeping all bindings, tooltips, and control semantics unchanged.

### Testing
- Verified the change is layout-only by reviewing the XAML diff and confirming only `DashesTabView.xaml` was modified and all edits are structural/layout changes.
- Performed a structural inspection of the updated XAML to ensure matching tags, correct `Grid.Row` placement for each `GroupBox`, and that child controls and bindings were preserved (inspection passed).
- Attempted to run `xmllint` for formal XML validation but the tool is not available in this environment, so formal linting was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1130dc34832fabf179d0041e2141)