### PR TITLE
Wrap Settings Friends List and Dash Control sections in Expanders

### DIFF
--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -18,7 +18,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <GroupBox Grid.Row="0" Header="BINDINGS" Margin="0,0,0,12">
+            <Expander Grid.Row="0" Header="Bindings" Margin="0,0,0,12" IsExpanded="True">
                 <StackPanel Margin="12,10,12,12">
                     <ui:ControlsEditor ActionName="LalaLaunch.MsgCx"
                                        FriendlyName="Cancel Msg Button"
@@ -36,9 +36,9 @@
                                        Margin="0,8,0,0"
                                        ToolTip="Assign a button to cycle declutter mode (0/1/2) for dash visibility bindings." />
                 </StackPanel>
-            </GroupBox>
+            </Expander>
 
-            <GroupBox Grid.Row="1" Header="GLOBAL DASH FUNCTIONS" Margin="0,0,0,12">
+            <Expander Grid.Row="1" Header="Global Dash Functions" Margin="0,0,0,12" IsExpanded="True">
                 <StackPanel Margin="12,10,12,12">
                     <TextBlock Text="General" FontWeight="Bold" Margin="0,0,0,6"/>
                     <styles:SHToggleCheckbox Content="Auto screen selection at session start"
@@ -115,9 +115,9 @@
                                      Value="{Binding Settings.StintFuelMarginPct, Mode=TwoWay}"
                                      ToolTip="Reserve fuel as a percentage of one lap (based on stable fuel burn) when calculating stint burn targets." />
                 </StackPanel>
-            </GroupBox>
+            </Expander>
 
-            <GroupBox Grid.Row="2" Header="DASH VISIBILITY">
+            <Expander Grid.Row="2" Header="Dash Visibility" IsExpanded="True">
                 <StackPanel Margin="12,10,12,12">
                     <TextBlock Text="Choose which dash families can show each feature."
                                Margin="0,0,0,10"
@@ -243,7 +243,7 @@
                                                  ToolTip="Show traffic alerts on the Overlay." />
                     </Grid>
                 </StackPanel>
-            </GroupBox>
+            </Expander>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/Docs/Lala_Plugin_User_Guide_v0.3.md
+++ b/Docs/Lala_Plugin_User_Guide_v0.3.md
@@ -46,6 +46,8 @@ Top-level plugin tabs are ordered left-to-right as **Strategy**, **Profiles**, *
 
 ### 3.1 Recommended bindings
 
+Dash Control is now organized into three expander sections — **Bindings**, **Global Dash Functions**, and **Dash Visibility** — and all three are expanded by default so the existing controls remain visible without the tab feeling as vertically heavy.
+
 - **Cancel Msg Button**: cancels pit and rejoin popups and temporarily suppresses repeats.
 - **Pit Screen Toggle**: manually shows or hides pit-related screens.
 
@@ -69,7 +71,7 @@ Adjust these only when you are chasing a specific false positive or a repeatable
 
 ## 4. Launch Settings & Analysis
 
-Launch Settings now lives inside the top-level **Settings** tab under a collapsed **Launch Settings** expander. It still controls launch behaviour and launch telemetry capture, and per-car defaults can still be stored in profiles and then applied to live use.
+The top-level **Settings** tab now starts with a collapsed **Friends List** expander, followed by a collapsed **Launch Settings** expander and then the Debug area. Launch Settings still controls launch behaviour and launch telemetry capture, and per-car defaults can still be stored in profiles and then applied to live use.
 
 - Typical launch controls include target RPM / throttle, tolerances, bite point behaviour, bog-down detection, and anti-stall sensitivity.
 - Launch telemetry recording is for post-run analysis and does not change what the dashboards do live.

--- a/Docs/Plugin_UI_Tooltips.md
+++ b/Docs/Plugin_UI_Tooltips.md
@@ -15,11 +15,12 @@ Branch: work
 - L40: Close without copying.
 
 ## DashesTabView.xaml
