### PR TITLE
Add GitHub-facing Shift Assist and Launch system docs

### DIFF
--- a/Docs/Launch_System.md
+++ b/Docs/Launch_System.md
@@ -1,0 +1,102 @@
+# Launch System
+
+The Launch system helps you prepare, execute, and review race starts more consistently.
+
+Think of it as two related parts:
+
+- **live launch behavior** that supports the start itself,
+- **Launch Analysis** for reviewing saved launch results afterwards.
+
+The plugin remains the source of truth for launch calculations, state, and saved data. Dashboards can show launch information, but they do not own the launch logic.
+
+## What the Launch system is for
+
+Use the Launch system when you want to:
+
+- build a repeatable starting baseline,
+- reduce guesswork around launch targets and tolerances,
+- capture launch results for later review,
+- refine your setup from patterns instead of one-off impressions.
+
+It is meant to support race starts without turning launch setup into a constant tuning distraction.
+
+## Where launch controls live
+
+Launch controls now live in:
+
+**Settings -> Launch Settings**
+
+That is where you should expect to review and adjust launch-related setup, including practical launch targets, tolerances, and capture behavior.
+
+## What Launch Analysis is for
+
+**Launch Analysis** is the separate review tab for saved launch traces and summaries.
+
+Use it after a run to answer questions like:
+
+- Was the launch close to the target?
+- Did the start look clean and repeatable?
+- Did it bog, bite too hard, or show anti-stall-style intervention?
+- Is there a pattern across several launches, or was one run just messy?
+
+Launch Analysis is for review and comparison. It is not where the live launch logic lives.
+
+## Live launch behavior vs post-launch review
+
+A useful way to think about the system is:
+
+- **Launch Settings** controls the live setup.
+- **Launch Analysis** helps you review what actually happened.
+
+During the start, the system is concerned with the live launch behavior.
+After the start, Launch Analysis helps you inspect saved summaries and traces so you can decide whether any tuning change is justified.
+
+## Summary and trace capture
+
+At a practical level, the Launch system can save:
+
+- a **summary** for quick review,
+- a **trace** for deeper launch-shape inspection.
+
+You do not need to treat every trace like engineering data. The practical goal is to compare several launches and look for repeatable trends.
+
+## Typical tuning concepts
+
+Most users will think about launch setup in terms of a few practical concepts:
+
+### Launch targets
+
+These are the baseline values you are trying to hit consistently at the start.
+
+### Tolerances
+
+These define how tightly the launch should stay around the intended target before you consider it meaningfully off.
+
+### Bite / anti-stall / bog-down style behavior
+
+These are the practical feel questions you review after a launch:
+
+- Did it bite too hard?
+- Did it fall into a bog?
+- Did it look like the start needed more protection against stalling?
+
+Use those observations carefully and only after you have more than one representative launch to compare.
+
+## Practical workflow
+
+A stable workflow usually looks like this:
+
+1. **Set a baseline** in **Settings -> Launch Settings**.
+2. **Record launches** instead of changing values after every run.
+3. **Review traces and summaries** in **Launch Analysis**.
+4. **Refine carefully** when you see the same problem repeated across several launches.
+
+This is usually better than chasing one bad start with a major retune.
+
+## Avoid over-tuning
+
+Do not keep rewriting launch settings because of a single poor launch.
+
+Bad starts can come from the driver, the session context, or one messy attempt. Wait for repeatable evidence in the saved summaries and traces before you make meaningful changes.
+
+A calm baseline with measured review is usually more useful than constant launch tweaking.

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -38,6 +38,8 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 - [User_Guide.md](User_Guide.md) - GitHub-facing end-user manual covering the current UI flow, saved-data model, dash control usage, launch settings location, and practical race-day habits.
 - [Dashboards.md](Dashboards.md) - user-facing overview of the supported dashboard package, visibility concepts, primary/support/overlay roles, and dash-vs-plugin responsibility split.
 - [Strategy_System.md](Strategy_System.md) - user-facing explanation of the Strategy tab workflow, Live Snapshot vs profile/manual planning, preset flow, and PreRace boundaries.
