### PR TITLE
Polish README landing page

### DIFF
--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,6 +1,6 @@
 # Repository status
 
-Validated against commit: dfee7ec
+Validated against commit: HEAD
 Last updated: 2026-03-21
 Branch: work
 
@@ -9,21 +9,18 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status (requested set)
-- Completed a documentation-structure cleanup only; no runtime/plugin code, XAML, JSON, dashboard, namespace, or property files were changed.
-- Restructured the repo docs into three layers: user-facing GitHub docs in `Docs/`, technical subsystem docs in `Docs/Subsystems/`, and internal/developer docs in `Docs/Internal/`.
-- Moved Codex/maintainer reference docs into `Docs/Internal/`: contract, architecture guardrails, task template, parameter inventory, tooltip inventory, log catalogue, and orientation snapshot.
-- Replaced the combined `Docs/Rejoin_And_Pit_Assists.md` user page with separate driver-facing pages for `Docs/Rejoin_Assist.md` and `Docs/Pit_Assist.md`.
-- Added dedicated top-level user pages for `Docs/Profiles_System.md` and `Docs/Fuel_Model.md` so profile trust/locking and fuel-learning behavior are now documented as first-class driver-facing systems.
-- Updated `README.md`, `Docs/Project_Index.md`, `Docs/User_Guide.md`, `Docs/Quick_Start.md`, and the existing user-facing system pages so navigation now reflects the new three-layer documentation structure.
-- Updated user-facing wording to use **Lala Race Assist Plugin** where appropriate while preserving internal technical names such as `LalaLaunch.*` in technical/internal docs.
-- Reviewed `CHANGELOG.md` and left it unchanged because this task reorganizes docs and branding wording only; it does not correct a public release-history claim about runtime behavior.
+- Completed a documentation-only README polish pass; no runtime/plugin code, XAML, JSON, dashboard, namespace, or property files were changed.
+- Refined `README.md` into a more public-facing landing page with a shorter intro, a scan-friendly Core Systems section, clearer responsibility boundaries, grouped documentation links, and tighter notes for first-time GitHub visitors.
+- Preserved the repo's three-layer documentation structure: user-facing docs in `Docs/`, technical subsystem docs in `Docs/Subsystems/`, and internal/developer docs in `Docs/Internal/`.
+- Preserved all existing user-facing documentation destinations for Quick Start, User Guide, Dashboards, Strategy System, Shift Assist, Launch System, Rejoin Assist, Pit Assist, H2H System, Profiles System, and Fuel Model.
+- Kept branding as **Lala Race Assist Plugin** and did not document the future/global message system as active.
+- Reviewed `Docs/Quick_Start.md`, `Docs/User_Guide.md`, `Docs/Dashboards.md`, and `Docs/Project_Index.md` during the README polish pass and left them unchanged because the task was presentation-only.
+- Reviewed `CHANGELOG.md` and left it unchanged because this task does not change runtime behavior or release-visible functionality.
 
 ## Delivery status highlights
-- Top-level user docs now read as a driver-facing layer centered on what the plugin does, what the driver sees, how to use it, and what to trust.
-- `Docs/Subsystems/` remains the technical/internal architecture layer for ownership, calculations, and export behavior.
-- `Docs/Internal/` now contains the maintainer/Codex support material needed for future tasks without mixing it into the user-facing docs.
-- Strategy remains the user-facing planning term, while Fuel Planner terminology remains technical/internal only.
-- Opponents and CarSA remain subsystem-level supporting docs; H2H stays the user-facing driver outcome page.
+- README now prioritizes first-screen clarity for public visitors by surfacing what the plugin covers before deeper documentation structure.
+- Documentation links are grouped into getting started, driver systems, and dash/reference sections for faster scanning.
+- Plugin-vs-dashboard ownership and current UI boundaries remain explicit without repeating the same ideas across multiple sections.
 
 ## Validation note
-- Validation recorded against commit `dfee7ec` (`Restructure documentation layers`).
+- Validation recorded against `HEAD` (`Polish README landing page`).

--- a/README.md
+++ b/README.md
@@ -1,42 +1,48 @@
 # Lala Race Assist Plugin
 
-Lala Race Assist Plugin is a SimHub plugin for **iRacing** focused on race-ready strategy, dashboard support, launch instrumentation, pit assistance, rejoin awareness, Shift Assist, and head-to-head race context.
+Lala Race Assist Plugin is a SimHub plugin for **iRacing** focused on race engineering, driver support, and dashboard-ready outputs. It combines planning, learned data, and live race context so drivers can make cleaner decisions without pushing core logic into dashboards.
 
-This repository now separates documentation into three layers:
-- **User-facing GitHub docs** in `Docs/` for drivers and dashboard users.
-- **Technical subsystem docs** in `Docs/Subsystems/` for internal behavior and ownership.
-- **Internal/developer docs** in `Docs/Internal/` for maintainers, support work, and Codex tasks.
+It is built to help with the practical race workflow: plan stints, trust learned fuel and pace data, manage launch and pit situations, and keep key race context visible while driving.
 
-## Supported scope
+## Core Systems
+
+- **Strategy** - stable planning workflow for race fuel, stint, and context decisions
+- **Shift Assist** - RPM-based shift cueing with profile-backed trust and locking workflows
+- **Launch System** - launch setup plus saved-run review through Launch Analysis
+- **Rejoin Assist** - recovery and rejoin awareness support after incidents or off-tracks
+- **Pit Assist** - pit-entry and pit-lane support surfaced through the plugin and dashboards
+- **H2H** - same-class race and local-track comparison context
+- **Profiles** - long-term saved data by car, track, and condition
+- **Fuel Model** - learned fuel burn and confidence that feed the planning workflow
+- **Dashboards** - dashboard integration for display, visibility, and interaction with plugin outputs
+
+## Supported Scope
 
 - **Platform:** SimHub
 - **Sim:** iRacing only
