### PR TITLE
Polish Strategy Preset Manager UX

### DIFF
--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,6 +1,6 @@
-# Repository status
+﻿# Repository status
 
-Validated against commit: 3f0af12824336625dd449cc0329702ac50394396
+Validated against commit: f071ec440ef30e7a243dbaa51107493af1a47343
 Last updated: 2026-03-20
 Branch: work
 
@@ -18,6 +18,7 @@ Branch: work
 - The top-level planner tab is now labeled `STRATEGY`, while the existing planner content and FuelCalcs-backed strategy workflow remain intact.
 - The former top-level `PRESETS` tab has been removed; preset management now opens as a modal Preset Manager from the `Presets...` button beside the Strategy tab's Race Preset combo.
 - The modal reuses the existing preset editor and shared `FuelCalcs` state, preserving preset selection/application semantics, save-current behavior, and preset persistence without changing preset storage or planner math.
+- Strategy-tab preset UX follow-up: the inline `Presets...` action now uses the primary blue button style, the modal auto-selects the active preset (or first available preset) on open, dark-theme preset-manager text/input colours are explicitly readable, and successful `Save Changes` closes the modal without a second success popup.
 - `Docs/User Docs/Changelog_Since_PR240.md` extended with concise user-facing highlights through PR #481, including Track planner migration, H2H, H2H follow-up fixes, and the latest Fuel Planner Live Snapshot leader-delta cleanup.
 - `Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md` added as the review-friendly source version of the tester quick-start, matching the current setup flow, fuel-planning model, track-marker/pit-learning workflow, and supported race-context aids.
 - `Docs/Lala_Plugin_User_Guide_v0.3.md` added as the review-friendly source version of the ship-ready user guide, reflecting current fuel/planner behaviour, track-scoped planner defaults, H2H, pit/rejoin aids, and the current inactive status of the broader message-dash system.

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -520,13 +520,13 @@
                             </TextBlock.Visibility>
                             </TextBlock>
 
-                            <styles:SHButtonSecondary Grid.Column="3"
-                                                      Content="Presets..."
-                                                      Height="28"
-                                                      Margin="12,0,0,0"
-                                                      VerticalAlignment="Center"
-                                                      Click="OnOpenPresetManager"
-                                                      ToolTip="Open the Preset Manager to create, rename, edit, or delete strategy presets."/>
+                            <styles:SHButtonPrimary Grid.Column="3"
+                                                    Content="Presets..."
+                                                    Height="28"
+                                                    Margin="12,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Click="OnOpenPresetManager"
+                                                    ToolTip="Open the Preset Manager to create, rename, edit, or delete strategy presets."/>
                         </Grid>
 
 

--- a/FuelCalculatorView.xaml.cs
+++ b/FuelCalculatorView.xaml.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 namespace LaunchPlugin
 {
@@ -30,10 +30,13 @@ namespace LaunchPlugin
                 MinWidth = 860,
                 MinHeight = 620,
                 ResizeMode = ResizeMode.CanResize,
+                Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x1F, 0x23, 0x2B)),
                 WindowStartupLocation = owner != null ? WindowStartupLocation.CenterOwner : WindowStartupLocation.CenterScreen,
                 Owner = owner,
                 ShowInTaskbar = false
             };
+
+            presetManager.Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x1F, 0x23, 0x2B));
 
             dialog.ShowDialog();
         }

--- a/PresetsManagerView.xaml
+++ b/PresetsManagerView.xaml
@@ -17,9 +17,59 @@
         <local:BooleanToTextConverter x:Key="BooleanToText" TrueText="Laps" FalseText="Litres"/>
         <local:EnumEqualsConverter x:Key="EnumEqualsConverter"/>
         <local:NotBoolConverter x:Key="NotBoolConverter"/>
