### PR TITLE
Lock Fuel Planner max fuel to live cap in Live Snapshot

### DIFF
--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -46,8 +46,8 @@ Branch: work
 - L321: Saved average lap time from profile (condition aware).
 - L337: How many seconds slower your average lap time is compared to the race leader.
 - L359: Adjust the pace delta to the leader (sec) used in the plan. Disabled while Planning Source is Live Snapshot.
-- L382: Limit the usable tank size for restricted fuel races (L).
-- L385: Limit the car's tank size for races with restricted fuel.
+- L382: Profile mode: limit the usable tank size for restricted fuel races (L). Live Snapshot: locked to the detected live session cap.
+- L385: Profile mode: edit the planner tank limit. Live Snapshot: this control is locked to the detected live session cap.
 - L414: Fuel burn per lap used for strategy (L/lap).
 - L417: Fuel burn per lap (L/lap). Edit to override the suggested value.
 - L452: Use the average fuel per lap saved in the selected profile.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,6 +1,6 @@
 ﻿# Repository status
 
-Validated against commit: f071ec440ef30e7a243dbaa51107493af1a47343
+Validated against commit: 23d4d55073be68286ab35a258737ce12048eeddf
 Last updated: 2026-03-20
 Branch: work
 
@@ -9,22 +9,16 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/Subsystems/Fuel_Planner_Tab.md` updated so the canonical planner doc now describes the top-level Strategy tab name, the preserved inline Race Preset selector, and the modal Preset Manager workflow that replaces the former separate Presets tab.
-- `Docs/Plugin_UI_Tooltips.md` updated so the tooltip inventory reflects the Strategy-tab navigation, the new `Presets...` button beside the Race Preset combo, and the Strategy wording inside the preset manager.
-- `Docs/Project_Index.md` updated so the subsystem map and tooltip reference describe the Strategy-tab / modal-preset workflow.
+- `Docs/Subsystems/Fuel_Planner_Tab.md` updated so the canonical planner doc now states that Live Snapshot max fuel is locked to the live detected cap only, while Profile mode retains manual/preset max-fuel behavior.
+- `Docs/Plugin_UI_Tooltips.md` updated so the Strategy-tab max-fuel tooltip text explicitly calls out the Profile-mode edit path and the Live Snapshot lock-to-live-cap behavior.
 - `Docs/RepoStatus.md` refreshed for the current validation summary.
 
 ## Delivery status highlights
-- The top-level planner tab is now labeled `STRATEGY`, while the existing planner content and FuelCalcs-backed strategy workflow remain intact.
-- The former top-level `PRESETS` tab has been removed; preset management now opens as a modal Preset Manager from the `Presets...` button beside the Strategy tab's Race Preset combo.
-- The modal reuses the existing preset editor and shared `FuelCalcs` state, preserving preset selection/application semantics, save-current behavior, and preset persistence without changing preset storage or planner math.
-- Strategy-tab preset UX follow-up: the inline `Presets...` action now uses the primary blue button style, the modal auto-selects the active preset (or first available preset) on open, dark-theme preset-manager text/input colours are explicitly readable, and successful `Save Changes` closes the modal without a second success popup.
-- `Docs/User Docs/Changelog_Since_PR240.md` extended with concise user-facing highlights through PR #481, including Track planner migration, H2H, H2H follow-up fixes, and the latest Fuel Planner Live Snapshot leader-delta cleanup.
-- `Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md` added as the review-friendly source version of the tester quick-start, matching the current setup flow, fuel-planning model, track-marker/pit-learning workflow, and supported race-context aids.
-- `Docs/Lala_Plugin_User_Guide_v0.3.md` added as the review-friendly source version of the ship-ready user guide, reflecting current fuel/planner behaviour, track-scoped planner defaults, H2H, pit/rejoin aids, and the current inactive status of the broader message-dash system.
+- Fuel Planner max-fuel selection now follows the same clean planning-source model as the recent pace-vs-leader fix: Profile mode keeps manual/preset behavior, while Live Snapshot uses only the live detected cap as the active planner tank basis.
+- Entering Live Snapshot no longer falls back to a remembered profile/preset/manual max-fuel value when the live cap is missing; instead the planner reports the missing live-cap validation state and blocks strategy outputs until valid live cap telemetry is available.
+- Ongoing live cap changes now flow straight through the planner tank basis and strategy outputs in Live Snapshot, including first-stint fuel, without any preset-side override path.
+- The Strategy-tab max-fuel control remains visually unchanged but is now documented as Profile-editable and Live Snapshot-locked to the detected live cap.
 - `Docs/RepoStatus.md` refreshed for the current validation summary.
-- User-facing documentation now has review-friendly markdown source guides in the repo: Quick Start is focused on install/bind/learn/lock workflow, while the full User Guide explains the current fuel planner, track-scoped data, race aids, and H2H without implying the broader message-dash system is active.
-- The user changelog now covers the recent H2H and fuel-planner updates through PR #481 in a concise tester-facing format instead of stopping short of the latest merged work.
 
 ## Notes
 - `Docs/Code_Snapshot.md` remains non-canonical orientation-only documentation.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -1,4 +1,4 @@
-# Fuel Planner / Strategy Tab
+﻿# Fuel Planner / Strategy Tab
 
 Validated against commit: 3f0af12824336625dd449cc0329702ac50394396
 Last updated: 2026-03-20
@@ -115,12 +115,14 @@ The planner tracks *what source is currently active* for each input:
 - **Wet factor support:** If wet mode is selected but only dry profile stats exist, the planner scales dry values by the selected track's wet-factor percentage and labels the source accordingly.
 
 ### Max fuel override handling (profile vs live)
-- **Profile mode:** `MaxFuelOverride` is clamped to the profile base tank (`BaseTankLitres`), and the UI shows a percent-of-base-tank badge.
+- **Profile mode:** `MaxFuelOverride` is clamped to the profile base tank (`BaseTankLitres`), remains manually editable, and the UI shows a percent-of-base-tank badge.
 - **Preset max fuel input:** Preset max fuel is expressed as a **percentage of base tank** (default 100%), making presets portable across cars with different base tanks.
-- **Live Snapshot mode:** `MaxFuelOverride` is set from the live session cap (MaxFuel × BoP), or `0` if the live cap is unavailable.
-- **Preset visibility in Live Snapshot:** Preset max-fuel values remain visible (read-only) so drivers can compare preset intent against live caps.
-- **Mode transitions:** switching into Live Snapshot stores the previous profile override; switching back to Profile restores it and re-applies the selected preset (if any).
-- **Validation:** if the live cap is missing in Live Snapshot mode, the planner surfaces an explicit “Live max fuel cap unavailable” error and blocks strategy outputs.
+- **Preset application in Profile mode:** applying/selecting a preset can still set the active planner max fuel exactly as before, subject to the existing profile-side clamp.
+- **Live Snapshot mode:** the planner tank basis comes only from the live detected session cap (`MaxFuel × BoP`). Manual/profile/preset max-fuel values do not remain active underneath Live Snapshot.
+- **Live Snapshot UI lock:** the max-fuel slider/input is non-editable in Live Snapshot and shows the live cap when available.
+- **Live Snapshot fallback:** if the live cap is unavailable, the planner uses `0` as the effective tank basis, surfaces an explicit “Live max fuel cap unavailable” validation error, and blocks strategy outputs rather than silently reusing an older profile/preset/manual value.
+- **Mode transitions:** switching into Live Snapshot stores the prior Profile-mode override for later restoration but immediately stops using it as the active planner tank basis; switching back to Profile restores normal editability, restores the remembered profile value, and reapplies the selected preset (if any) under Profile-mode rules.
+- **Ongoing live updates:** while Live Snapshot is active, live cap changes automatically update the planner tank basis and downstream strategy outputs, including first-stint fuel.
 
 These are exposed to the UI so the driver can see **why** a number changed.
 

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -185,7 +185,6 @@ namespace LaunchPlugin
     public ObservableCollection<CarProfile> AvailableCarProfiles { get; set; } // CHANGED
     public ObservableCollection<string> AvailableTracks { get; set; } = new ObservableCollection<string>();
     public string DetectedMaxFuelDisplay { get; private set; }
-    public ICommand SetLiveMaxFuelOverrideCommand { get; }
     private string _fuelPerLapText = "";
     private bool _suppressFuelTextSync = false;
     public string LapTimeSourceInfo
@@ -353,18 +352,12 @@ namespace LaunchPlugin
 
             ApplyPlanningSourceToAutoFields(applyLapTime: true, applyFuel: true);
 
-            if (value == PlanningSourceMode.LiveSnapshot && IsLiveSessionActive)
+            if (value == PlanningSourceMode.LiveSnapshot)
             {
                 _lastProfileMaxFuelOverride = MaxFuelOverride;
+
                 double? liveCap = GetLiveSessionCapLitresOrNull();
-                if (liveCap.HasValue)
-                {
-                    MaxFuelOverride = liveCap.Value;
-                }
-                else
-                {
-                    MaxFuelOverride = _lastProfileMaxFuelOverride;
-                }
+                MaxFuelOverride = liveCap ?? 0.0;
             }
 
             if (value == PlanningSourceMode.Profile)
@@ -640,7 +633,6 @@ namespace LaunchPlugin
     public bool IsLiveFuelPerLapAvailable => GetActiveAverageFuel().value.HasValue;
     public bool IsLiveFuelSaveAvailable { get; private set; }
 
-    public bool HasLiveMaxFuelSuggestion => _liveMaxFuel > 0;
 
     private double _liveMaxFuel;
     public bool IsMaxFuelOverrideTooHigh => MaxFuelOverride > _liveMaxFuel && _liveMaxFuel > 0;
@@ -1338,16 +1330,6 @@ namespace LaunchPlugin
         }
     }
 
-    private void ApplyLiveMaxFuelSuggestion()
-    {
-        if (SelectedPlanningSourceMode != PlanningSourceMode.Profile)
-            return;
-
-        if (_liveMaxFuel <= 0) return;
-
-        MaxFuelOverride = _liveMaxFuel;
-    }
-
     // This pair correctly handles UI thread updates for Live Fuel
     public void SetLiveFuelPerLap(double value)
     {
@@ -1974,22 +1956,13 @@ namespace LaunchPlugin
         {
             if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
             {
-                if (_appliedPreset != null)
-                {
-                    var presetValue = GetPresetMaxFuelOverrideLitres(_appliedPreset);
-                    if (presetValue.HasValue)
-                    {
-                        return presetValue.Value;
-                    }
-                }
-
                 var liveCap = GetLiveSessionCapLitresOrNull();
                 if (liveCap.HasValue && liveCap.Value > 0.0)
                 {
                     return liveCap.Value;
                 }
 
-                return GetProfileBaseTankLitresOrDefault();
+                return 0.0;
             }
 
             if (_appliedPreset != null)
@@ -2973,7 +2946,6 @@ namespace LaunchPlugin
         UseProfileFuelSaveCommand = new RelayCommand(_ => UseProfileFuelSave(), _ => IsProfileFuelSaveAvailable);
         UseProfileFuelMaxCommand = new RelayCommand(_ => UseProfileFuelMax(), _ => IsProfileFuelMaxAvailable);
         UseMaxFuelPerLapCommand = new RelayCommand(_ => UseMaxFuelPerLap(), _ => IsMaxFuelAvailable);
-        SetLiveMaxFuelOverrideCommand = new RelayCommand(_ => ApplyLiveMaxFuelSuggestion(), _ => HasLiveMaxFuelSuggestion && IsPlanningSourceProfile);
         RefreshLiveSnapshotCommand = new RelayCommand(_ => RefreshLiveSnapshot());
         RefreshPlannerViewCommand = new RelayCommand(_ => RefreshPlannerView());
         ResetEstimatedLapTimeToSourceCommand = new RelayCommand(_ => ResetEstimatedLapTimeToSource());
@@ -4453,7 +4425,6 @@ namespace LaunchPlugin
         DetectedMaxFuelDisplay = liveMaxFuel > 0 ? $"(Detected Max: {liveMaxFuel:F1} L)" : "(Detected Max: —)";
 
         OnPropertyChanged(nameof(DetectedMaxFuelDisplay));
-        OnPropertyChanged(nameof(HasLiveMaxFuelSuggestion));
         OnPropertyChanged(nameof(IsMaxFuelOverrideTooHigh));
         CommandManager.InvalidateRequerySuggested();
     }
@@ -4493,23 +4464,9 @@ namespace LaunchPlugin
             double? liveCapLitres = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
                 ? GetLiveSessionCapLitresOrNull()
                 : (double?)null;
-            double maxFuelLimit;
-            if (SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot)
-            {
-                var presetCap = GetPresetMaxFuelOverrideLitres(_appliedPreset);
-                if (presetCap.HasValue)
-                {
-                    maxFuelLimit = presetCap.Value;
-                }
-                else
-                {
-                    maxFuelLimit = liveCapLitres ?? 0.0;
-                }
-            }
-            else
-            {
-                maxFuelLimit = ClampMaxFuelOverride(MaxFuelOverride);
-            }
+            double maxFuelLimit = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
+                ? (liveCapLitres ?? 0.0)
+                : ClampMaxFuelOverride(MaxFuelOverride);
 
             double num = PitLaneTimeLoss; // use the current value directly
 
@@ -4562,8 +4519,7 @@ namespace LaunchPlugin
                                fuelPerLap <= 0.0 || fuelPerLap > 50.0;
 
             bool liveCapMissing = SelectedPlanningSourceMode == PlanningSourceMode.LiveSnapshot
-                                  && !liveCapLitres.HasValue
-                                  && !GetPresetMaxFuelOverrideLitres(_appliedPreset).HasValue;
+                                  && !liveCapLitres.HasValue;
             double maxAllowed = SelectedPlanningSourceMode == PlanningSourceMode.Profile
                 ? MaxFuelOverrideMaximum
                 : 500.0;

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -373,10 +373,10 @@
                         <StackPanel Grid.Row="6" Margin="0,15,0,0">
                             <Grid Margin="0,0,0,4">
                                 <TextBlock Text="Max Fuel Override (litres):" VerticalAlignment="Center"
-                                           ToolTip="Limit the usable tank size for restricted fuel races (L)." />
+                                           ToolTip="Profile mode: limit the usable tank size for restricted fuel races (L). Live Snapshot: locked to the detected live session cap." />
                             </Grid>
 
-                            <ui:TitledSlider Title="" Minimum="0" Maximum="{Binding MaxFuelOverrideMaximum}" Value="{Binding MaxFuelOverrideDisplayValue, Mode=TwoWay}" ToolTip="Limit the car's tank size for races with restricted fuel." IsEnabled="{Binding IsPlanningSourceProfile}">
+                            <ui:TitledSlider Title="" Minimum="0" Maximum="{Binding MaxFuelOverrideMaximum}" Value="{Binding MaxFuelOverrideDisplayValue, Mode=TwoWay}" ToolTip="Profile mode: edit the planner tank limit. Live Snapshot: this control is locked to the detected live session cap." IsEnabled="{Binding IsPlanningSourceProfile}">
                                 <ui:TitledSlider.Resources>
                                     <Style TargetType="TextBlock">
                                         <Style.Triggers>


### PR DESCRIPTION
### Motivation
- Eliminate mixed-source behavior where Live Snapshot could silently fall back to profile/preset/manual max-fuel values and leak an incorrect tank basis into planner outputs (notably first-stint fuel). 
- Make max-fuel follow the same clear planning-source model used for pace-vs-leader: Profile = editable/manual/preset, Live Snapshot = authoritative live cap only.

### Description
- In `FuelCalcs.cs` the Live Snapshot transition now stores the prior Profile override but sets the active planner tank basis to the live session cap or `0.0` when no live cap is available, preventing usage of stale profile/preset values while Live Snapshot is selected. 
- Strategy math now uses only the live cap as the `maxFuelLimit` in Live Snapshot and no longer treats preset max-fuel as a substitute source; missing live cap correctly triggers the existing validation path (`"Live max fuel cap unavailable."`). 
- Removed the obsolete manual live-max override path (`SetLiveMaxFuelOverrideCommand` / `ApplyLiveMaxFuelSuggestion`) and related suggestion flag wiring so there is no Profile->Live mixing through that command. 
- UI text clarified in `FuelCalculatorView.xaml` so the max-fuel slider tooltip explicitly states the control is editable in Profile and locked to the detected live cap in Live Snapshot, while keep-ing the existing `IsPlanningSourceProfile` enablement (no layout/style changes). 
- Documentation updated in `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Plugin_UI_Tooltips.md`, and `Docs/RepoStatus.md` to reflect the Live Snapshot live-cap-only contract and the Profile-mode preset/manual semantics.

### Testing
- Attempted `dotnet build LaunchPlugin.sln` but the environment has no `dotnet` runtime available so a full compile/test was not run. 
- Ran targeted source assertions (Python checks) that confirmed the obsolete live-max override command/path was removed and the new Live Snapshot assignments are present (asserted presence of `MaxFuelOverride = liveCap ?? 0.0;` and that `MaxFuelOverrideDisplayValue` returns live cap or `0.0` in Live Snapshot). 
- Ran XAML/source checks to confirm the max-fuel control remains enabled only in Profile (`IsEnabled="{Binding IsPlanningSourceProfile}"`) and the tooltip text was updated to mention the Live Snapshot lock. 
- Verified repository working-tree changes and updated `Docs/RepoStatus.md` to record the validation baseline for this task.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd42ac6178832f8beb404e607d09ae)