### PR TITLE
Add v0.3 User & Quick Start guides, extend changelog, and refresh RepoStatus

### DIFF
--- a/Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md
+++ b/Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md
@@ -1,0 +1,135 @@
+# Lala Plugin – Tester Quick Start Guide
+
+Get you racing with reliable data, fast.
+
+**Read time:** ~10 minutes.
+
+This guide focuses on the minimum setup and habits needed to get trustworthy data. Advanced tuning and inactive/back-shelf systems are intentionally left out.
+
+## 1. What This Plugin Does
+
+Lala Plugin is a SimHub race-engineering plugin for iRacing. In normal use it:
+
+- Learns fuel usage, lap pace, pit-lane loss, and track-specific markers.
+- Stores data per car, per track/layout, and per condition (dry/wet).
+- Feeds stable values to dashboards so you are not chasing noisy lap-to-lap swings.
+- Provides pit, rejoin, launch, and race-context assistance where the supported dashes expose it.
+
+**Important mindset:** let it learn → lock good values → trust the dash. If you constantly tweak things mid-run, you will usually make the data worse.
+
+## 2. Installation
+
+### 2.1 Copy Plugin DLLs
+
+Go to your main SimHub folder (for example `C:\Program Files (x86)\SimHub`), copy these files in, then restart SimHub.
+
+**Required:**
+- `RSC.iRacingExtraProperties.dll`
+- `LaunchPlugin.dll`
+
+**Optional:**
+- `DahlDesign.dll` (only needed if you plan to use the Lala dash package)
+
+### 2.2 Import Dashboards
+
+Import the dashboards you want by double-clicking the package or using SimHub import. Typical layout:
+
+- **Lala-Dash** = primary race dash, often on a phone or tablet behind the wheel.
+- **Strategy / secondary dash** = extra strategy and support data on another device or screen area.
+- **Lala Overlay** = extra alerts that can be overlaid anywhere on screen.
+- **Lovely Dashboard – Lala Edition(s)** = optional Lovely-based layouts; these can overwrite existing Lovely files, so import carefully.
+
+All of the dashes can also be converted to overlays in SimHub Dash Studio if that suits your layout better.
+
+## 3. Mandatory Setup
+
+Open **SimHub → Lala Plugin → Dashes / dash-control area**.
+
+### 3.1 Bind These Two Buttons
+
+Bind both of these to something you can reach while driving:
+
+- **Cancel Msg Button**: cancels pit and rejoin popups and temporarily suppresses repeated alerts.
+- **Pit Screen Toggle**: manually shows or hides pit-related screens when you want to override the automatic pit screen behaviour.
+
+If you bind nothing else, bind these two.
+
+### 3.2 Dash Visibility Toggles
+
+Use the main dash / secondary dash / overlay visibility toggles to control what appears where. If you are unsure, start with the defaults and only disable items that you know you do not want.
+
+## 4. First Session Checklist
+
+This prevents bad data and broken profiles.
+
+### 4.1 First Laps (Learning Phase)
+
+Drive 3–5 clean laps with:
+
+- no off-tracks,
+- no pit entries,
+- no black flags.
+
+Let fuel and pace stabilise before judging the numbers.
+
+### 4.2 Learn Pit-Lane Loss and Markers (Do This Once Per Track)
+
+1. Drive several clean laps first.
+2. Enter pit lane cleanly and complete a normal pit entry/exit cycle.
+3. Finish at least one full out-lap.
+4. When pit-lane loss and markers look sensible, go to **Profiles / Tracks** and lock the values you trust.
+
+You usually only need to do this once per car/track unless the track changes or the saved data is clearly wrong.
+
+### 4.3 What Not to Lock Yet
+
+Do not lock fuel-per-lap or average lap-time values during very early testing. Let the plugin build representative dry/wet data first, then lock it when it looks sensible.
+
+## 5. Fuel Planning Basics
+
+The Fuel tab has two distinct modes:
+
+- **Live Snapshot mode**: shows what the current session is doing right now and follows the live leader pace delta when available.
+- **Profile mode**: uses your stored profile/track planning inputs and stays stable until you change them.
+
+If Live Snapshot does not have a valid live leader pace yet, the pace-vs-leader effect falls back safely instead of reusing stale hidden manual values.
+
+## 6. During a Race
+
+### What to trust once the system has settled
+
+- Stable fuel numbers and pit strategy outputs.
+- Locked pit-lane loss and marker-driven pit guidance.
+- Pit-entry assist and rejoin warnings.
+- H2H / race-context widgets if your dash package includes them.
+
+### What to avoid
+
+- Constant UI tweaking mid-race.
+- Locking values after a messy lap or bad pit cycle.
+- Assuming every early-stint number is final before confidence has built up.
+
+## 7. If Something Looks Wrong (Quick Fixes)
+
+- **Fuel looks wrong** → unlock the affected fuel values and drive clean laps.
+- **Pit timing looks wrong** → unlock pit loss, do one clean pit cycle, then re-lock it.
+- **Pit entry cues look wrong** → verify the saved track markers and re-learn if needed.
+- **Too many popups** → use Cancel Msg and reduce the visibility toggles that feed your screens.
+- **Weird numbers after an update** → zero and relearn only the affected data, not everything.
+
+Rule of thumb: **unlock → relearn cleanly → lock again**.
+
+## 8. Where Data Is Stored
+
+- **Plugin data (JSON):** `SimHub\PluginsData\Common\LalaPlugin`
+- **Logs:** `SimHub\Logs`
+
+Only edit those files manually if you know exactly what you are doing.
+
+## 9. Help Improve the System
+
+Please report bugs, odd behaviour, and reproducible edge cases using the shared logging / feedback process for the plugin package you received.
+
+## 10. Final Advice
+
+This plugin rewards clean driving and patience. Let it learn, lock good values, and do not fight it mid-session.