-- BINDINGS section: contains only the true dash bindings for `Cancel Msg Button`, `Toggle Pit Screen Popup`, `Change Primary Dash Mode`, and `Cycle Declutter Mode`.
-- GLOBAL DASH FUNCTIONS -> General: `Auto screen selection at session start` automatically switches dash screens when a session starts based on context.
-- GLOBAL DASH FUNCTIONS -> Dark Mode: `Dark Mode` selector uses Off / Manual / Auto, `Dark Mode Brightness` sets base brightness, `Use Lovely True Dark` follows Lovely when available, and `Toggle Dark Mode` remains here as the dark-mode-specific binding row.
-- GLOBAL DASH FUNCTIONS -> Fuel: `Fuel Ready Confidence` sets the live-fuel readiness threshold and `Pit-in Fuel Reserve` sets the stint reserve margin.
-- DASH VISIBILITY section: keeps the existing main/message/overlay visibility matrix for Launch Assist, Pit Assists, Automatic Pit Screen, Rejoin Assist, Verbose Race Messages, Race Flags, Radio Messages, and Traffic Alerts.
+- Dash Control now uses three expander-based main sections: `Bindings`, `Global Dash Functions`, and `Dash Visibility`; all default to expanded so the existing content remains immediately visible while matching the Settings-tab tidy-up pattern.
+- `Bindings` contains only the true dash bindings for `Cancel Msg Button`, `Toggle Pit Screen Popup`, `Change Primary Dash Mode`, and `Cycle Declutter Mode`.
+- `Global Dash Functions` -> General: `Auto screen selection at session start` automatically switches dash screens when a session starts based on context.
+- `Global Dash Functions` -> Dark Mode: `Dark Mode` selector uses Off / Manual / Auto, `Dark Mode Brightness` sets base brightness, `Use Lovely True Dark` follows Lovely when available, and `Toggle Dark Mode` remains here as the dark-mode-specific binding row.
+- `Global Dash Functions` -> Fuel: `Fuel Ready Confidence` sets the live-fuel readiness threshold and `Pit-in Fuel Reserve` sets the stint reserve margin.
+- `Dash Visibility` keeps the existing main/message/overlay visibility matrix for Launch Assist, Pit Assists, Automatic Pit Screen, Rejoin Assist, Verbose Race Messages, Race Flags, Radio Messages, and Traffic Alerts.
 - `Launch Mode`, `Event Marker`, and `Post-Launch Results Display Time` no longer appear in Dash Control after this tidy-up.
 
 ## FuelCalculatorView.xaml
@@ -202,7 +203,7 @@ Branch: work
 - `ProfilesManagerView.xaml` L522: `Learning mode` tooltip explains shift-point data mining and learning-overlay visibility.
 - `ProfilesManagerView.xaml` L751-L768: custom WAV controls include the existing path/browse affordance while some adjacent labels remain tooltip-free.
 - `GlobalSettingsView.xaml` is now the top-level `SETTINGS` tab, with visible main-tab order `STRATEGY`, `PROFILES`, `DASH CONTROL`, `LAUNCH ANALYSIS`, `SETTINGS`.
-- `GlobalSettingsView.xaml` now surfaces the Friends List section first, then a collapsed `Launch Settings` expander, then the existing Debug block.
+- `GlobalSettingsView.xaml` now surfaces the Friends List tools/import flow inside a collapsed `Friends List` expander first, then a collapsed `Launch Settings` expander, then the existing Debug block.
 - `GlobalSettingsView.xaml` no longer contains the duplicated per-profile `USER VARIABLES` block; the Settings tab now begins with the Friends List tools/import flow.
 - `GlobalSettingsView.xaml` DEBUG section continues to host the existing debug toggles and the moved `Event Marker` binding under `Debug Actions`; Launch Settings now sits above this block inside its own collapsed expander.
 - `GlobalSettingsView.xaml` `Enable Debug Logging` tooltip says it enables verbose logging for troubleshooting the plugin.

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -21,7 +21,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 - [CODEX_CONTRACT.txt](CODEX_CONTRACT.txt) - mandatory Codex/global engineering policy.
 - [Architecture_Guardrails.md](Architecture_Guardrails.md) - practical architecture boundaries and subsystem ownership guidance.
 - [CODEX_TASK_TEMPLATE.txt](CODEX_TASK_TEMPLATE.txt) - reusable task skeleton for analysis-first Codex work.
-- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls, including the Strategy tab preset-manager modal flow, the reordered top-level tab layout (Strategy / Profiles / Dash Control / Launch Analysis / Settings), the embedded Launch Settings expander inside Settings, and the TRACKS tab's track-scoped planner inputs.
+- [Plugin_UI_Tooltips.md](Plugin_UI_Tooltips.md) - current tooltip inventory and UI navigation notes for plugin tabs and controls, including the Strategy tab preset-manager modal flow, the reordered top-level tab layout (Strategy / Profiles / Dash Control / Launch Analysis / Settings), the collapsed Friends List and Launch Settings expanders inside Settings, the expander-based Dash Control sections, and the TRACKS tab's track-scoped planner inputs.
 - [SimHubParameterInventory.md](SimHubParameterInventory.md) - canonical SimHub export contract.
 - [SimHubLogMessages.md](SimHubLogMessages.md) - canonical Info/Warn/Error log catalogue.
 - [Subsystems/Shift_Assist.md](Subsystems/Shift_Assist.md) - Shift Assist purpose, inputs/state, outputs, and validation checklist.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,6 +1,6 @@
 ﻿# Repository status
 
-Validated against commit: HEAD
+Validated against commit: f9d805f
 Last updated: 2026-03-20
 Branch: work
 
