### PR TITLE
Refresh v1 documentation sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,4 +50,5 @@ Main user-facing changes since the late-February documentation baseline include:
 - Repositioned **PreRace** as a display/on-grid layer under Strategy without implying that it changes planner calculations.
 - Cleaned up **Dash Control** so it stays dash-oriented, centered on Cancel Message, Toggle Pit Screen, Primary Dash Mode, Declutter Mode, visibility, and grouped global dash functions.
 - Expanded practical guidance for **rejoin warnings**, **pit popups**, and **pit entry assist**.
+- Completed the v1 documentation sweep across the main repo docs and canonical subsystem docs so GitHub readers can move from user pages into technical ownership docs without stale Fuel-tab-era wording or broken responsibility boundaries.
 - Refreshed repo-facing documentation so the GitHub repo can serve as the canonical user home alongside the canonical subsystem docs.

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,11 +1,16 @@
 # Project Index
 
 Validated against commit: HEAD
-Last updated: 2026-03-21
+Last updated: 2026-03-22
 Branch: work
 
 ## What this repo is
 Lala Race Assist Plugin is a SimHub plugin for iRacing that provides strategy planning, fuel learning, dashboards, launch instrumentation, pit assistance, rejoin support, Shift Assist cueing, profile-backed persistence, and H2H race context.
+
+This page is the canonical documentation map for the **v1 GitHub documentation set**. It should let a reader move cleanly between:
+- public/user guidance,
+- subsystem-level technical truth,
+- internal maintainer references.
 
 ## Codex read/start order
 1. If present at repo root, read `../AGENTS.md` as the thin agent entry point, then start with `Project_Index.md`.
@@ -17,7 +22,7 @@ Lala Race Assist Plugin is a SimHub plugin for iRacing that provides strategy pl
 7. Follow the analysis-first workflow and reusable task framing in `Docs/Internal/CODEX_TASK_TEMPLATE.txt`.
 
 ## User documentation
-These pages are the GitHub-facing driver/user layer. They should explain what the driver sees, how to use the feature, what to trust, and what to review when it feels wrong.
+These pages are the GitHub-facing driver/user layer. They explain what the driver sees, how to use the feature, what to trust, and what to review when it feels wrong.
 
 - [Quick Start](Quick_Start.md)
 - [User Guide](User_Guide.md)
@@ -32,7 +37,7 @@ These pages are the GitHub-facing driver/user layer. They should explain what th
 - [Fuel Model](Fuel_Model.md)
 
 ## Subsystem documentation
-These pages are the technical/canonical subsystem layer. They should explain internal ownership, inputs, outputs, calculations, persistence, caching, and architecture boundaries.
+These pages are the technical/canonical subsystem layer. They explain internal ownership, inputs, outputs, calculations, persistence, caching, architecture boundaries, and the plugin-vs-dash contract where relevant.
 
 - [Subsystems/Fuel_Model.md](Subsystems/Fuel_Model.md)
 - [Subsystems/Fuel_Planner_Tab.md](Subsystems/Fuel_Planner_Tab.md)
@@ -64,7 +69,14 @@ These pages support maintainers, support work, and Codex tasks. They are not par
 - [Internal/SimHubLogMessages.md](Internal/SimHubLogMessages.md)
 - [Internal/Code_Snapshot.md](Internal/Code_Snapshot.md)
 
+## v1 documentation notes
+- `README.md` is the public landing page.
+- `Docs/*.md` are the reader-facing feature/system pages.
+- `Docs/Subsystems/*.md` are the canonical technical ownership docs.
+- `Docs/RepoStatus.md` records the latest documentation sweep and validation note.
+- If user-facing pages and subsystem docs ever disagree, update both in the same task so GitHub readers do not get split truths.
+
 ## Freshness
 - Validated against commit: HEAD
-- Date: 2026-03-21
+- Date: 2026-03-22
 - Branch: work

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,26 +1,63 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-03-21
+Last updated: 2026-03-22
 Branch: work
 
 ## Current repo/link status
 - Local branch present: `work`.
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
-## Documentation sync status (requested set)
-- Completed a documentation-only README polish pass; no runtime/plugin code, XAML, JSON, dashboard, namespace, or property files were changed.
-- Refined `README.md` into a more public-facing landing page with a shorter intro, a scan-friendly Core Systems section, clearer responsibility boundaries, grouped documentation links, and tighter notes for first-time GitHub visitors.
+## Documentation sync status (v1 sweep)
+- Completed a documentation-only v1 release sweep focused on the main repo docs plus the canonical subsystem docs in `Docs/Subsystems/`.
+- No runtime/plugin code, XAML behavior, JSON storage, dashboard assets, namespaces, exports, or log-producing code paths were changed in this task.
+- Re-reviewed the GitHub-facing entry points (`README.md`, `Docs/Project_Index.md`, `CHANGELOG.md`) so GitHub readers can move from the landing page to the correct user/system/subsystem page without stale navigation.
+- Re-reviewed the user-facing feature/system pages in `Docs/` to keep terminology aligned with the current plugin UI, especially **Strategy**, **Launch Analysis**, **Launch Settings**, **Dash Control**, and the current assist naming.
+- Re-reviewed the subsystem set in `Docs/Subsystems/` and refreshed the stale canonical pages where the repo had drifted from older wording, especially around **Fuel Model**, **Pace and Projection**, **Launch Mode**, and **Dash Integration**.
 - Preserved the repo's three-layer documentation structure: user-facing docs in `Docs/`, technical subsystem docs in `Docs/Subsystems/`, and internal/developer docs in `Docs/Internal/`.
-- Preserved all existing user-facing documentation destinations for Quick Start, User Guide, Dashboards, Strategy System, Shift Assist, Launch System, Rejoin Assist, Pit Assist, H2H System, Profiles System, and Fuel Model.
-- Kept branding as **Lala Race Assist Plugin** and did not document the future/global message system as active.
-- Reviewed `Docs/Quick_Start.md`, `Docs/User_Guide.md`, `Docs/Dashboards.md`, and `Docs/Project_Index.md` during the README polish pass and left them unchanged because the task was presentation-only.
-- Reviewed `CHANGELOG.md` and left it unchanged because this task does not change runtime behavior or release-visible functionality.
+- Kept branding as **Lala Race Assist Plugin** and did not document the future/global message system as an active public feature.
+
+## Reviewed documentation set
+### Changed in this sweep
+- `README.md`
+- `CHANGELOG.md`
+- `Docs/Project_Index.md`
+- `Docs/RepoStatus.md`
+- `Docs/Subsystems/Fuel_Model.md`
+- `Docs/Subsystems/Launch_Mode.md`
+- `Docs/Subsystems/Pace_And_Projection.md`
+- `Docs/Subsystems/Dash_Integration.md`
+
+### Reviewed and left unchanged
+- `Docs/Quick_Start.md`
+- `Docs/User_Guide.md`
+- `Docs/Dashboards.md`
+- `Docs/Strategy_System.md`
+- `Docs/Shift_Assist.md`
+- `Docs/Launch_System.md`
+- `Docs/Rejoin_Assist.md`
+- `Docs/Pit_Assist.md`
+- `Docs/H2H_System.md`
+- `Docs/Profiles_System.md`
+- `Docs/Fuel_Model.md`
+- `Docs/Subsystems/Fuel_Planner_Tab.md`
+- `Docs/Subsystems/Pit_Entry_Assist.md`
+- `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
+- `Docs/Subsystems/Rejoin_Assist.md`
+- `Docs/Subsystems/Opponents.md`
+- `Docs/Subsystems/CarSA.md`
+- `Docs/Subsystems/H2H.md`
+- `Docs/Subsystems/Profiles_And_PB.md`
+- `Docs/Subsystems/Trace_Logging.md`
+- `Docs/Subsystems/Track_Markers.md`
+- `Docs/Subsystems/Message_System_V1.md`
+- `Docs/Subsystems/MessageEngineV1_Notes.md`
 
 ## Delivery status highlights
-- README now prioritizes first-screen clarity for public visitors by surfacing what the plugin covers before deeper documentation structure.
-- Documentation links are grouped into getting started, driver systems, and dash/reference sections for faster scanning.
-- Plugin-vs-dashboard ownership and current UI boundaries remain explicit without repeating the same ideas across multiple sections.
+- The repo landing page now points readers toward both the user pages and the canonical subsystem layer instead of acting like the user docs are the entire documentation set.
+- The documentation map now explicitly frames the v1 GitHub doc set and reinforces which pages own user guidance versus technical truth.
+- The Fuel / Pace / Launch / Dash subsystem docs now match the current Strategy-era UI terminology and current plugin responsibilities instead of older Fuel-tab-era or placeholder references.
+- The unchanged system pages remain valid for GitHub readers and still match the current plugin navigation and workflow.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Polish README landing page`).
+- Validation recorded against `HEAD` (`v1 documentation sweep for main and subsystem docs`).

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -1,70 +1,140 @@
 # Dash Integration
 
