### PR TITLE
Reorder main tabs and embed Launch Settings inside Settings expander

### DIFF
--- a/Docs/Lala_Plugin_User_Guide_v0.3.md
+++ b/Docs/Lala_Plugin_User_Guide_v0.3.md
@@ -1,4 +1,4 @@
-# Lala Plugin – Plugin & Dashboards User Guide
+﻿# Lala Plugin – Plugin & Dashboards User Guide
 
 **Applies to:** SimHub v9+
 
@@ -42,6 +42,8 @@ Locks exist so traffic, replays, weather transitions, incomplete pit cycles, or 
 
 ## 3. Dash Controls & Live Adjustments
 
+Top-level plugin tabs are ordered left-to-right as **Strategy**, **Profiles**, **Dash Control**, **Launch Analysis**, and **Settings**.
+
 ### 3.1 Recommended bindings
 
 - **Cancel Msg Button**: cancels pit and rejoin popups and temporarily suppresses repeats.
@@ -67,11 +69,11 @@ Adjust these only when you are chasing a specific false positive or a repeatable
 
 ## 4. Launch Settings & Analysis
 
-Launch Settings controls launch behaviour and launch telemetry capture. Per-car defaults can be stored in profiles and then applied to live use.
+Launch Settings now lives inside the top-level **Settings** tab under a collapsed **Launch Settings** expander. It still controls launch behaviour and launch telemetry capture, and per-car defaults can still be stored in profiles and then applied to live use.
 
 - Typical launch controls include target RPM / throttle, tolerances, bite point behaviour, bog-down detection, and anti-stall sensitivity.
 - Launch telemetry recording is for post-run analysis and does not change what the dashboards do live.
-- Post Launch Analysis is the place to review saved traces, summaries, and graph overlays.
+- **Launch Analysis** is the top-level tab used to review saved traces, summaries, and graph overlays.
 
 ## 5. Fuel System
 

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -83,7 +83,7 @@ Branch: work
 ## LaunchAnalysisControl.xaml
 - L27: Select a launch trace file to review in this tab.
 - L33: Pick a trace file captured from a launch session.
-- L37: Reloads the list of files from the path specified in the Settings tab.
+- L37: Reloads the list of files from the path specified in Settings → Launch Settings.
 - L41: Temporarily browse a different folder for launch trace files.
 - L46: WARNING: Permanently deletes the selected trace file from your disk.
 - L55: Auto-generated summary for the selected trace file.
@@ -107,19 +107,18 @@ Branch: work
 - L42: Allowed deviation (±%) around the bite point target.
 - L43: If the engine RPM drops below this percentage of the initial Launch RPM, the run will be flagged as 'Bogged'.
 - L44: Sets the sensitivity for detecting game-assisted anti-stall. % is delta between paddle and in game clutch.
-- LAUNCH UI / BINDINGS section: hosts only the moved `Launch Mode` binding and `Post-Launch Results Display Time` slider from Dash Control; no wider Launch Settings tidy-up was introduced.
+- Launch Settings content is no longer a standalone main tab; it now appears inside Settings under a collapsed `Launch Settings` expander placed after Friends List and before Debug.
+- LAUNCH UI / BINDINGS section: still hosts only the moved `Launch Mode` binding and `Post-Launch Results Display Time` slider from Dash Control; moving the block into Settings did not change their behavior or bindings.
 - L26-L27 of the moved block: `Launch Mode` manually primes/aborts launch mode for testing and non-standing-start sessions.
 - L32-L37 of the moved block: `Post-Launch Results Display Time` controls how long the results screen stays visible after a launch.
 - L51: Location for the one-line launch summary CSV. Leave blank to use the default path shown.
 - L66: Enable or disable writing the one-line summary of each launch.
 - L70: Custom path for the summary CSV. Leave blank to use the default path.
 - L73: Browse for a summary CSV location.