@@ -9,15 +9,15 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- `Docs/Subsystems/CarSA.md` updated so the canonical CarSA doc now records the new CarSA-owned fixed-6-sector cache foundation, its 60-checkpoint-to-6-sector mapping, overwrite/invalidation rules, and the narrow accessor seam while making clear H2H has not switched to it yet.
-- `Docs/Subsystems/H2H.md` updated so the canonical H2H doc now states that CarSA owns the new sector-cache foundation in this phase while published H2H outputs still come from the existing H2H runtime.
+- `GlobalSettingsView.xaml` updated so the Settings tab now hosts the existing Friends List tools/import flow inside a collapsed `Friends List` expander while preserving the existing order of Friends List -> Launch Settings -> Debug.
+- `DashesTabView.xaml` updated so Dash Control now uses expander-based `Bindings`, `Global Dash Functions`, and `Dash Visibility` sections, all expanded by default without changing their internal bindings or behavior.
+- `Docs/Plugin_UI_Tooltips.md`, `Docs/Project_Index.md`, and `Docs/Lala_Plugin_User_Guide_v0.3.md` updated so navigation/help text matches the new expander-based layout.
 - `Docs/RepoStatus.md` refreshed for the current validation summary.
 
 ## Delivery status highlights
-- CarSA now owns a per-car fixed-6-sector cache foundation derived from the existing 60-checkpoint progression, with per-car continuity anchors, per-sector `HasValue`/`DurationSec`, explicit modulo-advance `>10` discontinuity clears, and a narrow `TryGetFixedSectorCacheSnapshot` read seam for later H2H migration.
-- The new cache remains inside the CarSA ownership boundary and does not depend on selector state, lap-bound sector runtime, or H2H bind windows.
-- H2H output behavior is intentionally unchanged in this phase: the existing H2H runtime, selectors, and published dash contract remain in place while the new CarSA-side timing source is built and documented for later switchover.
-- `Docs/RepoStatus.md` refreshed for the current validation summary.
+- Settings is less vertically heavy because Friends List now follows the same collapsed-expander pattern already used for Launch Settings, while keeping Launch Settings below Friends List and above Debug.
+- Dash Control keeps the same three main content areas and bindings, but each area now sits inside a tidy expander container for cleaner scanning.
+- This task is UI-only: no subsystem logic, setting semantics, binding behavior, preset flow, or launch-setting behavior changed.
 
 ## Notes
 - `Docs/Code_Snapshot.md` remains non-canonical orientation-only documentation.

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -21,8 +21,10 @@
     </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10">
-            <styles:SHSection Title="FRIENDS LIST" ShowSeparator="True">
-                <StackPanel>
+            <Expander Header="Friends List"
+                      Margin="0,0,0,10"
+                      IsExpanded="False">
+                <StackPanel Margin="0,10,0,0">
                     <TextBlock Margin="0,0,0,5" Foreground="LightGray"
                                Text="Add iRacing Customer IDs and assign a driver tag in CarSA." />
                     <StackPanel Margin="0,0,0,8">
@@ -52,7 +54,6 @@
                                                     Content="Import"
                                                     Padding="8,2"
                                                     MinWidth="70"
-  
                                                     Click="ImportIOverlay_Click" />
                             <styles:SHButtonPrimary Grid.Column="4"
                                                     Content="Reload"
@@ -102,7 +103,7 @@
                                             HorizontalAlignment="Left"
                                             Click="AddFriend_Click" />
                 </StackPanel>
-            </styles:SHSection>
+            </Expander>
 
             <Expander Header="Launch Settings"
                       Margin="0,0,0,10"


### PR DESCRIPTION
### Motivation
- Reduce vertical weight of the `Settings` tab and make `Dash Control` easier to scan by using the same expander-style layout pattern already used elsewhere. 
- Keep this as a UI-only tidy-up that preserves all existing bindings, behavior, and control order. 
- Update directly-impacted documentation so the UI help text matches the final layout.

### Description
- Wrap the Friends List UI in `GlobalSettingsView.xaml` inside an `Expander` with header exactly `Friends List` and `IsExpanded="False"`, preserving the internal controls and leaving `Launch Settings` and `Debug` placement unchanged. 
- Convert the three top-level `DashesTabView.xaml` containers from `GroupBox` to `Expander` with headers `Bindings`, `Global Dash Functions`, and `Dash Visibility`, and set `IsExpanded="True"` for each while keeping inner layouts and bindings unchanged. 
- Update UI/help docs in `Docs/Plugin_UI_Tooltips.md`, `Docs/Project_Index.md`, and `Docs/Lala_Plugin_User_Guide_v0.3.md` to describe the new expander-based layout, and refresh `Docs/RepoStatus.md` to record the validated commit and summarize the tidy-up (validated commit: `f9d805f`). 
- Ensure all XAML remained well-formed and no semantic or binding changes were introduced (visual/container-only changes). 

### Testing
- Parsed `GlobalSettingsView.xaml` and `DashesTabView.xaml` with Python `xml.etree.ElementTree` and both files parsed successfully. 
- Verified presence of the new expander headers and default states using `rg`/search (found `Header="Friends List"` with `IsExpanded="False"` and `Header="Bindings"|"Global Dash Functions"|"Dash Visibility"` with `IsExpanded="True"`). 
- Attempted `dotnet build LaunchPlugin.sln` in the environment but `dotnet` is not available here so a full build/run test could not be executed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7b0af1b8832f860f6c23b8ba3f17)