### PR TITLE
Fuel tab Live Snapshot leader delta cleanup

### DIFF
--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -44,8 +44,7 @@ Branch: work
 - L314: Live rolling average lap time.
 - L321: Saved average lap time from profile (condition aware).
 - L337: How many seconds slower your average lap time is compared to the race leader.
-- L359: Adjust the pace delta to the leader (sec) used in the plan.
-- L372: Replace the manual pace delta with the current live average.
+- L359: Adjust the pace delta to the leader (sec) used in the plan. Disabled while Planning Source is Live Snapshot.
 - L382: Limit the usable tank size for restricted fuel races (L).
 - L385: Limit the car's tank size for races with restricted fuel.
 - L414: Fuel burn per lap used for strategy (L/lap).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,15 +9,14 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/Subsystems/H2H.md` updated for this scoped H2H follow-up so the canonical subsystem doc now covers bind-aware segment publication after true target rebinds plus the class-session-best fallback/export behavior.
-- `Docs/SimHubParameterInventory.md` updated so the published H2H export contract now includes `H2HRace.ClassSessionBestLapSec` / `H2HTrack.ClassSessionBestLapSec` and documents bind-aware `S1..S6State` / `S1..S6DeltaSec` rebuild semantics.
+- `Docs/Subsystems/Fuel_Planner_Tab.md` updated so the canonical Fuel planner doc now records that pace-vs-leader is editable only in Profile mode, auto-follows live leader delta in Live Snapshot mode, and falls back to `0.0` instead of stale manual/profile values when live leader pace is unavailable.
+- `Docs/Plugin_UI_Tooltips.md` updated to remove the obsolete leader-delta reset-to-live tooltip and describe the Live Snapshot lock behaviour for the pace-vs-leader control.
 - `Docs/RepoStatus.md` refreshed for the current validation summary.
 
 ## Delivery status highlights
-- `H2HRace.*` and `H2HTrack.*` now clear the published `S1..S6State` / `S1..S6DeltaSec` row immediately on a true ahead/behind target rebind, then repopulate segments only from post-bind player/target completions so swap-time stale timestamps cannot produce nonsense deltas.
-- Ordinary same-target lap-wrap carryover remains intact, so the just-finished closing segment can still publish after start-finish, including sector 6, while true participant reset/context discard/rebind paths still clear that carryover.
-- `H2HRace.ClassSessionBestLapSec` and `H2HTrack.ClassSessionBestLapSec` now publish the resolved same-class session-best lap time directly for dash/debug use.
-- Class session-best resolution still uses the normal same-class H2H scan first, then falls back only when unavailable to `IRacingExtraProperties.iRacing_Session_PlayerClassBestLapTime`; PB/session-best coloring continues to use that trusted resolved value, and no plugin UI/settings were added, no debug CSV logging was introduced, and CarSA/Opponents ownership boundaries were preserved.
+- Fuel planner leader delta now follows the selected planning source model: Profile mode keeps the manual/stored race-pace delta workflow, while Live Snapshot mode clears manual override state on entry and continuously uses the current live leader delta when available.
+- The Fuel tab no longer needs a separate "Reset to live" / "Use live" leader-delta recovery path; the manual slider is locked in Live Snapshot mode and strategy calculations fall back to zero leader delta when no live leader pace is available.
+- Live snapshot resets and car/track combination clears now wipe live/manual leader-delta runtime state without reviving stale hidden manual values during Live Snapshot mode, while still preserving track-stored profile behaviour for Profile mode.
 
 ## Notes
 - `Docs/Code_Snapshot.md` remains non-canonical orientation-only documentation.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -96,10 +96,12 @@ The planner tracks *what source is currently active* for each input:
   - manual / profile / live / max
 
 ### Race pace delta behaviour
-- Each track stores a **default** race-pace delta used when no live leader delta is available.
+- Each track stores a **default** race-pace delta for **Profile** planning mode.
 - Loading a track does **not** force manual leader-delta mode.
-- Planner saves persist the stored/default pace delta (or an explicit manual override), not the transient live leader-gap value.
-- Live leader-delta telemetry remains authoritative whenever it is available unless the driver explicitly edits the pace-delta control, which is the only path that sets manual override mode.
+- **Profile mode:** the pace-vs-leader slider remains editable, and planner saves persist the stored/default pace delta (or an explicit manual override).
+- **Live Snapshot mode:** the effective planner delta follows the current live leader delta whenever live leader pace is available; entering Live Snapshot clears any manual leader-delta override instead of preserving it behind the scenes.
+- **Live Snapshot fallback:** if live leader pace is unavailable, the effective leader delta falls back to `0.0` rather than reusing a stale manual or stored profile delta, so the planner does not masquerade as live while using old data.
+- The old manual "use live/reset to live" recovery path is no longer part of normal leader-delta operation.
 
 ### Track-condition handling (dry vs wet)
 - **Manual selection:** Drivers can explicitly switch the planner into dry or wet mode (per-track).

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -185,7 +185,6 @@ namespace LaunchPlugin
     public ObservableCollection<CarProfile> AvailableCarProfiles { get; set; } // CHANGED
     public ObservableCollection<string> AvailableTracks { get; set; } = new ObservableCollection<string>();
     public string DetectedMaxFuelDisplay { get; private set; }
-    public ICommand ResetLeaderDeltaToLiveCommand { get; }
     public ICommand SetLiveMaxFuelOverrideCommand { get; }
     private string _fuelPerLapText = "";
     private bool _suppressFuelTextSync = false;
@@ -294,6 +293,8 @@ namespace LaunchPlugin
         set { if (_isLeaderDeltaManual != value) { _isLeaderDeltaManual = value; OnPropertyChanged(); } }
     }
 
+    public bool IsLeaderDeltaEditable => SelectedPlanningSourceMode == PlanningSourceMode.Profile;
+
     public double LiveLeaderDeltaSeconds
     {
         get => _liveLeaderDeltaSeconds;
@@ -303,7 +304,7 @@ namespace LaunchPlugin
             _liveLeaderDeltaSeconds = value;
             OnPropertyChanged();
 
-            if (!IsLeaderDeltaManual)
+            if (!IsLeaderDeltaManual || SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
             {
                 UpdateEffectiveLeaderDelta();
             }
@@ -324,6 +325,7 @@ namespace LaunchPlugin
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsPlanningSourceProfile));
             OnPropertyChanged(nameof(IsPlanningSourceLiveSnapshot));
+            OnPropertyChanged(nameof(IsLeaderDeltaEditable));
             OnPropertyChanged(nameof(ShowLiveLapHelper));
             OnPropertyChanged(nameof(ShowProfileLapHelper));
             OnPropertyChanged(nameof(MaxFuelOverrideMaximum));
@@ -337,6 +339,7 @@ namespace LaunchPlugin
             // drop any manual overrides so the new source fully takes over.
             IsEstimatedLapTimeManual = false;
             IsFuelPerLapManual = false;
+            ClearManualLeaderDeltaOverride();
 
             // Auto-expand/collapse the Live Session telemetry panel based on planning source.
             if (value == PlanningSourceMode.LiveSnapshot)
@@ -1116,6 +1119,11 @@ namespace LaunchPlugin
             get => _leaderDeltaSeconds;
             set
             {
+                if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
+                {
+                    return;
+                }
+
                 if (IsLeaderDeltaManual && Math.Abs(_manualLeaderDeltaSeconds - value) < 0.001)
                 {
                     return;
@@ -1129,20 +1137,21 @@ namespace LaunchPlugin
         }
 
         /// <summary>
-        /// Recomputes the effective leader delta based on live and manual sources.
-        /// Manual input wins when set; otherwise live is used when available.
+        /// Recomputes the effective leader delta based on planning source.
+        /// Profile mode prefers manual input, then the stored track delta.
+        /// Live Snapshot mode follows the current live delta and otherwise falls back to zero.
         /// </summary>
         private void UpdateEffectiveLeaderDelta()
         {
             double newDelta;
 
-            if (IsLeaderDeltaManual)
+            if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
+            {
+                newDelta = _hasLiveLeaderDelta ? LiveLeaderDeltaSeconds : 0.0;
+            }
+            else if (IsLeaderDeltaManual)
             {
                 newDelta = _manualLeaderDeltaSeconds;
-            }
-            else if (_hasLiveLeaderDelta)
-            {
-                newDelta = LiveLeaderDeltaSeconds;
             }
             else
             {
@@ -1164,11 +1173,14 @@ namespace LaunchPlugin
         /// <summary>
         /// Fully clears all leader-delta state (live + manual) without calling the public setter.
         /// </summary>
-        private void ClearLeaderDeltaState()
+        private void ClearLeaderDeltaState(bool clearStoredDelta = true)
         {
             LiveLeaderDeltaSeconds = 0.0;
             _manualLeaderDeltaSeconds = 0.0;
-            _storedLeaderDeltaSeconds = 0.0;
+            if (clearStoredDelta)
+            {
+                _storedLeaderDeltaSeconds = 0.0;
+            }
             _hasLiveLeaderDelta = false;
             IsLeaderDeltaManual = false;
             _leaderDeltaSeconds = 0.0;
@@ -2966,7 +2978,6 @@ namespace LaunchPlugin
         RefreshPlannerViewCommand = new RelayCommand(_ => RefreshPlannerView());
         ResetEstimatedLapTimeToSourceCommand = new RelayCommand(_ => ResetEstimatedLapTimeToSource());
         ResetFuelPerLapToSourceCommand = new RelayCommand(_ => ResetFuelPerLapToSource());
-        ResetLeaderDeltaToLiveCommand = new RelayCommand(_ => ResetLeaderDeltaToLive());
         ApplySourceWetFactorCommand = new RelayCommand(_ => ApplySourceWetFactorFromSource(), _ => HasSourceWetFactor);
 
         ApplyPresetCommand = new RelayCommand(o => ApplySelectedPreset(), o => HasSelectedPreset);
@@ -3014,18 +3025,11 @@ namespace LaunchPlugin
         ApplyPlanningSourceToAutoFields(applyLapTime: false, applyFuel: true);
     }
 
-    private void ResetLeaderDeltaToLive()
-    {
-        IsLeaderDeltaManual = false;
-        _manualLeaderDeltaSeconds = LiveLeaderDeltaSeconds;
-        UpdateEffectiveLeaderDelta();
-    }
-
     public void ResetPlannerManualOverrides()
     {
         IsEstimatedLapTimeManual = false;
         IsFuelPerLapManual = false;
-        ResetLeaderDeltaToLive();
+        ClearManualLeaderDeltaOverride();
         ApplyPlanningSourceToAutoFields(applyLapTime: true, applyFuel: true);
     }
 
@@ -3327,14 +3331,14 @@ namespace LaunchPlugin
         }
         else
         {
-            // No usable live leader pace – clear live delta only,
-            // but leave any manual slider value alone.
+            // No usable live leader pace – clear the live-bound delta so
+            // Live Snapshot mode cannot keep using stale leader pacing.
             AvgDeltaToLdrValue = "-";
             LiveLeaderDeltaSeconds = 0.0;
             _hasLiveLeaderDelta = false;
         }
 
-        // Recompute effective delta (live if available, otherwise manual)
+        // Recompute the effective delta for the active planning source.
         UpdateEffectiveLeaderDelta();
 
         OnPropertyChanged(nameof(AvgDeltaToLdrValue));
@@ -3474,7 +3478,7 @@ namespace LaunchPlugin
         LiveLeaderPaceInfo = "-";
         LiveLapPaceInfo = "-";
         AvgDeltaToLdrValue = "-";
-        ClearLeaderDeltaState();
+        ClearLeaderDeltaState(clearStoredDelta: false);
         _hasLiveLeaderDelta = false;
         var nowUtc = DateTime.UtcNow;
         if ((nowUtc - _lastSnapshotResetLogUtc) > TimeSpan.FromSeconds(1))
@@ -3551,7 +3555,7 @@ namespace LaunchPlugin
         LiveLeaderPaceInfo = "-";
         AvgDeltaToLdrValue = "-";
         RacePaceVsLeaderSummary = "-";
-        ClearLeaderDeltaState();
+        ClearLeaderDeltaState(clearStoredDelta: false);
 
         ApplyLiveConfidenceLevels(0, 0, 0);
 
@@ -4510,29 +4514,33 @@ namespace LaunchPlugin
             double num = PitLaneTimeLoss; // use the current value directly
 
             double num3 = ParseLapTime(EstimatedLapTime);          // your estimated lap time
-            bool leaderPaceAvailable = IsLeaderDeltaManual || _hasLiveLeaderDelta;
-            double appliedDelta = IsLeaderDeltaManual ? LeaderDeltaSeconds : LiveLeaderDeltaSeconds;
+            bool leaderPaceAvailable = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
+                ? _hasLiveLeaderDelta
+                : LeaderDeltaSeconds > 0.0;
+            double appliedDelta = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
+                ? LiveLeaderDeltaSeconds
+                : LeaderDeltaSeconds;
             double num2 = leaderPaceAvailable
                 ? num3 - appliedDelta                       // leader pace (your pace - delta)
                 : num3;                                           // fall back to your pace when no leader data
 
-            if (LeaderDeltaSeconds > 0.0 && num3 > 0.0)
+            if (appliedDelta > 0.0 && num3 > 0.0)
             {
                 double leaderLap = num2;
                 bool shouldLog = Math.Abs(leaderLap - _lastLoggedStrategyLeaderLap) > 0.01 ||
                                  Math.Abs(num3 - _lastLoggedStrategyEstLap) > 0.01 ||
-                                 Math.Abs(LeaderDeltaSeconds - _lastLoggedLeaderDeltaSeconds) > 0.01;
+                                 Math.Abs(appliedDelta - _lastLoggedLeaderDeltaSeconds) > 0.01;
                 if (shouldLog)
                 {
                     SimHub.Logging.Current.Info(string.Format(
                         "[LalaPlugin:Leader Lap] CalculateStrategy: estLap={0:F3}, leaderDelta={1:F3}, leaderLap={2:F3}",
                         num3,
-                        LeaderDeltaSeconds,
+                        appliedDelta,
                         leaderLap));
 
                     _lastLoggedStrategyLeaderLap = leaderLap;
                     _lastLoggedStrategyEstLap = num3;
-                    _lastLoggedLeaderDeltaSeconds = LeaderDeltaSeconds;
+                    _lastLoggedLeaderDeltaSeconds = appliedDelta;
                 }
             }
 

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -347,7 +347,6 @@
                                         <!-- Value column: Auto and SHARED across both rows -->
                                         <ColumnDefinition Width="Auto" SharedSizeGroup="DeltaValueCol"/>
                                         <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
 
                                     <Slider Grid.Column="0"
@@ -357,6 +356,7 @@
               Minimum="0" Maximum="5"
               SmallChange="0.1" TickFrequency="0.1"
               IsSnapToTickEnabled="True"
+              IsEnabled="{Binding IsLeaderDeltaEditable}"
               ToolTip="Adjust the pace delta to the leader (sec) used in the plan." />
 
                                     <TextBlock Grid.Column="1"
@@ -365,13 +365,6 @@
                 Margin="10,0,0,0"
                 MinWidth="35"
                 TextAlignment="Right"/>
-
-                                    <Button Grid.Column="3"
-                        Content="Reset to live"
-                        Command="{Binding ResetLeaderDeltaToLiveCommand}"
-                        Margin="8,0,0,0"
-                        ToolTip="Replace the manual pace delta with the current live average."
-                        Visibility="{Binding IsLeaderDeltaManual, Converter={StaticResource BoolToVisibilityConverter}}" />
                                 </Grid>
                             </Grid>
 


### PR DESCRIPTION
### Motivation
- Fix a stale/manual leader-delta override surviving when the user selects Planning Source = Live Snapshot so the planner can appear "live" while actually using old manual values.
- Align the pace-vs-leader control with the existing Live Snapshot model used by other Live-bound planner fields (auto-follow live when available and lock manual editing while live-selected).

### Description
- Update `FuelCalcs.cs` to clear manual leader-delta override on planning-source changes, make Live Snapshot prefer the live leader delta (and fall back to `0.0` when live leader pace is unavailable), and preserve stored/profile delta for Profile mode; the effective-delta recomputation now follows the selected planning source.
- Remove the legacy recovery path and UI command by deleting `ResetLeaderDeltaToLiveCommand` usage and its handler, and stop exposing the reset button to the UI; the manual reset-to-live control is removed from the XAML and command registration.
- Disable the pace-vs-leader slider in `FuelCalculatorView.xaml` while Planning Source is Live Snapshot via a new `IsLeaderDeltaEditable` binding, preventing manual edits in Live Snapshot mode.
- Update documentation to reflect the behavior change by editing `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Plugin_UI_Tooltips.md`, and `Docs/RepoStatus.md` to record that pace-vs-leader is editable only in Profile mode, auto-follows live leader delta in Live Snapshot, and no longer exposes a "Reset to live" action.

### Testing
- Static/reference checks: ran repository text searches and diffs to confirm the `ResetLeaderDeltaToLive` command/button references were removed and the new `IsLeaderDeltaEditable` binding is in place, and these checks succeeded.
- Diff/commit verification: produced and reviewed a focused diff of `FuelCalcs.cs`, `FuelCalculatorView.xaml`, and the three docs files to verify consistent changes and absence of dangling references, and this verification succeeded.
- Build attempt: attempted `dotnet build LaunchPlugin.sln` but it could not be executed in the current environment because `dotnet` is not installed (automated build check failed for environmental reasons, not code correctness).
- Runtime/behavioral validation: examined live-leader telemetry flow in `LalaLaunch.cs` and verified no runtime leader-delta telemetry changes were required; full integration tests were not run in this environment due to missing build/runtime toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd259a80f4832fb9700db5f24e0985)