-Validated against commit: b9250e1
-Last updated: 2026-02-24
+Validated against commit: HEAD
+Last updated: 2026-03-22
 Branch: work
 
 ## Purpose
-Define how SimHub exports from LalaLaunch should be consumed by dashboards with emphasis on the **Pit Entry Assist** surface. This document complements the subsystem specs and focuses on binding, gating, and rendering guidance.
+Define how Lala Race Assist Plugin exports should be consumed by dashboards.
+
+This document is the canonical dash-facing contract layer. It does **not** redefine subsystem behavior; it explains:
+- which plugin outputs are meant for dash consumption,
+- how dashboards should gate and render them,
+- where the plugin ends and dashboard presentation begins.
 
 ## Core principles
-- **Defensive consumption:** All properties may be `null`/zero on session start; gate on readiness flags when present.
-- **Prefer stable variants:** Use `_Stable` when available for UI text; use numeric forms for gauges.
-- **Visibility gating:** Use explicit visibility flags (e.g., `Pit.EntryAssistActive`) to avoid SimHub suppression.
-- **No renormalisation:** Preserve plugin-provided units; avoid cue-driven remapping that hides continuous metrics.
+- **The plugin owns logic; dashboards own presentation.**
+- **Prefer stable exports** when both raw/live and stable variants exist.
+- **Use explicit visibility gates** instead of guessing from text/value presence.
+- **Do not renormalize plugin units** unless the dash needs purely visual scaling.
+- **Clear state aggressively on session transitions** so stale visuals do not linger.
+
+## High-level dash ownership map
+### Strategy / fuel / pace
+- Use stable strategy/fuel exports for labels and decision widgets.
+- Treat `LalaLaunch.PreRace.*` as a separate on-grid/pre-race info layer, not a replacement for live `Fuel.*` or Strategy planner ownership.
+- If a widget is meant to represent runtime truth, prefer stable `Fuel.*` / pace outputs over UI-only text from elsewhere.
+
+### Launch
+- Gate live launch widgets on `LaunchModeActive` and related launch-visible state.
+- Keep **Launch Analysis** concepts separate from live launch widgets; dashboards can show results, but trace review belongs to the plugin review surface.
+
+### Rejoin / pit / messages
+- Rejoin widgets should respect the explicit rejoin exports rather than infer active state from message text alone.
+- Pit-screen / pit-entry widgets should combine pit visibility toggles with pit-specific active flags.
+- Message-dash widgets should consume the message engine outputs directly rather than rebuilding message priority logic in SimHub expressions.
+
+### H2H / traffic
+- `H2HRace.*` and `H2HTrack.*` are already flattened for dashboard binding; dashboards should not try to recreate selector logic.
+- CarSA / Opponents data that is not part of a published dash contract should stay a technical dependency, not a dashboard-owned truth source.
+
+## Visibility and gating
+### Dash visibility toggles
+Use the exported visibility families as hard gates:
+- `LalaDashShow*` = main dash visibility
+- `MsgDashShow*` = message dash visibility
+- `OverlayDashShow*` = overlay visibility
+
+These toggles are the contract between plugin settings and dash layout visibility. Dash JSON should not fight them.
+
+### Session-reset expectations
+Hide or clear visuals when:
+- session identity changes,
+- a subsystem’s explicit active flag goes false,
+- the relevant dash visibility toggle goes false,
+- a widget’s source data is clearly invalid / unavailable.
 
 ## Pit Entry Assist binding
-- **Properties:** `Pit.EntryAssistActive`, `Pit.EntryDistanceToLine_m`, `Pit.EntryRequiredDistance_m`, `Pit.EntryMargin_m`, `Pit.EntryCue`, `Pit.EntryCueText`, `Pit.EntrySpeedDelta_kph`, `Pit.EntryDecelProfile_mps2`, `Pit.EntryBuffer_m`.
-- **Validity window:** Only render while `Pit.EntryAssistActive == true`; the assist clears itself when distance >500 m or inputs are invalid.
-- **Primary signal:** `Pit.EntryMargin_m` (metres). Use cues only as secondary state indicators.
-- **Cue mapping (0–4):** OFF / OK / BRAKE SOON / BRAKE NOW / LATE; derived from margin vs. buffer.
+### Primary properties
+- `Pit.EntryAssistActive`
+- `Pit.EntryDistanceToLine_m`
+- `Pit.EntryRequiredDistance_m`
+- `Pit.EntryMargin_m`
+- `Pit.EntryCue`
+- `Pit.EntryCueText`
+- `Pit.EntrySpeedDelta_kph`
+- `Pit.EntryDecelProfile_mps2`
+- `Pit.EntryBuffer_m`
 
-### Recommended visualisation
-- **Layout:** Vertical slider or marker with fixed ±150 m scale; centre = 0 m (ideal brake point).
-- **Direction:** Marker up = early; marker down = late.
-- **Secondary labels:** Show `Pit.EntryCueText` beside the marker; keep colours neutral to avoid masking small movements.
-- **Expression hygiene:** Force floating-point math in SimHub expressions (e.g., `150.0`) to prevent integer truncation; avoid nested `if` blocks that cause stepped movement.
+### Consumption guidance
+- Use `Pit.EntryAssistActive` as the hard visibility gate.
+- Use `Pit.EntryMargin_m` as the primary continuous signal.
+- Treat cue text/value as secondary state, not the main visualization input.
+- A fixed-scale marker is preferred over re-scaling around the current cue.
 
-## Pit screen mode + visibility exports
-- **Properties:** `PitScreenActive`, `PitScreenMode`.
-- **Mode values:** `auto` (pit-road auto mode) or `manual` (user toggled on track). Use these to display distinct banners or colour treatments when the pit screen is intentionally forced on.
-- **Manual lifecycle:** manual mode is reset to auto on session token changes or car/track combo changes; if you cache state in dashboards, clear it on those transitions.
+### Recommended visualization
+- Fixed ±150 m vertical or horizontal marker range.
+- Center line = ideal braking point.
+- Up/positive = early; down/negative = late.
+- Keep cue colors simple so small margin changes remain visible.
 
-### Dash visibility toggles
-- **Main dash:** `LalaDashShow*`
-- **Message dash:** `MsgDashShow*`
-- **Overlay:** `OverlayDashShow*`
+## Pit screen mode
+### Properties
+- `PitScreenActive`
+- `PitScreenMode`
 
-Use these toggles as hard gates for visibility. For pit-screen overlays, combine:
-- `PitScreenActive` AND relevant `*ShowPitScreen` toggle.
+### Contract
+- `auto` = plugin-driven pit-screen activation.
+- `manual` = user-forced pit screen while on track.
 