-- **Primary use:** strategy planning, race support, dashboards, launch review, and profile-backed driver aids
+- **Primary use:** race planning, learned-data workflows, driver aids, and dashboard-supported race context
 
-## What it does
+## Plugin vs Dashboard Responsibility
 
-- Learns and stores fuel, pace, pit-loss, marker, and profile data by car, track, and condition.
-- Provides a **Strategy** workflow for stable race planning using saved data or live session snapshots.
-- Publishes stable outputs to dashboards so the driver is not chasing noisy lap-to-lap changes.
-- Supports Shift Assist, the Launch system, rejoin awareness, pit guidance, H2H race context, and profile-backed trust/lock workflows.
+The plugin owns the **learning, storage, calculations, and exports**. Dashboards are the presentation layer: they show those outputs and provide limited interaction, but they do not own strategy math, saved learning, H2H selection, or launch logic.
 
-## Plugin vs dashboard responsibility
-
-The plugin is the source of truth for **learning, storage, calculations, and exports**. Dashboards display those outputs and provide limited interaction, but they do not own strategy math, saved data, H2H selection, or launch logic.
-
-## Install summary
+## Install Summary
 
 1. Copy the plugin files into your SimHub installation.
 2. Keep **`RSC.iRacingExtraProperties.dll` required for now**.
 3. Restart SimHub.
 4. Import the dashboards you want to use.
-5. Open the plugin and start with **Strategy**, then review **Profiles**, **Dash Control**, and **Settings**.
+5. Open the plugin and begin with **Strategy**, then review **Profiles**, **Dash Control**, and **Settings**.
 
-## User documentation
+## Documentation
+
+### Getting Started
 
 - [Quick Start](Docs/Quick_Start.md)
 - [User Guide](Docs/User_Guide.md)
-- [Dashboards](Docs/Dashboards.md)
+
+### Driver Systems
+
 - [Strategy System](Docs/Strategy_System.md)
 - [Shift Assist](Docs/Shift_Assist.md)
 - [Launch System](Docs/Launch_System.md)
@@ -45,15 +51,14 @@ The plugin is the source of truth for **learning, storage, calculations, and exp
 - [H2H System](Docs/H2H_System.md)
 - [Profiles System](Docs/Profiles_System.md)
 - [Fuel Model](Docs/Fuel_Model.md)
+
+### Dash and Reference
+
+- [Dashboards](Docs/Dashboards.md)
 - [Changelog](CHANGELOG.md)
-
-## Technical and internal docs
-
 - [Project Index](Docs/Project_Index.md)
-- [Subsystem docs](Docs/Subsystems/)
-- [Internal / developer docs](Docs/Internal/)
 
-## Current UI structure
+## Current UI Structure
 
 The current top-level plugin navigation is:
 
@@ -65,13 +70,13 @@ The current top-level plugin navigation is:
 
 Presets are managed from **Strategy** through the **`Presets...`** modal flow. There is no separate top-level Presets tab.
 
-## Notes
+## Notes / Important Boundaries
 
-- PreRace is an **on-grid/display layer** only. It does not replace the planner or change the live fuel model.
-- Live Snapshot mode can auto-drive relevant planning values. When live control is active, the corresponding manual controls are disabled.
-- Launch-related controls live under **Settings → Launch Settings**, while **Launch Analysis** remains the saved-run review tab.
+- **PreRace** is display-only. It does not replace the planner or change the live fuel model.
+- **Live Snapshot** can auto-drive relevant planning values. When it is active, the corresponding manual controls are disabled.
+- Launch controls live under **Settings -> Launch Settings**. **Launch Analysis** remains the saved-run review tab.
 - The future/global message system is not documented here as an active user feature.
 
-## Feedback and requests
+## Feedback and Requests
 
-If you hit a bug or want a feature, open a GitHub issue in this repo so the docs and code can stay aligned.
+If you hit a bug, want a workflow improvement, or need clearer documentation, open a GitHub issue so the public docs and plugin behavior can stay aligned.


### PR DESCRIPTION
### Motivation

- Improve the repository front page for a public v1.0 release by making the README more professional, easier to scan, and focused on what first-time visitors need to know. 
- Keep the existing three-layer docs structure and all user-facing documentation links intact while making the landing page clearer for drivers and dashboard users.

### Description

- Rewrote `README.md` into a concise landing page with a short intro, a scan-friendly **Core Systems** list, clear **Supported Scope** and **Plugin vs Dashboard Responsibility** sections, grouped documentation links, and tightened notes about UI boundaries. 
- Updated `Docs/RepoStatus.md` to record this as a documentation-only README polish pass and to note that no runtime code, assets, or namespaces were changed. 
- Preserved every existing user-facing doc destination (Quick Start, User Guide, Dashboards, Strategy, Shift Assist, Launch, Rejoin, Pit, H2H, Profiles, Fuel Model, Changelog, Project Index) and kept branding as `Lala Race Assist Plugin`. 
- This is a documentation-only change and does not alter runtime behavior, subsystems, settings names, or exported properties.

### Testing

- Verified that all required documentation links appear in `README.md` using an automated presence check (`rg -F` against each target), with all targets reported OK. 
- Ran `git diff --check` and `git status` to validate there are no whitespace or index issues and the working tree reflected only the expected doc changes. 
- Confirmed the only files changed are `README.md` and `Docs/RepoStatus.md`, and the edits were committed to the current working branch successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec269534c832f83204d6f42ba95fd)