-- L76: Location for detailed launch trace files used by the Launch Analysis tab. Leave blank to use the default path shown.
-- L91: Enable or disable creating detailed trace files for the 'LAUNCH ANALYSIS' tab.
+- L76: Location for detailed launch trace files used by the Launch Analysis tab in the top-level navigation. Leave blank to use the default path shown.
+- L91: Enable or disable creating detailed trace files for the 'LAUNCH ANALYSIS' tab in the top-level navigation.
 - L95: Custom path for launch trace files. Leave blank to use the default path.
 - L98: Browse for a launch trace folder.
-- L102: Enables verbose logging for troubleshooting the plugin.
-- L105: Adds PitExit math audit details to pit-in snapshots for troubleshooting.
 
 ## PresetsManagerView.xaml
 - L34: Manage reusable race strategy presets.
@@ -202,7 +201,11 @@ Branch: work
 - `ProfilesManagerView.xaml` L411-L417: `Urgent sound` tooltip says it plays a delayed secondary shift beep at 50% of the main beep volume.
 - `ProfilesManagerView.xaml` L522: `Learning mode` tooltip explains shift-point data mining and learning-overlay visibility.
 - `ProfilesManagerView.xaml` L751-L768: custom WAV controls include the existing path/browse affordance while some adjacent labels remain tooltip-free.
-- `GlobalSettingsView.xaml` no longer contains the duplicated per-profile `USER VARIABLES` block; true global sections now begin with `DRIVER TAGS`.
-- `GlobalSettingsView.xaml` DEBUG section continues to host the existing debug toggles and now also hosts the moved `Event Marker` binding under `Debug Actions`.
+- `GlobalSettingsView.xaml` is now the top-level `SETTINGS` tab, with visible main-tab order `STRATEGY`, `PROFILES`, `DASH CONTROL`, `LAUNCH ANALYSIS`, `SETTINGS`.
+- `GlobalSettingsView.xaml` now surfaces the Friends List section first, then a collapsed `Launch Settings` expander, then the existing Debug block.
+- `GlobalSettingsView.xaml` no longer contains the duplicated per-profile `USER VARIABLES` block; the Settings tab now begins with the Friends List tools/import flow.
+- `GlobalSettingsView.xaml` DEBUG section continues to host the existing debug toggles and the moved `Event Marker` binding under `Debug Actions`; Launch Settings now sits above this block inside its own collapsed expander.
+- `GlobalSettingsView.xaml` `Enable Debug Logging` tooltip says it enables verbose logging for troubleshooting the plugin.
+- `GlobalSettingsView.xaml` `PitExit Verbose Logging` tooltip says it adds PitExit math audit details to pit-in snapshots for troubleshooting.
 - `GlobalSettingsView.xaml` `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
 - `GlobalSettingsView.xaml` `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -21,7 +21,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 - [CODEX_CONTRACT.txt](CODEX_CONTRACT.txt) - mandatory Codex/global engineering policy.
 - [Architecture_Guardrails.md](Architecture_Guardrails.md) - practical architecture boundaries and subsystem ownership guidance.
 - [CODEX_TASK_TEMPLATE.txt](CODEX_TASK_TEMPLATE.txt) - reusable task skeleton for analysis-first Codex work.
-- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls, including the Strategy tab preset-manager modal flow plus the Profiles/Dash/Global tidy-up layout and the TRACKS tab's track-scoped planner inputs.
+- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls, including the Strategy tab preset-manager modal flow, the reordered top-level tab layout (Strategy / Profiles / Dash Control / Launch Analysis / Settings), the embedded Launch Settings expander inside Settings, and the TRACKS tab's track-scoped planner inputs.
 - [SimHubParameterInventory.md](SimHubParameterInventory.md) - canonical SimHub export contract.
 - [SimHubLogMessages.md](SimHubLogMessages.md) - canonical Info/Warn/Error log catalogue.
 - [Subsystems/Shift_Assist.md](Subsystems/Shift_Assist.md) - Shift Assist purpose, inputs/state, outputs, and validation checklist.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,20 +9,17 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/Subsystems/Fuel_Planner_Tab.md` updated so the canonical planner doc now states that Live Snapshot max fuel is locked to the live detected cap only, while Profile mode retains manual/preset max-fuel behavior.
-- `Docs/Plugin_UI_Tooltips.md` updated so the Strategy-tab max-fuel tooltip text explicitly calls out the Profile-mode edit path and the Live Snapshot lock-to-live-cap behavior.
+- `Docs/Project_Index.md` updated so the canonical doc map now mentions the reordered main-tab layout and the embedded Launch Settings expander inside Settings.
+- `Docs/Plugin_UI_Tooltips.md` updated so the tooltip/navigation inventory reflects the new main-tab order, the `Launch Analysis` / `Settings` labels, and the moved Launch Settings location under Settings.
+- `Docs/Lala_Plugin_User_Guide_v0.3.md` updated so current user-facing navigation wording matches the new Settings/Launch Analysis layout.
 - `Docs/RepoStatus.md` refreshed for the current validation summary.
 
 ## Delivery status highlights
-- The top-level planner tab is now labeled `STRATEGY`, while the existing planner content and FuelCalcs-backed strategy workflow remain intact.
-- The former top-level `PRESETS` tab has been removed; preset management now opens as a modal Preset Manager from the `Presets...` button beside the Strategy tab's Race Preset combo.
-- The modal reuses the existing preset editor and shared `FuelCalcs` state, preserving preset selection/application semantics, save-current behavior, and preset persistence without changing preset storage or planner math.
-- Strategy-tab preset UX follow-up: the inline `Presets...` action now uses the primary blue button style, the modal auto-selects the active preset (or first available preset) on open, dark-theme preset-manager text/input colours are explicitly readable, and successful `Save Changes` closes the modal without a second success popup.
-- Strategy-tab preset-manager follow-up: the modal now keeps the PreRace Mode combo on the same dark input styling as the rest of the plugin, spaces the active-preset helper text away from the name field, detaches its `FuelCalcs.PropertyChanged` listener when the dialog unloads/closes, and uses a small Strategy-tab guard to avoid accidental re-entrant dialog opens.
-- `Docs/User Docs/Changelog_Since_PR240.md` extended with concise user-facing highlights through PR #481, including Track planner migration, H2H, H2H follow-up fixes, and the latest Fuel Planner Live Snapshot leader-delta cleanup.
-- `Docs/Lala_Plugin_Quick_Start_Guide_v0.3.md` added as the review-friendly source version of the tester quick-start, matching the current setup flow, fuel-planning model, track-marker/pit-learning workflow, and supported race-context aids.
-- `Docs/Lala_Plugin_User_Guide_v0.3.md` added as the review-friendly source version of the ship-ready user guide, reflecting current fuel/planner behaviour, track-scoped planner defaults, H2H, pit/rejoin aids, and the current inactive status of the broader message-dash system.
-- `Docs/RepoStatus.md` refreshed for the current validation summary.
+- The top-level plugin tabs are now ordered `STRATEGY`, `PROFILES`, `DASH CONTROL`, `LAUNCH ANALYSIS`, `SETTINGS`.
+- The former `POST LAUNCH ANALYSIS` label is now `LAUNCH ANALYSIS`, and the former `GLOBAL SETTINGS` label is now `SETTINGS`.
+- The standalone top-level `LAUNCH SETTINGS` tab has been removed.
+- The existing Launch Settings UI is now hosted inside the `SETTINGS` tab under a collapsed `Launch Settings` expander placed after Friends List and before Debug.
+- The embedded Launch Settings block reuses the existing controls and bindings, so launch-setting semantics and launch-analysis trace/logging behavior remain unchanged.
 
 ## Notes
 - `Docs/Code_Snapshot.md` remains non-canonical orientation-only documentation.

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -21,7 +21,7 @@
     </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10">
-            <styles:SHSection Title="DRIVER TAGS" ShowSeparator="True">
+            <styles:SHSection Title="FRIENDS LIST" ShowSeparator="True">
                 <StackPanel>
                     <TextBlock Margin="0,0,0,5" Foreground="LightGray"
                                Text="Add iRacing Customer IDs and assign a driver tag in CarSA." />
@@ -103,6 +103,12 @@
                                             Click="AddFriend_Click" />
                 </StackPanel>
             </styles:SHSection>
+
+            <Expander Header="Launch Settings"
+                      Margin="0,0,0,10"
+                      IsExpanded="False">
+                <ContentControl x:Name="LaunchSettingsHost" Margin="0,10,0,0"/>
+            </Expander>
 
             <StackPanel Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock Text="DEBUG" FontSize="16" FontWeight="Bold" Margin="0,5,10,0"/>

--- a/GlobalSettingsView.xaml.cs
+++ b/GlobalSettingsView.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -15,12 +15,15 @@ namespace LaunchPlugin
         private readonly ObservableCollection<IOverlayCategory> _iOverlayCategories = new ObservableCollection<IOverlayCategory>();
 
         public LalaLaunch Plugin { get; }
+        public TelemetryTraceLogger TelemetryService { get; }
 
-        public GlobalSettingsView(LalaLaunch plugin)
+        public GlobalSettingsView(LalaLaunch plugin, TelemetryTraceLogger telemetry)
         {
             InitializeComponent();
             Plugin = plugin;
+            TelemetryService = telemetry;
             DataContext = plugin;
+            LaunchSettingsHost.Content = new LaunchPluginSettingsUI(plugin, telemetry);
             InitializeIOverlayImport();
         }
 

--- a/LaunchPluginCombinedSettingsControl.xaml.cs
+++ b/LaunchPluginCombinedSettingsControl.xaml.cs
@@ -10,12 +10,19 @@ namespace LaunchPlugin
         {
             InitializeComponent();
 
-            var globalSettingsTab = new SHTabItem
+            var strategyTab = new SHTabItem
             {
-                Header = "GLOBAL SETTINGS",
-                Content = new GlobalSettingsView(mainPluginInstance)
+                Header = "STRATEGY",
+                Content = new FuelCalculatorView(mainPluginInstance.FuelCalculator)
             };
-            MainTabControl.Items.Add(globalSettingsTab);
+            MainTabControl.Items.Add(strategyTab);
+
+            var profilesTab = new SHTabItem
+            {
+                Header = "PROFILES",
+                Content = new ProfilesManagerView(mainPluginInstance.ProfilesViewModel)
+            };
+            MainTabControl.Items.Add(profilesTab);
 
             var dashesTab = new SHTabItem
             {
@@ -24,34 +31,19 @@ namespace LaunchPlugin
             };
             MainTabControl.Items.Add(dashesTab);
 
-            var settingsTab = new SHTabItem
-            {
-                Header = "LAUNCH SETTINGS",
-                Content = new LaunchPluginSettingsUI(mainPluginInstance, telemetryTraceLoggerService)
-            };
-            MainTabControl.Items.Add(settingsTab);
-
             var launchAnalysisTab = new SHTabItem
             {
-                Header = "POST LAUNCH ANALYSIS",
+                Header = "LAUNCH ANALYSIS",
                 Content = new LaunchAnalysisControl(telemetryTraceLoggerService)
             };
             MainTabControl.Items.Add(launchAnalysisTab);
 
-            var fuelTab = new SHTabItem
+            var settingsTab = new SHTabItem
             {
-                Header = "STRATEGY",
-                Content = new FuelCalculatorView(mainPluginInstance.FuelCalculator)
+                Header = "SETTINGS",
+                Content = new GlobalSettingsView(mainPluginInstance, telemetryTraceLoggerService)
             };
-            MainTabControl.Items.Add(fuelTab);
-
-            // The Profiles tab now gets its content from a view that is given the new ViewModel
-            var profilesTab = new SHTabItem
-            {
-                Header = "PROFILES",
-                Content = new ProfilesManagerView(mainPluginInstance.ProfilesViewModel)
-            };
-            MainTabControl.Items.Add(profilesTab);
+            MainTabControl.Items.Add(settingsTab);
         }
     }
 }

--- a/LaunchPluginSettingsUI.xaml
+++ b/LaunchPluginSettingsUI.xaml
@@ -12,8 +12,7 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
     </UserControl.Resources>
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="10">
+    <StackPanel Margin="10">
 
             <styles:SHSection Title="LAUNCH PARAMETERS" ShowSeparator="True">
                 <StackPanel>
@@ -87,7 +86,7 @@
                                                 ToolTip="Browse for a summary CSV location."/>
                     </Grid>
                     <TextBlock Margin="0,15,0,2" Foreground="LightGray"
-                               ToolTip="Location for detailed launch trace files used by the Launch Analysis tab. Leave blank to use the default path shown.">
+                               ToolTip="Location for detailed launch trace files used by the Launch Analysis tab in the main navigation. Leave blank to use the default path shown.">
                         <TextBlock.Text>
                             <MultiBinding StringFormat="{}Detailed Trace Files Path (Leave blank for default: {0})">
                                 <Binding ElementName="SettingsPage" Path="DefaultTraceLogPath" Mode="OneWay"/>
@@ -102,7 +101,7 @@
                         </Grid.ColumnDefinitions>
                         <styles:SHToggleCheckbox Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"
                                                  IsChecked="{Binding Settings.EnableTelemetryTracing, Mode=TwoWay}"
-                                                 ToolTip="Enable or disable creating detailed trace files for the 'LAUNCH ANALYSIS' tab."/>
+                                                 ToolTip="Enable or disable creating detailed trace files for the 'LAUNCH ANALYSIS' tab in the main navigation."/>
                         <TextBox Grid.Column="1" x:Name="TracePathTextBox" 
                                  Text="{Binding Settings.TraceLogPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                  VerticalAlignment="Center"
@@ -114,6 +113,5 @@
                 </StackPanel>
             </styles:SHSection>
 
-        </StackPanel>
-    </ScrollViewer>
+    </StackPanel>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Tidy and simplify the top-level navigation by ordering main tabs by priority and using clearer names.  
- Remove the standalone `LAUNCH SETTINGS` tab while preserving its controls and bindings to avoid duplicated UI paths.  
- Keep settings semantics and runtime behaviour unchanged while making the Launch Settings reachable under `Settings` in a collapsed expander.  

### Description
- Reordered and renamed top-level tabs in `LaunchPluginCombinedSettingsControl.xaml.cs` to the exact left-to-right order `STRATEGY`, `PROFILES`, `DASH CONTROL`, `LAUNCH ANALYSIS`, `SETTINGS`, removed the standalone `LAUNCH SETTINGS` entry, and renamed `POST LAUNCH ANALYSIS` → `LAUNCH ANALYSIS` and `GLOBAL SETTINGS` → `SETTINGS`.  
- Embedded the existing `LaunchPluginSettingsUI` view inside the Settings page by adding an `Expander` titled exactly `Launch Settings` (collapsed by default) and a `ContentControl` host in `GlobalSettingsView.xaml`, and wiring the host in `GlobalSettingsView.xaml.cs` to instantiate `LaunchPluginSettingsUI` so all original bindings are preserved.  
- Adjusted `LaunchPluginSettingsUI.xaml` for embedding by removing the outer `ScrollViewer` wrapper (so it composes cleanly inside `GlobalSettingsView`'s scrolling) and updated a few navigation/help tooltips to reference the new `Launch Analysis` / `Settings` layout.  
- Updated documentation files to reflect the new tab order and moved Launch Settings location: `Docs/Project_Index.md`, `Docs/Plugin_UI_Tooltips.md`, `Docs/RepoStatus.md`, and `Docs/Lala_Plugin_User_Guide_v0.3.md`, without changing any setting semantics or planner/launch logic.  

### Testing
- Ran `git diff --check` to confirm no whitespace or diff-check issues and it passed.  
- Verified UI host and ordering by searching the updated host and views (`rg`/code inspection) for `Header = "STRATEGY"`, `Header = "PROFILES"`, `Header = "DASH CONTROL"`, `Header = "LAUNCH ANALYSIS"`, `Header = "SETTINGS"`, the `Launch Settings` `Expander`, and the `FRIENDS LIST` placement, all of which matched the required layout.  
- Executed a small Python assertion that confirmed legacy labels (`POST LAUNCH ANALYSIS`, `GLOBAL SETTINGS`, `LAUNCH SETTINGS` top-level) were removed from the tab host, and it passed.  
- Attempted to build with `msbuild` and `dotnet build` in this environment but the required tools are not available here, so a full compilation run was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6c60a688832fb1c7cdda77e9429e)