+- [Shift_Assist.md](Shift_Assist.md) - user-facing guide to Shift Assist cues, learning workflow, locking practice, and practical troubleshooting.
+- [Launch_System.md](Launch_System.md) - user-facing guide to Launch Settings, Launch Analysis, saved launch review, and careful tuning workflow.
 - [H2H_System.md](H2H_System.md) - concise user-facing overview of H2H Race and H2H Track, what they compare, and where they appear.
 - [Rejoin_And_Pit_Assists.md](Rejoin_And_Pit_Assists.md) - user-facing guide to rejoin warnings, pit popups, and pit entry assist trust/override workflow.
 
@@ -58,7 +60,7 @@ LalaLaunchPlugin is a SimHub plugin for iRacing that provides launch instrumenta
 | Dash integration | Main/message/overlay visibility, screen state exports, and global dark-mode controls (`LalaLaunch.Dash.DarkMode.*`) | [Subsystems/Dash_Integration.md](Subsystems/Dash_Integration.md) |
 
 ## GitHub-facing user docs
-These pages are for end users and GitHub readers. They summarize the current supported workflow without replacing the canonical subsystem specifications above. When behavior details matter, the subsystem docs remain authoritative.
+These pages are for end users and GitHub readers. They summarize the current supported workflow without replacing the canonical subsystem specifications above. When behavior details matter, the subsystem docs remain authoritative. The public set now covers quick start, the full user guide, dashboards, strategy, Shift Assist, the Launch system, H2H, and rejoin/pit assists.
 
 ## Freshness
 - Validated against commit: HEAD

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -123,6 +123,8 @@ If something is repeatedly wrong, the usual cause is saved data or thresholds th
 - **Fuel or pace looks wrong:** unlock the affected values and gather clean laps.
 - **Pit-loss looks wrong:** relearn with one clean pit cycle, then lock again.
 - **Pit entry cues feel wrong:** review pit markers and pit-entry settings in the profile.
+- **Shift Assist cues feel early, late, or inconsistent:** review the learned or stored Shift Assist values for the active profile, then retest cleanly.
+- **Launch tuning feels inconsistent:** keep a stable baseline, record several launches, then review summaries/traces in **Launch Analysis** before changing settings.
 - **Rejoin or pit popups are distracting:** use **Cancel Message** in the moment, then review thresholds or saved data later.
 - **Dash looks wrong:** remember the plugin owns the data; the dash is usually only showing it.
 
@@ -131,5 +133,7 @@ If something is repeatedly wrong, the usual cause is saved data or thresholds th
 - [User Guide](User_Guide.md)
 - [Dashboards](Dashboards.md)
 - [Strategy System](Strategy_System.md)