-## Reset behaviour
-- Hide or clear Pit Entry Assist visuals when:
-  - Session identity changes,
-  - `Pit.EntryAssistActive` is false,
-  - SimHub reports `IsInPitLane` true and the line transition already fired (assist logs `END`).
+Dashboards can style these differently, but they should not reinterpret the lifecycle. Manual pit-screen state is reset by the plugin on major session/combo resets.
+
+## Message engine consumption
+For dashboards that use the v1 message engine:
+- bind directly to `MSGV1.*` exports for active text, colors, counts, and stack state,
+- keep `MsgCx` / clear behavior in the plugin action path,
+- avoid recreating priority resolution in dash expressions.
+
+The subsystem docs own message-system behavior; dashboards should remain consumers only.
+
+## Dark Mode integration
+### Stable exports for dashboards
+- `LalaLaunch.Dash.DarkMode.Mode`
+- `LalaLaunch.Dash.DarkMode.Active`
+- `LalaLaunch.Dash.DarkMode.BrightnessPct`
+- `LalaLaunch.Dash.DarkMode.LovelyAvailable`
+- `LalaLaunch.Dash.DarkMode.OpacityPct`
+- `LalaLaunch.Dash.DarkMode.ModeText`
+
+### Consumption rules
+- Bind dashboards to the `LalaLaunch.Dash.DarkMode.*` exports, not Lovely internals.
+- `BrightnessPct` remains `0..100`.
+- `Mode` contract is:
+  - `0` = Off
+  - `1` = Manual
+  - `2` = Auto
+- When Lovely override is enabled and available, dashboards should still trust the plugin export rather than probing Lovely directly.
+
+## Expression hygiene
+- Force floating-point math in SimHub expressions where scaling matters.
+- Prefer simple thresholding over deeply nested expression trees.
+- Avoid dash-side smoothing that masks the plugin’s own stable-vs-live contract.
 
 ## Logging alignment
-- Dash developers can cross-check live visuals with logs:
-  - `ACTIVATE` confirms input resolution (distance, pit speed, decel/buffer).
-  - `LINE` provides `firstOK`/`okBefore` for post-run tuning.
-  - `END` confirms teardown; visuals should already be hidden when this appears.
+Dash developers/support work can cross-check live visuals against plugin logs for:
+- launch state changes,
+- pit-entry assist activation / line / end events,
+- message engine behavior,
+- projection source changes,
+- rejoin state transitions.
 
-## Non-Pit Entry guidance (summary)
-- Use `_Stable` pace/fuel properties for any text labels.
-- Gate launch UI on `LaunchModeActive`; gate rejoin displays on `RejoinIsExitingPits`.
-- Keep visibility toggles (`LalaDashShow...`) respected to avoid fighting user preferences.
+## Non-goals
+Dashboards should **not**:
+- recreate strategy math,
+- own H2H selector logic,
+- own launch or rejoin logic,
+- bypass plugin visibility toggles,
+- depend on undocumented internal state when a canonical export already exists.
 
-
-## Dark Mode integration (global dash control)
-- **Stable exports for dashboards:**
-  - `LalaLaunch.Dash.DarkMode.Mode` (internal key `Dash.DarkMode.Mode`)
-  - `LalaLaunch.Dash.DarkMode.Active` (internal key `Dash.DarkMode.Active`)
-  - `LalaLaunch.Dash.DarkMode.BrightnessPct` (internal key `Dash.DarkMode.BrightnessPct`)
-- **Consumption rule:** Dash JSON should consume only `LalaLaunch.Dash.DarkMode.*` and must not reference Lovely directly.
-- **Brightness contract:** `BrightnessPct` is `0..100` with `100` brightest; when inactive it reports user slider value (unscaled), when active it reports effective value after manual/auto scaling.
-- **Mode contract:**
-  - `0` Off: `Active` forced false.
-  - `1` Manual: active follows manual toggle unless Lovely override is enabled and available.
-  - `2` Auto: active follows solar hysteresis when manual toggle is off and Lovely override is not in control.
-- **Lovely UI behavior:** “Use Lovely True Dark” checkbox stays visible; enabled only when Lovely is detected.
+## v1 documentation note
+The v1 GitHub docs now present dashboards as the presentation layer across all systems. This page is the canonical technical companion to the user-facing `Docs/Dashboards.md` page.

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -1,210 +1,191 @@
 # Fuel Model
 
-Validated against commit: 708af0f  
-Last updated: 2026-01-27  
+Validated against commit: HEAD
+Last updated: 2026-03-22
 Branch: work
 
 ## Purpose
-The Fuel Model is the runtime engine that:
-- Captures **live fuel burn per lap** (with strict acceptance/rejection rules).
-- Maintains **rolling windows** (dry/wet) and computes a **stable fuel-per-lap** used for projections.
-- Seeds fuel burn across session transitions to avoid cold starts in Race.
-- Persists stable fuel and pace stats into profiles when confidence thresholds are met.
-- Projects **laps remaining in race**, including **after-zero** behaviour for timed races.
-- Computes **deltas, pit needs, and pit window state** outputs consumed by the Fuel Tab and dashboards.
+The Fuel Model is the runtime fuel-learning and fuel-projection engine. It:
+- captures accepted live fuel-burn samples lap by lap,
+- maintains dry/wet rolling windows,
+- publishes a stable fuel-per-lap value for dashboards and runtime calculations,
+- persists trustworthy condition-specific values into profiles,
+- projects race distance / after-zero behavior for timed races,
+- feeds pit-need, pit-window, and stint-burn guidance outputs.
 
-Canonical behaviour and edge-case rules live in:
-- `Docs/FuelProperties_Spec.md` (fuel + pit logic contract).
-- `Docs/Internal/SimHubParameterInventory.md` (exports list/cadence).
-- `Docs/FuelTab_SourceFlowNotes.md` (how the Fuel Tab consumes “live snapshot” + readiness).
+For GitHub readers, the practical split is:
+- **`Docs/Fuel_Model.md`** = driver-facing explanation of what to trust.
+- **`Docs/Subsystems/Fuel_Model.md`** = canonical runtime behavior and ownership.
+- **`Docs/Subsystems/Fuel_Planner_Tab.md`** = the separate Strategy-tab planning workflow that consumes fuel-model outputs but does not replace the runtime engine.
 