+
+        <SolidColorBrush x:Key="PresetManagerBackgroundBrush" Color="#1F232B"/>
+        <SolidColorBrush x:Key="PresetManagerPanelBrush" Color="#262B34"/>
+        <SolidColorBrush x:Key="PresetManagerBorderBrush" Color="#4A525F"/>
+        <SolidColorBrush x:Key="PresetManagerPrimaryTextBrush" Color="#F2F4F8"/>
+        <SolidColorBrush x:Key="PresetManagerSecondaryTextBrush" Color="#C9CFDC"/>
+        <SolidColorBrush x:Key="PresetManagerHintTextBrush" Color="#AEB7C6"/>
+        <SolidColorBrush x:Key="PresetManagerInputBackgroundBrush" Color="#171A20"/>
+        <SolidColorBrush x:Key="PresetManagerInputBorderBrush" Color="#566171"/>
+
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+        </Style>
+
+        <Style TargetType="RadioButton">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+        </Style>
+
+        <Style TargetType="{x:Type ui:TitledSlider}">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+        </Style>
+
+        <Style TargetType="TextBox">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+            <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource PresetManagerInputBorderBrush}"/>
+            <Setter Property="CaretBrush" Value="White"/>
+        </Style>
+
+        <Style TargetType="ComboBox">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+            <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource PresetManagerInputBorderBrush}"/>
+        </Style>
+
+        <Style TargetType="ComboBoxItem">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+            <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
+        </Style>
+
+        <Style TargetType="ListBox">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+            <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource PresetManagerInputBorderBrush}"/>
+        </Style>
+
+        <Style TargetType="ListBoxItem">
+            <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
     </UserControl.Resources>
 
-    <Grid Margin="10">
+    <Grid Margin="10" Background="{StaticResource PresetManagerBackgroundBrush}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="250" MinWidth="200"/>
             <ColumnDefinition Width="10"/>
@@ -32,6 +82,7 @@
              Text="Preset Manager"
              FontSize="16" FontWeight="Bold"
              Margin="0,0,0,10"
+             Foreground="{StaticResource PresetManagerPrimaryTextBrush}"
              ToolTip="Manage reusable race strategy presets."/>
 
             <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">
@@ -52,7 +103,8 @@
             <ListBox ItemsSource="{Binding AvailablePresets}"
                  SelectedItem="{Binding EditorSelection, ElementName=Root, Mode=TwoWay}"
                  DisplayMemberPath="Name"
-                 BorderThickness="1" BorderBrush="Gray"
+                 BorderThickness="1" BorderBrush="{StaticResource PresetManagerBorderBrush}"
+                 Background="{StaticResource PresetManagerPanelBrush}"
                  ToolTip="Select a preset to edit."/>
         </DockPanel>
 
@@ -67,7 +119,7 @@
             <TextBlock Grid.Row="0"
              Text="Select a preset from the list, or click &quot;Create New Preset&quot;."
              FontStyle="Italic"
-             Foreground="#AAA"
+             Foreground="{StaticResource PresetManagerHintTextBrush}"
              HorizontalAlignment="Center"
              VerticalAlignment="Center">
                 <TextBlock.Style>
@@ -85,7 +137,8 @@
             <!-- Scrollable editor; disabled when no selection -->
             <ScrollViewer Grid.Row="0"
                 VerticalScrollBarVisibility="Auto"
-                HorizontalScrollBarVisibility="Disabled">
+                HorizontalScrollBarVisibility="Disabled"
+                Background="{StaticResource PresetManagerBackgroundBrush}">
                 <StackPanel x:Name="EditorPanel"
                 Margin="10,28,10,10"
                 DataContext="{Binding EditingPreset, ElementName=Root}">
@@ -115,11 +168,11 @@
                                    Text="{Binding ActivePresetHelperText, ElementName=Root}"
                                    VerticalAlignment="Center"
                                    FontStyle="Italic"
-                                   Foreground="#888">
+                                   Foreground="{StaticResource PresetManagerSecondaryTextBrush}">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="FontStyle" Value="Italic"/>
-                                    <Setter Property="Foreground" Value="#888"/>
+                                    <Setter Property="Foreground" Value="{StaticResource PresetManagerSecondaryTextBrush}"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding IsEditingActivePreset, ElementName=Root}" Value="True">
                                             <Setter Property="FontStyle" Value="Normal"/>
@@ -285,7 +338,7 @@
                     </StackPanel>
 
                     <!-- Unified action box -->
-                    <Border Height="1" Background="#444" Margin="0,12,0,12"/>
+                    <Border Height="1" Background="{StaticResource PresetManagerBorderBrush}" Margin="0,12,0,12"/>
                     <Grid Margin="0,0,0,8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="260"/>