+- [Shift Assist](Shift_Assist.md) for cueing, learning, and locking guidance
+- [Launch System](Launch_System.md) for Launch Settings and Launch Analysis workflow
 - [H2H System](H2H_System.md)
 - [Rejoin and Pit Assists](Rejoin_And_Pit_Assists.md)

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,19 +9,18 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- Refreshed `Docs/CODEX_CONTRACT.txt` and `Docs/CODEX_TASK_TEMPLATE.txt` so the internal Codex workflow now explicitly requires review/update decisions for GitHub-facing docs when tasks change user-visible behavior.
-- For this internal policy refresh, `README.md`, `CHANGELOG.md`, and the user-facing docs were reviewed and left unchanged because no user-facing behavior or workflow changed.
-- Added a GitHub-facing user documentation layer at repo root and `Docs/` with `README.md`, `CHANGELOG.md`, `Docs/Quick_Start.md`, `Docs/User_Guide.md`, `Docs/Dashboards.md`, `Docs/Strategy_System.md`, `Docs/H2H_System.md`, and `Docs/Rejoin_And_Pit_Assists.md`.
-- User-facing wording now reflects the current documented UI flow: `Strategy`, `Profiles`, `Dash Control`, `Launch Analysis`, `Settings`.
-- User docs now describe presets through the Strategy-tab `Presets...` modal flow, remove outdated `Use Live` wording, keep PreRace display-only, and place launch controls under `Settings -> Launch Settings`.
-- `Docs/Project_Index.md` now links the new GitHub-facing user docs while preserving subsystem docs as canonical technical truth.
-- `Docs/RepoStatus.md` refreshed for the current validation summary.
-- The GitHub-facing documentation structure introduced in PR #495 is now aligned with the v1.0 release wording and public release framing.
+- Reviewed the GitHub-facing documentation set for missing public coverage and confirmed the two remaining major user-facing gaps were dedicated pages for Shift Assist and the Launch system.
+- Added `Docs/Shift_Assist.md` as the public user-facing Shift Assist page, covering cue types, learning workflow, profile-backed storage, first-use advice, and troubleshooting without changing subsystem ownership.
+- Added `Docs/Launch_System.md` as the public user-facing Launch system page, covering `Settings -> Launch Settings`, Launch Analysis, saved summaries/traces, and careful launch tuning workflow.
+- Updated `README.md`, `Docs/User_Guide.md`, `Docs/Quick_Start.md`, and `Docs/Project_Index.md` so the new pages are easy to discover and cross-linked from the main public documentation flow.
+- Kept Launch wording aligned to the current UI split: live launch controls under `Settings -> Launch Settings`, with `Launch Analysis` remaining the separate review tab for saved traces and summaries.
+- Kept Shift Assist wording aligned to the current ownership model: the plugin owns learning, storage, and calculations; dashboards remain display/interaction surfaces only.
+- Reviewed `CHANGELOG.md` and left it unchanged because it did not claim the GitHub-facing documentation set was already complete enough to require a release-history correction for these additions.
 
 ## Delivery status highlights
-- The repo now has a clean GitHub-facing documentation structure for installation, quick start, the full user guide, dashboards, strategy, H2H, driver assists, and release history.
+- The repo now has a clean GitHub-facing documentation structure for installation, quick start, the full user guide, dashboards, strategy, Shift Assist, the Launch system, H2H, driver assists, and release history.
 - User docs have been aligned to the current UI and ownership model without changing runtime code, telemetry logic, exports, settings behavior, or dashboard ownership boundaries.
-- Dash Control remains documented as dash-oriented, while launch controls are documented under `Settings -> Launch Settings`.
+- Dash Control remains documented as dash-oriented, while launch controls are documented under `Settings -> Launch Settings` and `Launch Analysis` remains the separate review surface.
 - Strategy remains the planning entry point, with Live Snapshot/manual distinctions and PreRace display-only positioning called out explicitly.
 
 ## Notes