----
+Canonical companion docs:
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/SimHubLogMessages.md`
+- `Docs/Subsystems/Pace_And_Projection.md`
+- `Docs/Subsystems/Fuel_Planner_Tab.md`
 
 ## Scope and boundaries
-This doc describes the **fuel model runtime** (burn capture → stable selection → projection → pit math → pit window outputs).
-It does **not** re-document:
-- Fuel Planner UI source selection logic (see `Subsystems/Fuel_Planner_Tab.md` + `FuelTab_SourceFlowNotes.md`).
-- Pace estimator internals (see `Subsystems/Pace_And_Projection.md`).
+This doc covers the **runtime** fuel path:
+- lap acceptance,
+- rolling fuel windows,
+- stable burn selection,
+- race-distance projection inputs,
+- pit math,
+- pit-window states,
+- profile persistence of learned fuel values.
 
----
+Out of scope:
+- Strategy-tab input ownership and preset behavior,
+- user-facing planner workflow,
+- dashboard artwork/layout decisions.
 
 ## Inputs (source + cadence)
+### Runtime telemetry
+- Fuel level / fuel delta at lap transitions.
+- Session type, session time remaining, timer-zero state, and laps-completed state.
+- Pit-lane / pit-trip state.
+- Refuel request and live tank-capacity inputs.
+- Tyre compound / wetness context used to separate dry vs wet learning.
 
-### Telemetry and SimHub core data (runtime, 500 ms poll)
-- Fuel level, laps/completed laps, session time remaining, “timer zero” signals.
-- Pit lane status / pitting state.
-- Refuel request (MFD fuel to add), tyre selection state.
-- SimHub computed fallback fuel-per-lap (`DataCorePlugin.Computed.Fuel_LitersPerLap`) when no accepted laps exist.
-- Live max fuel inputs: `DataCorePlugin.GameData.MaxFuel` and `DriverCarMaxFuelPct` (BoP) for effective tank capacity.
+### Profile baselines
+- Track/car dry and wet fuel averages.
+- Track/car lap-time baselines used to keep acceptance and projection behavior defensible.
+- Condition lock state that prevents telemetry-driven overwrites when a condition has been intentionally frozen.
 
-### Profile baselines (on access)
-- Track/car profile fuel baselines (dry/wet averages) used for:
-  - Rejection bracketing (0.5x–1.5x baseline).
-  - Stable fallback when live confidence is low.
-  - Seeding on session transition (Driving → Race).
-
-### Pace inputs (integrated dependency)
-- Projection lap time selection (stint avg / last5 / profile / fallback estimator) feeds race-distance projection and pit window.
-
----
+### Pace / projection dependency
+- Projection lap-time selection from the Pace & Projection subsystem.
+- Strategy-derived after-zero allowance when no live after-zero estimate is ready yet.
 
 ## Internal state
+### Rolling fuel windows
+- Separate dry and wet accepted-lap windows.
+- Per-session max-burn tracking with spike protection.
+- Seed markers so carry-over baseline values are not immediately evicted on a session transition.
 
-### Rolling windows and fuel capture
-- Dry and wet rolling lists (max 5 accepted laps each).
-- Session max burn tracking (bounded by baseline multiplier to avoid spikes).
-- “Active seeds” markers (so seeded laps aren’t immediately evicted).
-- Wet/dry mode flag influencing which window is considered “live”.
+### Stable burn state
+- A continuously evaluated candidate burn.
+- A stable exported burn value held with a deadband so dashboards do not thrash on minor changes.
+- Source/confidence tags so consumers can tell whether the value is live, profile-backed, or fallback-driven.
 
-### Surface detection & wet mode
-- **Wet mode source:** tire compound telemetry (iRacing PlayerTireCompound / extra property) drives `wet` vs `dry` mode. Track wetness telemetry is captured for dashboards but does not override the tyre-based mode.
-- **Track wetness exports:** numeric wetness and a label (“Dry”, “Damp”, “Light Wet”, “Mod Wet”, “Very Wet”, “Unknown”) are exported for UI display.
-- **Cross-mode penalty:** when using the opposite-condition window (e.g., wet mode with only dry samples), confidence applies a wet/dry match penalty.
+### Wet/dry routing
+- Wet mode follows tyre-compound telemetry for learning/persistence routing.
+- Track wetness is exported for UI use, but tyre mode remains the canonical routing choice for fuel learning.
+- Cross-condition fallback is allowed, but confidence is penalized when dry data is being used in wet mode or vice versa.
 
-### Seed handling across sessions
-- On session transitions, the model captures dry/wet seeds (burn averages + sample counts) and re-applies them when entering a Race session for the same car/track.
-- Seeded laps are protected from immediate eviction in the rolling window until fresh samples arrive.
+### Persistence state
+- Dry and wet condition stats persist independently.
+- Each condition has its own sample count, last-updated metadata, and lock gate.
+- Session-transition seeding is used to reduce race-session cold starts.
 
-### Stable burn state (the number dashboards should trust)
-- `_stableFuelPerLap` + `Fuel.LiveFuelPerLap_StableSource` + `Fuel.LiveFuelPerLap_StableConfidence`.
-- Deadband hold: when the candidate is “close enough”, stable value holds while source/confidence can still evolve.
-
-### Live max tank tracking
-- Live max tank is computed as `MaxFuel × BoP` with BoP clamped to [0.01, 1.0] and defaulted to 1.0 when missing.
-- The last valid live max fuel is retained so tank-space calculations remain stable if telemetry temporarily drops.
-- Live Session UI displays are cleared to `—` when no valid cap exists, avoiding stale values during session transitions.
-
-### Profile persistence (dry vs wet)
-- Once enough samples exist (≥2 valid laps), the model persists min/avg/max fuel burn, sample counts, and avg lap time into the active track profile.
-- Condition locks (`DryConditionsLocked`/`WetConditionsLocked`) prevent telemetry-driven writes.
-- Per-condition “last updated” metadata is recorded separately for dry and wet stats.
-
-### After-zero state (timed-race support)
-- Planner after-zero seconds always available (from strategy/profile).
-- Live after-zero estimate becomes valid once timer zero is observed and post-zero time advances.
-- Source switches between planner and live (and is exported).
-
-### Pit window state cache
-- Last pit window state enum + label + last log timestamp to avoid spam logging.
-- Pit window opening/closing lap calculations are computed from stable burn + tank space logic.
-
----
+### Projection and pit-window state
+- Last valid live max tank for stable tank-space behavior.
+- Current after-zero source (`planner` vs `live`).
+- Debounced pit-window state / label so logs and dashes do not chatter.
 
 ## Calculation blocks (high level)
+### 1) Lap acceptance
+On lap completion, the subsystem calculates the lap fuel delta and rejects non-representative samples.
 
-### 1) Lap acceptance (per lap crossing)
-On lap completion, compute fuel delta for the lap and apply rejection rules before inserting into windows.
+Common reject cases include:
+- race warmup / earliest laps,
+- pit-involved laps or the first lap after pit exit,
+- incident-latched laps when that signal is active,
+- impossible or clearly bad fuel deltas,
+- deltas that fall too far outside the saved profile baseline when a baseline exists.
 
-**Rejection gates (canonical):**
-- Race warmup (laps ≤ 1) → reject.
-- Pit involvement / first lap after pit exit → reject.
-- Incident/off-track latched reason (if wired) → reject.
-- Fuel delta sanity (>0.05 L, and <= max(10 L, 20% of effective tank)) → reject.
-- If profile baseline exists: require 0.5x–1.5x baseline → reject otherwise.
+Wet/dry mode does **not** change the validity rules; it only decides which condition window receives an accepted sample.
 
-Wet/dry mode **does not change** the acceptance rules; it only controls which condition’s rolling window receives the lap and which stats can be persisted.
+### 2) Rolling window maintenance
+Accepted samples are inserted into the active condition window.
+The subsystem then:
+- enforces maximum window size,
+- updates min/max guidance values,
+- refreshes session max-burn state inside guarded bounds,
+- protects newly seeded values until enough fresh live data exists.
 
-Source of truth: `FuelProperties_Spec.md`.
+### 3) Stable burn selection
+The runtime chooses a stable burn candidate from:
+1. trustworthy live window data,
+2. profile condition averages,
+3. safe fallback behavior.
 
-### 2) Rolling window maintenance (per accepted lap)
-- Insert accepted lap into dry or wet list (depending on wet mode).
-- Maintain max length (5).
-- Track minima/maxima for guidance.
-- Update session max burn only when within a safe baseline multiplier band (avoid spikes).
+A deadband holds the previous stable value when the new candidate is only trivially different, while source and confidence labels can still update.
 
-### 3) Live burn and confidence (continuous)
-- `Fuel.LiveFuelPerLap` is the burn used for projections when live is valid.
-- `Fuel.Confidence` grows with window size/quality (fuel confidence only; pace confidence is separate).
-- `Pace.OverallConfidence` reflects combined/derived confidence behaviour and is used by dashes.
+### 4) Confidence growth
+Fuel confidence rises as accepted live samples accumulate and becomes weaker when:
+- samples are sparse,
+- opposite-condition data is being reused,
+- the session is too young,
+- the accepted sample set is still noisy or incomplete.
 
-### 4) Stable fuel selection (continuous)
-Stable fuel-per-lap exists so dashboards don’t “thrash” when live data is noisy.
+### 5) Race-distance projection input
+The Fuel Model consumes the selected runtime projection lap time and combines it with:
+- session time remaining,
+- planner after-zero allowance,
+- live after-zero estimate once timer-zero has actually been observed.
 
-**Candidate sources:**
-- Live window average when valid.
-- Profile track average when confidence below readiness threshold (or no live yet).
-- Fallback when neither exists.
+If the runtime projection path is invalid, the subsystem can still fall back to sim-provided laps-remaining behavior.
 
-**Deadband hold:**
-If the new candidate is within `StableFuelPerLapDeadband`, hold the old stable value while still allowing source/confidence to update.
+### 6) Pit math and stint guidance
+Using current fuel, stable burn, projection laps, tank-space limits, and pit-menu add intent, the subsystem computes:
+- laps remaining in tank,
+- total fuel needed to end,
+- fuel to add,
+- stops required,
+- current-stint burn target and burn band.
 
-### 5) Race-distance projection (continuous)
-Compute projected laps remaining using:
-- Projection lap time (from Pace subsystem source selection).
-- Session time remaining.
-- After-zero allowance seconds (planner or live estimate).
-If invalid, fallback to SimHub’s laps-remaining telemetry.
-
-### 6) Pit math + deltas (continuous)
-Using current fuel + projected laps + burns (push/stable/save), compute:
-- Laps remaining in tank, target burn, delta laps.
-- Liters needed vs end (`Fuel.Pit.TotalNeededToEnd`), liters to add (`Fuel.Pit.NeedToAdd`).
-- “Will add” litres based on MFD request clamped to tank space.
-- Required stops by capacity vs by plan, and final stops required to end.
-- **Stops-required fields:** `PitStopsRequiredByFuel` is computed from liters short ÷ effective tank capacity. `PitStopsRequiredByPlan` now mirrors planner-feasible stop count output (authoritative planner result). Driver-selected mode intent is exported via `LalaLaunch.PreRace.Selected` / `SelectedText` for the pre-race info layer only. `Pit.StopsRequiredToEnd` still mirrors planner-feasible stop count for live/planner dashboards.
-- **Stint burn target (current tank only):** a per-lap target burn that respects the configured pit-in reserve (percentage of one lap’s stable burn). The output is banded (`SAVE`/`PUSH`/`HOLD`/`OKAY`) to guide the current stint without implying long-term strategy.
-
-### 7) Pit window state machine (continuous)
-Pit window is **race-only** and only meaningful when stops may be required.
-
-Canonical gates (in priority order):
-1. Not Race / session not running / no fuel stops required → **N/A**
-2. Stable confidence below readiness threshold → **NO DATA YET**
-3. Refuel off or request <= 0 → **SET FUEL!**
-4. Unknown tank capacity → **TANK ERROR**
-5. Otherwise evaluate whether required add fits within tank space for:
-   - PUSH burn, then
-   - STD (stable burn), then
-   - ECO (save burn)
-
-If any fits → open window with state label:
-- **CLEAR PUSH** / **RACE PACE** / **FUEL SAVE**
-If none fit → **TANK SPACE**.
-
----
+### 7) Pit-window state machine
+Pit window state is race-only and depends on both stable confidence and tank feasibility.
+Typical states include:
+- `N/A`
+- `NO DATA YET`
+- `SET FUEL!`
+- `TANK ERROR`
+- open-window states such as `CLEAR PUSH`, `RACE PACE`, or `FUEL SAVE`
+- `TANK SPACE` when required fuel cannot fit under the current assumptions.
 
 ## Outputs (exports + logs)
+### Core exports
+The full authoritative export list lives in `Docs/Internal/SimHubParameterInventory.md`. The key Fuel Model families are:
+- `Fuel.LiveFuelPerLap*`
+- `Fuel.LiveLapsRemainingInRace*`
+- `Fuel.LapsRemainingInTank`
+- `Fuel.TargetFuelPerLap`
+- `Fuel.Delta*`
+- `Fuel.Pit.*`
+- `Fuel.StintBurnTarget*`
+- `Fuel.Live.ProjectedDriveSecondsRemaining`
+- `LalaLaunch.PreRace.*` as the separate pre-race/on-grid info layer
 
-### Core exports (selected)
-See `Docs/Internal/SimHubParameterInventory.md` for the full list, but the main Fuel Model outputs include:
-- `Fuel.LiveFuelPerLap`, `Fuel.LiveFuelPerLap_Stable`, `Fuel.LiveFuelPerLap_StableSource`, `Fuel.LiveFuelPerLap_StableConfidence`
-- `Fuel.LiveLapsRemainingInRace(_Stable)` (+ `_S` strings)
-- `Fuel.DeltaLaps`, `Fuel.TargetFuelPerLap`, `Fuel.LapsRemainingInTank`
-- `Fuel.StintBurnTarget`, `Fuel.StintBurnTargetBand`
-- Pit deltas and need-to-add: `Fuel.Pit.*` and `Fuel.Delta.*`
-- Stops required: `Fuel.PitStopsRequiredByFuel`, `Fuel.PitStopsRequiredByPlan`, `Fuel.Pit.StopsRequiredToEnd`
-- After-zero model: `Fuel.Live.DriveTimeAfterZero`, `Fuel.Live.ProjectedDriveSecondsRemaining`
+### Logging expectations
+The subsystem logs:
+- lap acceptance / rejection summaries,
+- projection source changes,
+- after-zero source changes,
+- pit-window state changes,
+- wet/dry mode flips with surface context.
 
-### Fuel tab UI refresh
-- When a new live car/track combination appears, the Fuel Tab’s live snapshot is cleared and fuel-burn summaries are recomputed so the UI renders “-” instead of stale profile values during startup.
+Canonical wording remains in `Docs/Internal/SimHubLogMessages.md`.
 
-### Logs
-Fuel model emits structured INFO logs for:
-- Per-lap acceptance/rejection summary (fuel + pace + projection lines).
-- Projection source changes (lap-time source, after-zero source).
-- Pit window state changes (debounced).
-- Wet surface mode flips (tyre compound changes) with track wetness context.
+## Dependencies / ordering assumptions
+- Lap detection must happen before live fuel capture for that lap.
+- Pace/projection selection must be ready before final fuel-to-end and pit-window outputs are finalized.
+- The Strategy tab reads the live snapshot from this subsystem but remains the separate human-owned planning layer.
 
----
+## Reset rules
+Fuel-model state resets on:
+- session-token changes,
+- session-type changes,
+- broader combo/identity resets,
+- any reset path that must clear stale live windows, projection state, and pit-window labels.
 
-## Reset rules (session identity + transitions)
-Fuel model state is reset on:
-- Session type change (notably Driving → Race includes seeding behaviour).
-- Session token change (`SessionID:SubSessionID`) which performs broader clearing across subsystems.
+Driving → Race transitions can seed race state from the just-learned baseline instead of forcing a full cold start.
 
-Reset contract (what gets cleared) is canonical in `FuelProperties_Spec.md`.
+## Failure modes / edge cases
+- **Replay timing anomalies:** acceptance/projection behavior may need log verification.
+- **Missing live tank cap:** runtime keeps the last valid cap for stability, while UI can still clear user-facing displays when no current valid cap exists.
+- **Weak early-session data:** profile-backed fallback may legitimately remain safer than live values until confidence improves.
+- **Cross-condition reuse:** dry/wet fallback works, but confidence should be interpreted as lower.
 
----
-
-## Failure modes / known edge cases
-- **Replay sessions:** timer behaviour and lap validity may differ; projection/after-zero source switching should be validated with logs.
-
-
-### Pre-race info exports
-- `LalaLaunch.PreRace.*` exports are a short-lived pre-race/on-grid info layer and are intentionally separate from the continuous live `Fuel.*` model view and planner internals.
-- `LalaLaunch.PreRace.Selected` / `SelectedText`: selected pre-race mode (0 No Stop, 1 Single Stop, 2 Multi Stop, 3 Auto). Mode persistence is PreRace-only (`SelectedPreRaceMode` / `PreRaceMode`) and mode impact is limited to PreRace outputs.
-- `LalaLaunch.PreRace.Stints`: key threshold signal (decimal, 1dp) computed as total fuel required / usable tank capacity; this is total stints needed (not shortfall from current fuel) and replaces separate stop exports for dash contract use.
-- `LalaLaunch.PreRace.TotalFuelNeeded`: unified pre-race fuel projection using race session definition time (`CurrentSessionInfo._SessionTime`) + after-zero allowance. Manual modes include a fixed +2-lap fuel allowance (pre-race-only proxy for formation+contingency).
-- `LalaLaunch.PreRace.FuelDelta`: single pre-race delta output. `Auto` remains planner-first for totals/stints. When planner-required next add (`PlannerNextAddLitres`) is greater than zero, delta compares the driver’s live pit-menu refuel request (`PitSvFuel`) against that planner-required add. When next-add is zero/unavailable, Auto falls back to planner fuel-basis delta (`currentFuel - planner first-stint/total reference`) and does not include pit-menu add intent. `Single Stop` uses current fuel + pit-menu refuel intent; `No Stop`/`Multi Stop` use current fuel only.
-- `LalaLaunch.PreRace.FuelSource` / `LapTimeSource`: short informational source labels (`planner`, `simhub`, `fallback`) for dash message assembly. Auto reports planner/planner when planner values are available, with runtime fallback labels only when planner values are unavailable. Manual modes use explicit fallback order: planner/profile -> SimHub/iRacing -> hard fallback defaults (3.0 L/lap fuel, 120.0 s lap).
-- `LalaLaunch.PreRace.StatusText`: pre-race strategy status text for dash warning bands. Current contract values are `STRATEGY OKAY`, `STRATEGY MARGINAL`, and `UNABLE STRATEGY`. Initial logic is mode+stints based with a fixed marginal tolerance of +0.2 stints over the No Stop (1.0) and Single Stop (2.0) targets; Multi Stop and Auto currently report `STRATEGY OKAY`.
+## v1 documentation note
+Use **Strategy** terminology for GitHub-facing explanations. Treat older “Fuel tab” wording as legacy technical language only; the canonical UI story is now the Strategy tab plus the separate runtime Fuel Model.

--- a/Docs/Subsystems/Launch_Mode.md
+++ b/Docs/Subsystems/Launch_Mode.md
@@ -1,121 +1,137 @@
 # Launch Mode
 
-Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1
-Last updated: 2025-12-28
-Branch: docs/refresh-index-subsystems
+Validated against commit: HEAD
+Last updated: 2026-03-22
+Branch: work
 
 ## Purpose
-Launch Mode manages automated and manual race starts by coordinating:
-- Driver intent (manual arming / disabling),
-- Vehicle state (speed, clutch, gear),
-- Session context (race start only),
-- Safety timeouts and abort conditions.
+Launch Mode owns the live race-start assistance path. It coordinates:
+- launch arming and activation,
+- the manual launch action,
+- launch blocking/abort conditions,
+- launch result capture,
+- the handoff to Launch Analysis for saved trace review.
 
-It exists to reduce start variability while remaining fully defeatable by the driver.
+For GitHub readers, keep this boundary clear:
+- **Settings → Launch Settings** owns launch configuration.
+- **Launch Mode** owns the live start-state machine.
+- **Launch Analysis** is the separate post-run review surface.
 
----
+## Scope and boundaries
+This subsystem covers the live launch state and recording workflow.
+It does **not** own:
+- dashboard artwork,
+- generic dash visibility toggles,
+- rejoin logic,
+- saved profile systems outside launch-specific values,
+- the user-facing explanation page in `Docs/Launch_System.md`.
 
-## Inputs
+## Inputs (source + cadence)
+### Runtime telemetry
+- Vehicle speed.
+- Start-state/session-state context.
+- Launch-related telemetry used to determine whether the car is idle, waiting, active, or complete.
+- Post-launch telemetry used for summary/trace capture.
 
-- Vehicle speed
-- Clutch state / bite point
-- Gear selection
-- Session state (race, green flag)
-- Manual launch button bindings
-- Timer-zero and session identity
+### User / settings inputs
+- `LaunchMode` action for manual prime / re-enable / abort behavior.
+- Launch configuration from **Settings → Launch Settings**.
+- Results-display time and launch summary/trace file locations.
 
-Inputs are evaluated continuously in the main update loop.
+### Cross-subsystem blockers
+- In-pit state.
+- Serious rejoin state (spin / wrong-way style blockers).
+- Session identity changes that force a reset.
 
----
+## Internal state
+Key runtime state includes:
+- user-disabled latch,
+- manual-prime latch,
+- current launch phase/state,
+- launch abort latch,
+- launch success / completion flags,
+- launch end timestamp,
+- active telemetry logger / summary writer state.
 
-## Internal State
+## Calculation blocks (high level)
+### 1) Eligibility and blocking
+Launch Mode can be blocked before or during a launch attempt when:
+- the car is in pits,
+- a serious rejoin incident is active,
+- session identity changed,
+- the runtime no longer considers the launch attempt valid.
 
-- LaunchModeEnabled (user-configurable)
-- LaunchArmed / LaunchActive
-- ManualPrimed flag
-- Timeout timestamps
-- User-disabled latch (post-abort)
+When blocked, Launch Mode is prevented from arming or is aborted back to idle.
 
-State transitions are logged.
+### 2) Manual action behavior
+The `LaunchMode` action behaves as a three-way control:
+- if launch was hard-disabled, pressing it re-enables launch mode,
+- if launch is idle, pressing it manual-primes a launch attempt,
+- if launch is already in progress, pressing it aborts and sets the user-disabled latch.
 
----
+Manual prime is intentionally time-limited rather than staying armed forever.
 
-## Logic Blocks
+### 3) Arming and live launch progression
+Once eligible, the subsystem progresses through its launch phases using current telemetry and start-state context.
+At a high level it manages:
+- idle / waiting behavior,
+- active launch behavior,
+- completion handling,
+- post-launch results visibility.
 
-### 1) Eligibility
-Launch Mode only evaluates when:
-- Session type == Race
-- Vehicle speed below threshold
-- Driver has not disabled launch this session
+### 4) Manual-prime timeout
+Manual-prime mode has a **30-second timeout**. If the launch does not actually start inside that window, the attempt is canceled and the subsystem behaves like a user-disabled abort until the driver explicitly re-enables it.
 
-Otherwise, the subsystem remains dormant.
+### 5) Completion and review handoff
+When a launch completes successfully enough to be recorded, the subsystem writes:
+- a one-line summary CSV entry when enabled,
+- a detailed launch trace file,
+- launch-summary data that the **Launch Analysis** tab can later read and review.
 
----
+## Outputs (exports + logs)
+### Core exports
+Representative launch-facing exports include:
+- `LaunchModeActive`
+- launch-state / launch-result visibility outputs used by dashes and the results view
+- saved summary / trace data consumed by Launch Analysis
 
-### 2) Arming
-Launch may arm via:
-- Automatic detection (grid start)
-- Manual priming button
+The export inventory remains canonical in `Docs/Internal/SimHubParameterInventory.md`.
 
-Manual priming starts a timeout window.
+### Logs
+Launch logging is meant to explain state transitions rather than stream noise. Important log families include:
+- manual prime / re-enable / abort actions,
+- blocked launch reasons,
+- manual-prime timeout,
+- launch trace open/append/close errors,
+- summary/trace capture outcomes.
 
----
+Canonical message wording remains in `Docs/Internal/SimHubLogMessages.md` where applicable.
 
-### 3) Execution
-When armed:
-- Clutch output ramps according to configured curve
-- Gear and throttle assumptions are monitored
-- Launch deactivates once speed threshold exceeded
+## Dependencies / ordering assumptions
+- Rejoin state must be current before launch-block checks run.
+- Launch update/order must happen before final launch-result display logic.
+- Launch trace and summary writers are downstream of the live launch state rather than independent features.
 
----
-
-### 4) Abort Conditions
-Launch aborts immediately if:
-- Timeout exceeded
-- Driver disables launch
-- Unexpected speed/gear state
-- Session identity changes
-
-Abort reason is logged and latched.
-
----
-
-## Outputs
-
-- Launch active flags
-- Clutch output percentage
-- Debug state exports
-- INFO logs explaining transitions
-
----
-
-## Reset Rules
-
+## Reset rules
 Launch state resets on:
-- Session identity change
-- Abort or completion
-- Manual disable
+- session identity change,
+- explicit abort,
+- completion teardown,
+- manual disable / re-enable flow,
+- any broader runtime reset that clears transient launch state.
 
----
+## Failure modes / safeguards
+- **Blocked by pits or serious rejoin:** launch will not arm or continue.
+- **Manual-prime timeout:** launch returns to idle and behaves as user-disabled until re-enabled.
+- **File IO issues:** traces/summaries may fail to save, but the live launch state machine still completes independently.
+- **Replay or unusual timing:** validate with logs rather than assuming live-session timing behavior is identical.
 
-## Failure Modes
+## Test checklist
+- Trigger `LaunchMode` from idle and confirm manual-prime behavior.
+- Let manual prime expire and confirm timeout + re-enable behavior.
+- Trigger a blocked state (pit lane or serious rejoin) and confirm launch cannot proceed.
+- Complete a clean launch and confirm summary/trace capture appears for Launch Analysis.
+- Confirm post-launch results hide after the configured results-display time.
 
-- Missed grid detection → manual prime required
-- Timeout expiry → launch disabled for session
-- Replay timing anomalies → verify via logs
-
----
-
-## Test Checklist
-
-- Auto launch on race start
-- Manual prime success
-- Timeout abort
-- Session reset clears all state
-
----
-
-## TODO / VERIFY
-
-- TODO/VERIFY: Confirm exact speed threshold used to disengage launch.
-- TODO/VERIFY: Confirm clutch curve configuration source.
+## v1 documentation note
+User-facing docs should explain launch as **Launch Settings + Launch Analysis + live launch behavior**. This subsystem doc owns the technical contract for the live launch path and recording handoff.

--- a/Docs/Subsystems/Pace_And_Projection.md
+++ b/Docs/Subsystems/Pace_And_Projection.md
@@ -1,273 +1,140 @@
 # Pace and Projection
 
-Validated against commit: 708af0f  
-Last updated: 2026-01-27  
+Validated against commit: HEAD
+Last updated: 2026-03-22
 Branch: work
 
 ## Purpose
-The Pace & Projection subsystem provides a **stable, defensible lap-time reference** used to:
-- Project race distance (laps remaining) in timed races.
-- Support fuel-to-end and pit window calculations.
-- Provide a baseline for **DTL-based pit loss**.
-- Drive dashboards with meaningful, low-noise pace figures.
+The Pace & Projection subsystem owns the runtime lap-time reference used by the plugin when it needs a defensible answer to:
+- “What lap pace should the runtime trust right now?”
+- “How many laps are realistically left in this timed race?”
+- “How should fuel-to-end and pit-window math be driven when live pace is weak or noisy?”
 
 It explicitly separates:
-- **Observed pace** (what just happened),
-- **Usable pace** (what projections should trust),
-- **Fallback pace** (when live data is insufficient).
+- **observed pace** from recent live laps,
+- **stable projection pace** for runtime use,
+- **fallback pace** when live data is not ready.
 
-Canonical references:
-- Export definitions: `Docs/Internal/SimHubParameterInventory.md`
-- Fuel integration rules: `Docs/FuelProperties_Spec.md`
-- Pit loss integration: `Subsystems/Pit_Timing_And_PitLoss.md`
-- Reset semantics: `Docs/Reset_And_Session_Identity.md`
-
----
+Canonical companion docs:
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/SimHubLogMessages.md`
+- `Docs/Subsystems/Fuel_Model.md`
+- `Docs/Subsystems/Fuel_Planner_Tab.md`
+- `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
 
 ## Scope and boundaries
-
-This doc covers:
-- Lap-time capture and rejection.
-- Rolling pace windows and confidence.
-- Projection lap-time selection and fallbacks.
-- Timed-race “after-zero” integration.
+This subsystem covers:
+- live lap-time acceptance / rejection,
+- recent-lap and leader-lap pace windows,
+- runtime projection source selection,
+- stable projection lap-time export,
+- after-zero-aware race-distance input into Fuel Model.
 
 Out of scope:
-- Fuel burn modelling (see `Fuel_Model.md`).
-- Fuel planner UI behaviour (see `Fuel_Planner_Tab.md`).
-- Dash rendering logic (see `Subsystems/Dash_Integration.md`).
-
----
+- the Strategy tab’s deterministic planning math,
+- fuel-burn modeling,
+- dashboard layout/rendering.
 
 ## Inputs (source + cadence)
+### Runtime inputs
+- Lap completion events and lap times.
+- Session type / time remaining / timer-zero state.
+- Pit-trip state and pit-exit warmup context.
+- Incident / off-track state used to reject compromised laps.
+- Leader-lap timing when available.
 
-### Telemetry inputs (runtime, 500 ms cadence)
-- Lap completion events (lap number, lap time).
-- Session time remaining / timer-zero signals.
-- Session state (race / non-race).
-- Incident / off-track flags (if wired).
-
-Lap detection and cadence are shared with the Fuel Model.
-
----
-
-### Profile and planner inputs
-- Profile lap-time averages (dry/wet).
-- Planner-selected lap time (when planner overrides are active).
-- PB-derived lap times (used by planner, not runtime projection unless selected).
-
-The runtime projection prefers **live observed pace** unless explicitly overridden.
-
----
+### Baselines and fallbacks
+- Profile lap-time averages.
+- Session PB fallback where appropriate.
+- Sim/session fallback values when live pace cannot yet be trusted.
 
 ## Internal state
+### Recent pace windows
+- Recent accepted clean laps for live pace.
+- Last-5 / rolling-average style windows.
+- Leader-lap rolling average when the feed is available.
 
-### Rolling pace windows
-- **Stint average**: rolling mean of accepted laps in the current stint.
-- **Last-5 average**: rolling window of up to 5 accepted laps.
-- **Leader pace**: parsed leader lap times where available.
+### Stable projection state
+- Current stable projection lap time.
+- Current stable source label.
+- Last logged source/value so source changes can be debounced and explained.
 
-Each window tracks:
-- Sample count.
-- Min/max bounds.
-- Confidence contribution.
-
----
-
-### Pace confidence
-Pace confidence reflects **how trustworthy live pace is** for projection.
-
-It increases with:
-- Number of accepted laps.
-- Stability of lap times (low variance).
-- Consistency of window membership.
-
-It is reduced or held low when:
-- Laps are frequently rejected.
-- Large variance exists (traffic, incidents).
-- Session has just started.
-
-Pace confidence is used indirectly to decide projection source.
-
----
+### Confidence state
+- Pace confidence from accepted sample count and quality.
+- Combined/overall confidence signals published for dashboards and runtime consumers.
 
 ## Calculation blocks (high level)
+### 1) Pace lap acceptance
+Recent lap times are accepted only when they look representative.
+Common reject paths include:
+- race warmup / earliest laps,
+- pit laps and first lap after pit exit,
+- off-track / incident-latched laps,
+- impossible or grossly outlying lap times.
 
-### 1) Lap acceptance (pace)
-On each lap completion:
-- Reject laps with pit involvement.
-- Reject implausibly short or long laps (sanity bounds).
-- Reject laps marked invalid by incident logic (if present).
+### 2) Rolling pace maintenance
+Accepted laps update the runtime clean-lap windows.
+Leader-lap timing is maintained separately so the plugin can use it as context without letting it silently replace the player-focused live pace path.
 
-Accepted laps feed pace windows; rejected laps do not affect averages.
+### 3) Baseline selection
+When enough live pace is not available, the subsystem falls back through guarded baseline choices such as:
+- profile average,
+- session-PB-style fallback,
+- safe default/fallback behavior.
 
-Wet/dry mode follows tyre-compound telemetry and uses the **same** lap validity rules; it only routes accepted laps into dry vs wet profile fields.
+The exact chosen source is published and logged so downstream behavior stays explainable.
 
-Acceptance rules mirror fuel-lap acceptance where possible.
+### 4) Stable projection selection
+The subsystem selects a runtime projection lap time and then stabilizes it so dashes and fuel math do not oscillate constantly.
+The exported source label reflects whether the runtime is using live pace, profile-backed pace, session PB, or a deeper fallback path.
 
----
-
-### 2) Rolling window maintenance
-For each accepted lap:
-- Update stint-average window.
-- Update last-5 window (max 5 samples).
-- Track min/max to detect outliers.
-- Update confidence metrics.
-
-Window contents are reset on pit entry and session identity change.
-
----
-
-### 3) Projection lap-time candidates
-The subsystem maintains multiple candidate lap times:
-- **StintAvgLapTime**
-- **Last5LapAvg**
-- **LeaderLapAvg** (if available)
-- **ProfileLapTime** (fallback)
-- **Planner-selected lap time** (if explicitly active)
-
-Each candidate carries:
-- Source label.
-- Validity flag.
-- Confidence contribution.
-
----
-
-### 4) Projection source selection
-The **projection lap time** is selected using priority rules:
-
-1. Planner-selected lap time (explicit override).
-2. Live stint/last-5 average when confidence sufficient.
-3. Leader-based pace (if configured and valid).
-4. Profile lap time.
-5. Fallback estimator (SimHub computed or last-known).
-
-Source switches are logged to make behaviour observable.
-
-This selected lap time is exported as the “projection pace”.
-
----
-
-### 5) Timed-race projection
-For timed races:
-- Remaining session time is divided by projection lap time to compute laps remaining.
-- **After-zero allowance** seconds are added to session time:
-  - Planner-defined allowance always exists.
-  - Live after-zero estimate becomes valid only after timer zero is observed.
-
-This ensures end-of-race laps are not undercounted.
-
----
-
-### 6) Smoothing and presentation
-To avoid dash thrashing:
-- Numeric projection values are smoothed.
-- String-formatted projections (`*_S`) are debounced.
-
-Raw values remain available for diagnostics.
-
----
+### 5) Timed-race projection support
+The resulting projection lap time feeds the Fuel Model’s timed-race math together with:
+- session time remaining,
+- planner after-zero allowance,
+- live after-zero estimate once timer-zero has genuinely been observed.
 
 ## Outputs (exports + logs)
-
 ### Core exports
-(See `Docs/Internal/SimHubParameterInventory.md` for authoritative list.)
-
-Typical outputs include:
+Representative outputs include:
 - `Pace.StintAvgLapTimeSec`
 - `Pace.Last5LapAvgSec`
 - `Pace.LeaderLapAvgSec`
-- `Pace.ProjectionLapTimeSec`
-- `Fuel.LiveLapsRemainingInRace`
-- `Fuel.Live.ProjectedDriveSecondsRemaining`
-- Projection source labels
+- `ProjectionLapTime_Stable`
+- `ProjectionLapTime_StableSource`
+- overall/live pace confidence values used elsewhere in the plugin
 
-These outputs feed:
-- Fuel Model race-distance math.
-- Pit loss DTL baseline.
-- Dash projections.
-
----
+See `Docs/Internal/SimHubParameterInventory.md` for the authoritative inventory.
 
 ### Logs
-The subsystem emits INFO logs for:
-- Lap acceptance/rejection (pace side).
-- Projection source changes.
-- After-zero source changes.
-
-Logs are designed to explain *why* a projection changed.
-
-See `Docs/Internal/SimHubLogMessages.md` for canonical definitions.
-
----
+Important log families include:
+- pace acceptance / rejection summaries,
+- baseline selection changes,
+- projection source changes,
+- after-zero source changes when the runtime moves from planner to live behavior.
 
 ## Dependencies / ordering assumptions
-- Lap detector must fire before pace updates.
-- Pace updates must complete before fuel projections.
-- Fuel Model relies on projection pace being stable within a tick.
-
----
+- Lap detection must complete before pace windows are updated.
+- Pace / projection must settle before Fuel Model consumes the result for fuel-to-end and pit-window math.
+- Strategy can display runtime pace context, but it remains a separate human-owned planner.
 
 ## Reset rules
+Pace and projection state resets on:
+- session identity changes,
+- combo changes,
+- broader fuel/runtime resets that must prevent stale live pace from leaking into a new session.
 
-Pace state resets on:
-- Session identity change.
-- Pit entry (stint boundaries).
-- Car or track change.
-
-On reset:
-- All rolling windows cleared.
-- Confidence reset.
-- Projection source re-evaluated from defaults.
-
-Reset contract is defined in:
-`Docs/Reset_And_Session_Identity.md`.
-
----
-
-## Failure modes / edge cases
-
-- **Heavy traffic**
-  - Variance rises; confidence drops.
-  - Projection falls back to profile or leader pace.
-
-- **Replays**
-  - Lap timing events may bunch.
-  - Validate projection behaviour via logs.
-
-- **Leader data missing**
-  - Leader pace candidate invalidated.
-  - Projection continues without it.
-
-- **Short sessions**
-  - Insufficient samples → fallback pace dominates.
-
----
+## Failure modes / safeguards
+- **Heavy traffic / compromised laps:** confidence falls and fallback pace may legitimately take over.
+- **Dropped leader feed:** leader average clears rather than silently reusing stale values.
+- **Short or noisy sessions:** projection may stay profile/fallback driven for longer than the driver expects.
+- **Replay timing:** source changes should be verified with logs.
 
 ## Test checklist
+- Run clean laps and confirm pace confidence rises while the stable source stays sensible.
+- Trigger pit/off-track rejection scenarios and confirm the affected laps do not contaminate projection pace.
+- Remove/lose leader timing and confirm leader context clears without reviving stale values.
+- In timed sessions, confirm planner after-zero is used first and live after-zero can later take over when valid.
 
-1. **Clean stint**
-   - Confidence rises smoothly.
-   - Projection source remains stable.
-
-2. **Traffic stint**
-   - Confidence drops.
-   - Projection source switches are logged.
-
-3. **Planner override**
-   - Projection uses planner lap time regardless of live data.
-
-4. **Timed race**
-   - After-zero allowance increases laps remaining appropriately.
-
-5. **Reset behaviour**
-   - Pit entry resets stint windows.
-   - Session change clears all pace state.
-
----
-
-## TODO / VERIFY
-
-- TODO/VERIFY: Confirm exact variance thresholds used to suppress live pace confidence.
-- TODO/VERIFY: Confirm leader pace parsing rules and when leader data is considered valid.
-- TODO/VERIFY: Confirm fallback estimator precedence when both profile and SimHub computed pace exist.
+## v1 documentation note
+Use **Strategy** for the user-facing planning story, but keep **Pace & Projection** as the canonical runtime subsystem that feeds fuel math and stable live race-distance behavior.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Lala Race Assist Plugin is a SimHub plugin for **iRacing** focused on race engin
 
 It is built to help with the practical race workflow: plan stints, trust learned fuel and pace data, manage launch and pit situations, and keep key race context visible while driving.
 
+Version **1.0** documentation is now organized so GitHub readers can move from a quick user overview into the canonical subsystem docs without guessing which page owns which truth.
+
 ## Core Systems
 
 - **Strategy** - stable planning workflow for race fuel, stint, and context decisions
@@ -52,11 +54,12 @@ The plugin owns the **learning, storage, calculations, and exports**. Dashboards
 - [Profiles System](Docs/Profiles_System.md)
 - [Fuel Model](Docs/Fuel_Model.md)
 
-### Dash and Reference
+### Technical / Canonical Subsystems
 
-- [Dashboards](Docs/Dashboards.md)
+- [Project Index](Docs/Project_Index.md) - documentation map and ownership guide
+- [Subsystem docs](Docs/Subsystems/) - canonical subsystem behavior, boundaries, and export-level contracts
+- [Dash integration notes](Docs/Subsystems/Dash_Integration.md)
 - [Changelog](CHANGELOG.md)
-- [Project Index](Docs/Project_Index.md)
 
 ## Current UI Structure
 


### PR DESCRIPTION
### Motivation
- Prepare a v1-ready GitHub documentation sweep so public readers can move from the landing page into canonical user and subsystem docs without stale wording. 
- Align the canonical subsystem docs with the current Strategy-era UI and runtime responsibilities (separating planner/Strategy from runtime engines). 
- Keep the documentation surface consistent with the repository’s architecture guardrails and preserve the three-layer docs structure (user, subsystem, internal). 

### Description
- Updated the public landing and index files including `README.md`, `CHANGELOG.md`, `Docs/Project_Index.md`, and `Docs/RepoStatus.md` to present the v1 documentation map and validation note. 
- Rewrote/refreshed subsystem canonical docs to match current runtime/UI ownership for `Docs/Subsystems/Fuel_Model.md`, `Docs/Subsystems/Pace_And_Projection.md`, `Docs/Subsystems/Launch_Mode.md`, and `Docs/Subsystems/Dash_Integration.md`. 
- Preserved and re-reviewed other user-facing pages in `Docs/` and kept the three-layer structure intact so only documentation changed and no runtime code, XAML, JSON, dashboard assets, exports, or logs were modified. 
- Committed the documentation edits as a documentation-only sweep (files changed: `README.md`, `CHANGELOG.md`, `Docs/Project_Index.md`, `Docs/RepoStatus.md`, `Docs/Subsystems/Fuel_Model.md`, `Docs/Subsystems/Launch_Mode.md`, `Docs/Subsystems/Pace_And_Projection.md`, `Docs/Subsystems/Dash_Integration.md`). 

### Testing
- Ran a markdown link resolution check (script scanning `Docs/`, `README.md`, `CHANGELOG.md`) which succeeded with no missing local links. 
- Ran a stale-wording scan using `rg` for legacy Fuel-tab-era references and found no remaining occurrences in the edited docs. 
- Ran a whitespace/diff sanity check (`git diff --check`) and a working-tree status validation, and both checks passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfec92b27c832fb5f75ef17a4bece2)