--- a/PresetsManagerView.xaml.cs
+++ b/PresetsManagerView.xaml.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Xml.Linq;
 
 namespace LaunchPlugin
 {
@@ -83,11 +82,33 @@ namespace LaunchPlugin
 
             _vm.PropertyChanged += OnVmPropertyChanged;
 
-            // Start by mirroring whatever the Strategy tab had selected; from now on selection is local
-            EditorSelection = _vm.SelectedPreset;
+            // Start with the active Strategy preset when possible, otherwise the first available preset.
+            EditorSelection = ResolveInitialSelection();
         }
 
         private RacePreset GetActivePreset() => _vm?.AppliedPreset ?? _vm?.SelectedPreset;
+
+        private RacePreset ResolveInitialSelection()
+        {
+            var presets = _vm?.AvailablePresets;
+            if (presets == null || presets.Count == 0)
+            {
+                return null;
+            }
+
+            var active = GetActivePreset();
+            if (active != null)
+            {
+                var activeMatch = presets.FirstOrDefault(x =>
+                    string.Equals(x.Name, active.Name, StringComparison.OrdinalIgnoreCase));
+                if (activeMatch != null)
+                {
+                    return activeMatch;
+                }
+            }
+
+            return presets.FirstOrDefault();
+        }
 
         private void OnVmPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
@@ -112,9 +133,8 @@ namespace LaunchPlugin
         private void RebuildWorkingCopyFromEditorSelection()
         {
             var s = EditorSelection;
-            // No defaults here: blank when nothing selected
-            EditingPreset = s != null ? CreateEditableCopy(s) : new RacePreset { Name = "" };
-            _originalName = s?.Name ?? "";
+            EditingPreset = s != null ? CreateEditableCopy(s) : new RacePreset { Name = string.Empty };
+            _originalName = s?.Name ?? string.Empty;
         }
 
         private RacePreset CreateEditableCopy(RacePreset p)
@@ -198,8 +218,8 @@ namespace LaunchPlugin
                 EditorSelection = saved ?? _vm.AvailablePresets?.FirstOrDefault(x =>
                     string.Equals(x.Name, _originalName, StringComparison.OrdinalIgnoreCase));
 
-                MessageBox.Show("Preset saved.", "Presets",
-                    MessageBoxButton.OK, MessageBoxImage.Information);
+                var owner = Window.GetWindow(this);
+                owner?.Close();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Improve visual consistency and first-run experience for the Strategy Preset Manager after the modal integration by fixing button styling, startup selection, readability in dark theme, and the redundant save-confirmation flow.
- Keep changes narrowly scoped to the preset manager UI and startup behavior without altering preset semantics, persistence, or planner logic.

### Description
- Swap the Strategy tab inline `Presets...` action from secondary to primary style (`SHButtonSecondary` -> `SHButtonPrimary`) so it matches other primary actions in the UI (`FuelCalculatorView.xaml`).
- Make the modal background match the preset manager theme and keep the manager content background explicit to avoid light/default window contrast (`FuelCalculatorView.xaml.cs`).
- Add explicit dark-theme brushes and light foreground styles for the Preset Manager (labels, helper text, list, inputs, and sliders) to ensure readable text in dark mode (`PresetsManagerView.xaml`).
- Change initial selection logic: `PresetsManagerView` now calls `ResolveInitialSelection()` which auto-selects the active/applied preset if present, otherwise selects the first available preset, and only shows the blank hint when there are no presets (`PresetsManagerView.xaml.cs`).
- Remove the extra success `MessageBox` on `Save Changes` and instead close the owning modal when save succeeds while preserving existing error dialogs for failures (`PresetsManagerView.xaml.cs`).
- Small XAML/code hygiene tweaks to use explicit empty string initializers and consistent background assignments; only UI/UX surface changes were made.

### Testing
- Parsed XAML files successfully with `xml.etree.ElementTree` for `FuelCalculatorView.xaml` and `PresetsManagerView.xaml` (both returned OK).
- Verified source-level checks that the primary `Presets...` button, `ResolveInitialSelection()` helper, and the `owner?.Close()` save-success path are present in the modified files via script checks.
- Attempted to run a full build (`msbuild` / `dotnet build`) but those tools are not available in this environment, so a full compile could not be executed here.
- No automated unit tests exist for these UI flows in this patch; visual/manual verification is recommended during integration testing to confirm dark-theme rendering and modal-close behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd402abb88832fa228a860f2e473cd)