--- a/Docs/Shift_Assist.md
+++ b/Docs/Shift_Assist.md
@@ -1,0 +1,100 @@
+# Shift Assist
+
+Shift Assist is a driver aid for cleaner, more repeatable upshift timing.
+
+It watches the current gear and RPM, then gives you cues near the target RPM for that gear. It helps the driver react consistently, but it does **not** shift the car for you.
+
+## What it is for
+
+Use Shift Assist when you want:
+
+- a clearer upshift cue than watching the tach alone,
+- more consistent shift timing across laps,
+- a practical way to learn and review gear-specific shift targets,
+- a quick reminder before you run too deep into the limiter.
+
+The plugin remains the source of truth for the targets it stores, learns, and publishes. Dashboards can display the cues, but they do not own the Shift Assist logic.
+
+## What you see and hear
+
+Shift Assist can provide three practical cue types:
+
+- **Shift Sound** for the main audio cue.
+- **Shift Light** for visual cue routing.
+- **Urgent reminder / redline protection behavior** when you stay in the gear too long after the main cue.
+
+In normal use, the main cue tells you the preferred shift point. The urgent reminder is there to reinforce that you are late, not to replace the main timing cue.
+
+## Core outputs
+
+### Shift Sound
+
+The main Shift Assist beep is the primary upshift cue. It is intended to fire near the target RPM for the current gear, with predictive timing support available so the cue can arrive slightly before the raw target when needed.
+
+### Shift Light
+
+Shift Assist also exposes Shift Light output for dashboards and visual layouts. Depending on the selected routing, the light can follow the primary cue, the urgent cue, or both.
+
+### Urgent reminder / redline protection behavior
+
+If you stay in the gear after the main cue, Shift Assist can issue an additional urgent reminder. Think of it as a late warning near the top of the usable range rather than a separate shift strategy.
+
+It does not change the learned targets, the stored profile data, or the normal shift timing logic. It is only an extra reminder to help you avoid hanging on the limiter.
+
+## Learning workflow
+
+Shift Assist learning is meant to be practical, not complicated.
+
+1. **Enable learning** for the active profile or gear stack.
+2. **Do several clean pulls** with strong throttle application so the plugin can gather usable data.
+3. **Review the learned values** and look for stable, believable gear-by-gear targets.
+4. **Lock gears once stable** so good values stop drifting.
+
+The usual pattern is:
+
+**learn → review → lock → trust**
+
+Do not rush the lock step. If a gear still looks noisy or inconsistent, leave that gear unlocked and keep gathering clean data.
+
+## Profile and storage relationship
+
+Shift Assist uses profile-backed storage.
+
+That means:
+
+- the plugin stores the useful learned values,
+- the active profile and gear stack matter,
+- resets and locks should be done deliberately,
+- dashboards only consume the outputs the plugin publishes.
+
+If you change cars, profile context, or the relevant gear-stack setup, review the stored Shift Assist values instead of assuming the old ones still apply.
+
+## Practical first-use advice
+
+For a first pass:
+
+- start with the feature enabled,
+- use the standard cue first before chasing custom tuning,
+- do a few clean full-throttle pulls,
+- check whether the cues feel believable in each important gear,
+- lock only the gears that have clearly settled.
+
+Treat the first session as calibration, not final truth.
+
+## If cues feel early, late, or inconsistent
+
+If Shift Assist feels wrong, use a simple order of operations:
+
+1. Check that you are evaluating it during clean, repeatable pulls.
+2. Review the current learned or stored values for the active profile.
+3. If the cues are consistently early or late, adjust carefully and then retest.
+4. If one gear is unreliable, unlock or relearn that gear instead of disturbing everything else.
+5. If the problem is visual-only, review the dash/light presentation separately from the plugin values.
+
+Avoid overreacting to one messy run. Look for repeatable patterns before changing multiple gears or repeatedly resetting learning.
+
+## Important boundary
+
+Shift Assist is a **driver aid**, not an auto-shift system.
+
+It gives you timing cues. The driver still decides when to shift.

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -146,7 +146,7 @@ Launch controls belong in **Settings → Launch Settings**.
 
 ## 6. Launch settings and launch analysis
 
-Launch behaviour is configured in **Settings → Launch Settings**.
+Launch behaviour is configured in **Settings → Launch Settings**. For the user-facing launch workflow and tuning habits, see [Launch System](Launch_System.md).
 
 Typical launch controls include:
 
@@ -156,9 +156,18 @@ Typical launch controls include:
 - launch summary and trace capture locations,
 - launch logging options.
 
-**Launch Analysis** is the separate top-level tab used to review saved launch traces and summaries.
+**Launch Analysis** is the separate top-level tab used to review saved launch traces and summaries. Keep live launch setup in Settings, then use Launch Analysis for post-run review.
 
-## 7. Dashboards
+
+## 7. Shift Assist
+
+Shift Assist is a driver aid for RPM-based shift cueing. It can provide a **Shift Sound**, **Shift Light**, and an additional urgent reminder if you stay in the gear too long after the main cue.
+
+Use it to improve shift timing consistency, then review learned values and lock gears once they are stable. It is still a cueing aid, not an automatic shift feature.
+
+For setup and first-use guidance, see [Shift Assist](Shift_Assist.md).
+
+## 8. Dashboards
 
 The supported dashboard package normally includes:
 