--- a/Docs/Lala_Plugin_User_Guide_v0.3.md
+++ b/Docs/Lala_Plugin_User_Guide_v0.3.md
@@ -1,0 +1,180 @@
+# Lala Plugin – Plugin & Dashboards User Guide
+
+**Applies to:** SimHub v9+
+
+**Supported sims:** iRacing only.
+
+This guide explains the supported user-facing parts of the plugin and dashboard package, how they interact, and how to use them without corrupting data or distracting the driver.
+
+> **Scope note:** the broader message-dash / global message system is not currently active on release dashes and is not covered here as a normal user feature. Functional pit and rejoin popups are covered normally.
+
+## 1. System Overview
+
+Lala Plugin separates responsibilities like this.
+
+### Plugin
+
+- Learns data.
+- Stores data.
+- Protects data.
+- Performs calculations and publishes outputs.
+
+### Dashboards
+
+- Display the results.
+- Provide situational awareness.
+- Offer limited interaction through touch areas or hardware bindings.
+- Do not learn or store data themselves.
+
+If something looks wrong on a dash, the fix is usually in the plugin inputs, saved values, or current session state rather than in the dashboard art.
+
+## 2. Data Model & Philosophy
+
+Data is stored at three levels:
+
+- **Car profile**
+- **Track profile / layout-specific record**
+- **Condition data** (dry / wet)
+
+Typical lifecycle: **auto-learn → validate → lock → trust**.
+
+Locks exist so traffic, replays, weather transitions, incomplete pit cycles, or bad laps do not overwrite good reference data.
+
+## 3. Dash Controls & Live Adjustments
+
+### 3.1 Recommended bindings
+
+- **Cancel Msg Button**: cancels pit and rejoin popups and temporarily suppresses repeats.
+- **Pit Screen Toggle**: manually shows or hides pit-related screens.
+
+Other bindings may exist, but those two are the important everyday controls.
+
+### 3.2 Visibility and pit-screen behaviour
+
+Main dash, message/strategy dash, and overlay visibility are controlled separately. These toggles change where information is shown; they do not change the underlying calculations.
+
+Pit screens can appear automatically when pit context is active, or manually when you force them on. If a pit screen appears at the wrong moment, **Pit Screen Toggle** is the driver override.
+
+### 3.3 User variables
+
+Some live-adjustment controls tune thresholds rather than core calculations. Typical examples include:
+
+- Rejoin linger time and clear-speed thresholds.
+- Spin detection sensitivity.
+- Pit entry deceleration behaviour and pit entry buffer.
+
+Adjust these only when you are chasing a specific false positive or a repeatable mismatch with your driving style.
+
+## 4. Launch Settings & Analysis
+
+Launch Settings controls launch behaviour and launch telemetry capture. Per-car defaults can be stored in profiles and then applied to live use.
+
+- Typical launch controls include target RPM / throttle, tolerances, bite point behaviour, bog-down detection, and anti-stall sensitivity.
+- Launch telemetry recording is for post-run analysis and does not change what the dashboards do live.
+- Post Launch Analysis is the place to review saved traces, summaries, and graph overlays.
+
+## 5. Fuel System
+
+The Fuel system combines live telemetry, stored profile data, confidence logic, and deterministic maths to produce a stable strategy instead of reacting to every lap fluctuation.
+
+It operates in two modes:
+
+- **Live Snapshot mode** = observe the current session and compare against live conditions.
+- **Profile mode** = commit to planning inputs and keep the strategy stable until you deliberately change them.
+
+### 5.1 Why live numbers take time to settle
+
+Not every lap is accepted for pace and fuel learning. Pit laps, obvious incidents, invalid laps, cold-tyre out-laps, and major anomalies are filtered so the planner is not poisoned by bad data.
+
+### 5.2 Confidence and stable values
+
+Confidence is the plugin’s answer to “how representative is this live data?” Until enough clean laps exist, live values remain tentative and profile values may still be safer for planning.
+
+### 5.3 Live Snapshot mode
+
+- Shows live fuel burn, live pace, confidence, session context, and live tank-cap information when available.
+- The live-session panel is intentionally live-only; when there is no current live sample, it should read as unavailable rather than silently pretending profile values are live.
+- Pace-vs-leader follows the current live leader pace delta when that live source exists.
+- If live leader pace is unavailable, the planner falls back safely instead of keeping a stale hidden manual override.
+
+### 5.4 Profile mode
+
+- Uses stored car and track data plus your current planning inputs.
+- Keeps the plan deterministic until you deliberately change the inputs.
+- This is where presets and locked reference values are meant to be used.
+
+### 5.5 Planning inputs that are now track-scoped
+
+Some planning values now belong to the selected track/layout record rather than the general car profile. The important ones are wet multiplier, pace-vs-leader, and fuel contingency settings. That makes the planner less likely to carry the wrong assumptions from one venue to another.
+
+### 5.6 Strategy window basics
+
+The strategy calculation uses race type, race length, lap time, fuel burn, tank capacity, refuel rate, pit-lane loss, tyre-change time, contingencies, and mandatory stop rules to produce a practical stop plan.
+
+- Timed races include the expected drive time after the clock reaches zero.
+- Pace delta to leader affects effective race distance in long races.
+- Pit-lane loss should be learned cleanly, then locked once trusted.
+- Preset max fuel is treated as a percentage of base tank so presets remain portable across cars.
+
+## 6. Profiles & TRACKS Data
+
+Profiles are the plugin’s long-term memory.
+
+### 6.1 Car profile
+
+Stores car-specific launch, fuel, and related defaults. **Apply to Live Session** pushes those values into the active session; saving persists them to disk.
+
+### 6.2 TRACKS / per-layout storage
+
+- Pit-lane time loss.
+- Pit entry / exit markers.
+- Dry and wet best / average lap times.
+- Dry and wet fuel-per-lap data.
+- Track-scoped planning defaults such as wet multiplier, pace-vs-leader, and contingency settings.
+
+Pit-lane loss and markers should be auto-learned, checked, then locked when they are known-good. Dry/wet pace and fuel values should only be locked once they are representative.
+
+### 6.3 Locking philosophy
+
+**Locked** means automatic learning will not overwrite the saved value. **Unlocked** means learning is allowed. Lock too early and you freeze bad data; never lock and noise can keep leaking in.
+
+### 6.4 When to zero and relearn
+
+- Track layout changed.
+- Major car physics or setup assumptions changed.
+- Saved data is clearly corrupted or untrustworthy.
+- A specific learned item no longer matches reality.
+
+## 7. Driver Aids & Race Context
+
+### 7.1 Pit Entry Assist
+
+Pit Entry Assist uses learned/saved pit markers and braking maths to show how early or late you are for the pit entry line. It is most useful once the track markers are validated and locked.
+
+### 7.2 Rejoin warnings and pit popups
+
+Pit and rejoin popups are active user-facing features. Use **Cancel Msg** if they become distracting in a specific moment, but if they are repeatedly wrong the better fix is usually to review the saved data or thresholds behind them.
+
+### 7.3 Opponents and Head-to-Head (H2H)
+
+Supported dashes can show nearby race-context information from Opponents plus H2H comparison widgets.
+
+- **Race H2H** compares your class targets ahead and behind in the race order.
+- **Track H2H** compares nearby same-class cars around you on track.
+- H2H is a read-only race-context aid for the driver; it is not something you constantly manage in the plugin UI.
+
+## 8. Dashboards
+
+Dashboards consume plugin outputs and automatically change pages based on session state. Touch areas and SimHub page bindings are fallbacks, not the primary workflow.
+
+- **Primary race dash** = main driver view.
+- **Strategy / support dash** = extra strategy and utility information.
+- **Overlay** = supplementary alerts and compact helpers.
+- Visibility toggles and declutter-style options should be used to decide what appears where, rather than editing the calculations.
+
+## 9. Best Practice
+
+- Let the systems learn first.
+- Lock good values once they are representative.
+- Avoid mid-race tuning unless something is clearly wrong.
+- Treat the plugin like a race engineer, not a lap-by-lap calculator.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,14 +9,14 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/Subsystems/Fuel_Planner_Tab.md` updated so the canonical Fuel planner doc now records that pace-vs-leader is editable only in Profile mode, auto-follows live leader delta in Live Snapshot mode, and falls back to `0.0` instead of stale manual/profile values when live leader pace is unavailable.
-- `Docs/Plugin_UI_Tooltips.md` updated to remove the obsolete leader-delta reset-to-live tooltip and describe the Live Snapshot lock behaviour for the pace-vs-leader control.
+- `Docs/User Docs/Changelog_Since_PR240.md` extended with concise user-facing highlights through PR #481, including Track planner migration, H2H, H2H follow-up fixes, and the latest Fuel Planner Live Snapshot leader-delta cleanup.
+- `Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md` added as the review-friendly source version of the tester quick-start, matching the current setup flow, fuel-planning model, track-marker/pit-learning workflow, and supported race-context aids.
+- `Docs/Lala_Plugin_User_Guide_v0.3.md` added as the review-friendly source version of the ship-ready user guide, reflecting current fuel/planner behaviour, track-scoped planner defaults, H2H, pit/rejoin aids, and the current inactive status of the broader message-dash system.
 - `Docs/RepoStatus.md` refreshed for the current validation summary.
 
 ## Delivery status highlights
-- Fuel planner leader delta now follows the selected planning source model: Profile mode keeps the manual/stored race-pace delta workflow, while Live Snapshot mode clears manual override state on entry and continuously uses the current live leader delta when available.
-- The Fuel tab no longer needs a separate "Reset to live" / "Use live" leader-delta recovery path; the manual slider is locked in Live Snapshot mode and strategy calculations fall back to zero leader delta when no live leader pace is available.
-- Live snapshot resets and car/track combination clears now wipe live/manual leader-delta runtime state without reviving stale hidden manual values during Live Snapshot mode, while still preserving track-stored profile behaviour for Profile mode.
+- User-facing documentation now has review-friendly markdown source guides in the repo: Quick Start is focused on install/bind/learn/lock workflow, while the full User Guide explains the current fuel planner, track-scoped data, race aids, and H2H without implying the broader message-dash system is active.
+- The user changelog now covers the recent H2H and fuel-planner updates through PR #481 in a concise tester-facing format instead of stopping short of the latest merged work.
 
 ## Notes
 - `Docs/Code_Snapshot.md` remains non-canonical orientation-only documentation.

--- a/Docs/User Docs/Changelog_Since_PR240.md
+++ b/Docs/User Docs/Changelog_Since_PR240.md
@@ -25,3 +25,7 @@
 - **Declutter dash control**: secondary dash mode renamed to declutter with a 0/1/2 visibility cycle (legacy alias preserved).
 - **Radio transmit exports**: live frequency names, mute state, and class position labels updated with more robust fallbacks and live refresh.
 - **Off-track debug change-only logging**: optional setting writes CSV rows only when the probe snapshot changes to reduce file size.
+- **TRACKS planner migration**: planner defaults such as wet multiplier, pace-vs-leader, and fuel contingency now live with the track/layout data they belong to instead of following the wrong venue.
+- **Head-to-head (H2H) dash support**: new race-target and on-track same-class comparison outputs with lap summaries, six fixed comparison segments, and dash-ready class/lap colouring.
+- **H2H reliability fixes**: target swaps, lap-wrap carryover, segment rebuild timing, and bind-aware publication were tightened so the comparison stays stable when identities or lap state change.
+- **Latest Fuel Planner cleanup (through PR481)**: Live Snapshot pace-vs-leader now follows the current live leader delta, clears stale manual override state on entry, and safely falls back to `0.0` when live leader pace is unavailable.


### PR DESCRIPTION
### Motivation
- Provide review-friendly Markdown source user documentation that matches the current plugin behaviour and UI flows.
- Surface recent feature work (TRACKS planner migration, H2H support/fixes, and Fuel Planner Live Snapshot cleanup) in the user changelog.
- Keep repository metadata current so reviewers and CI can see the validation summary and documentation sync status.

### Description
- Added the tester-friendly quick-start `Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md` containing install, bind, learn, lock, and race usage guidance.
- Added the full `Docs/Lala_Plugin_User_Guide_v0.3.md` describing the plugin/dash interaction, data model, fuel planner modes, TRACKS migration, H2H, and driver aids.
- Extended `Docs/User Docs/Changelog_Since_PR240.md` with concise highlights for TRACKS planner migration, H2H features and fixes, and the Fuel Planner Live Snapshot leader-delta cleanup (PR #481).
- Updated `Docs/RepoStatus.md` to reflect the current validation summary and to list the new documentation files and delivery status highlights.

### Testing
- The repository validation run was executed and the output was recorded in `Docs/RepoStatus.md` as `Validated against commit: HEAD`, indicating the validation completed successfully.
- No code changes were made, so no unit tests were required for this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd29c2f668832f8f23f9f4504f108e)