@@ -171,7 +180,7 @@ Use visibility settings, primary mode, and declutter mode to decide what appears
 
 For details, see [Dashboards](Dashboards.md).
 
-## 8. H2H and race context
+## 9. H2H and race context
 
 H2H is a read-only race-context aid for the driver.
 
@@ -182,7 +191,7 @@ Use it for awareness and comparison, not as something you constantly configure.
 
 For details, see [H2H System](H2H_System.md).
 
-## 9. Rejoin, pit entry, and pit popups
+## 10. Rejoin, pit entry, and pit popups
 
 The plugin includes practical driver aids for:
 
@@ -196,7 +205,7 @@ If a popup is wrong once, cancel or override it and keep driving. If it is wrong
 
 For details, see [Rejoin and Pit Assists](Rejoin_And_Pit_Assists.md).
 
-## 10. Practical best practice
+## 11. Practical best practice
 
 - Start each new car/track combination by gathering clean laps.
 - Validate pit-loss and track markers before locking them.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo is the user-facing home for the plugin's **v1.0 release** documentatio
 - Learns and stores fuel, pace, pit-loss, and track marker data.
 - Provides a **Strategy** workflow for planning laps/time races using profile data or live session snapshots.
 - Publishes stable outputs to dashboards so the driver is not chasing noisy lap-to-lap changes.
-- Supports pit-entry assist, pit popups, rejoin warnings, launch analysis, Shift Assist, and head-to-head race/track comparisons.
+- Supports pit-entry assist, pit popups, rejoin warnings, the Launch system with Launch Analysis review, Shift Assist, and head-to-head race/track comparisons.
 - Coordinates multiple dash types, visibility options, and declutter modes without moving calculation ownership into the dashboards.
 
 ## Plugin vs dashboard responsibility
@@ -40,6 +40,8 @@ For full instructions, use the docs below.
 - [User Guide](Docs/User_Guide.md)
 - [Dashboards](Docs/Dashboards.md)
 - [Strategy System](Docs/Strategy_System.md)
+- [Shift Assist](Docs/Shift_Assist.md)
+- [Launch System](Docs/Launch_System.md)
 - [H2H System](Docs/H2H_System.md)
 - [Rejoin and Pit Assists](Docs/Rejoin_And_Pit_Assists.md)
 - [Changelog](CHANGELOG.md)


### PR DESCRIPTION
### Motivation
- Close two missing public documentation gaps by adding clear GitHub-facing user pages for Shift Assist and the Launch system using existing canonical subsystem specs as the technical source of truth.
- Ensure users can discover and follow practical setup, learning, tuning, and review workflows without exposing internal implementation details or changing runtime behaviour.
- Keep the change strictly documentation-only and follow the repository `CODEX_CONTRACT.txt` guidance and subsystem ownership guardrails.

### Description
- Add two new user-facing pages: `Docs/Shift_Assist.md` (Shift Assist overview, cues, learning workflow, storage, first-use advice, troubleshooting) and `Docs/Launch_System.md` (Launch Settings location, Launch Analysis, summary/trace capture, tuning concepts, practical workflow).
- Wire both pages into the public docs by updating `README.md`, `Docs/User_Guide.md`, `Docs/Quick_Start.md`, and `Docs/Project_Index.md` so the pages are discoverable from the main repo entry points.
- Update `Docs/RepoStatus.md` to record the added public coverage and to note that `CHANGELOG.md` was reviewed and left unchanged.
- No runtime code, settings, telemetry, `.cs`, `.xaml`, dashboard JSON, or subsystem ownership was modified.

### Testing
- Ran repository integrity checks and diff/whitespace validation and observed no failures (documentation changes only).
- Verified the new pages are discoverable from the README and `Docs/Project_Index.md` and that cross-links in `Docs/User_Guide.md` and `Docs/Quick_Start.md` point to the new pages.
- Reviewed `CHANGELOG.md` and confirmed no changelog update was required for these documentation additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be8ec920f0832f8fac4d6ba62115c1)