### PR TITLE
Release polish: dash visibility labels, debug warning, dark Preset combo, and embedded defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,10 @@ Main user-facing changes since the late-February documentation baseline include:
 - Expanded practical guidance for **rejoin warnings**, **pit popups**, and **pit entry assist**.
 - Completed the v1 documentation sweep across the main repo docs and canonical subsystem docs so GitHub readers can move from user pages into technical ownership docs without stale Fuel-tab-era wording or broken responsibility boundaries.
 - Refreshed repo-facing documentation so the GitHub repo can serve as the canonical user home alongside the canonical subsystem docs.
+
+## v1.1 – Release polish pass
+
+- Shortened Dash Control visibility column labels to **`DRIVER`**, **`STRATEGY`**, and **`OVERLAY`** while keeping tooltip wording explicit.
+- Added a release-facing warning below the debug-mode master toggle so troubleshooting features are less likely to be left on accidentally.
+- Kept Strategy preset editing in the existing Preset Manager popup but fixed the dark-theme combo-box readability issue for the `PreRace Mode` selector.
+- Embedded the shipped preset defaults and expanded track-marker defaults directly in the owning code paths so the repo/package ships with the intended first-run data, including the shorter `IMSA 40m` / `Sprint 20m` preset names and additional seeded tracks.

--- a/DashesTabView.xaml
+++ b/DashesTabView.xaml
@@ -142,105 +142,108 @@
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="1" Text="MAIN DASH" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center" />
-                        <TextBlock Grid.Row="0" Grid.Column="2" Text="MESSAGE DASH" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center" />
-                        <TextBlock Grid.Row="0" Grid.Column="3" Text="OVERLAY" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="DRIVER" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center"
+                                   ToolTip="DRIVER = Lala Race Dash." />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Text="STRATEGY" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center"
+                                   ToolTip="STRATEGY = Lala Strategy Dash." />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Text="OVERLAY" FontWeight="Bold" Margin="0,0,0,6" HorizontalAlignment="Center"
+                                   ToolTip="OVERLAY = overlay surfaces." />
 
                         <TextBlock Text="Launch Assist" Grid.Row="1" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable the Launch screen for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="1" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowLaunchScreen, Mode=TwoWay}"
-                                                 ToolTip="Show the Launch screen on the Main Dash." />
+                                                 ToolTip="Show the Launch screen on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="1" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowLaunchScreen, Mode=TwoWay}"
-                                                 ToolTip="Show the Launch screen on the Message Dash." />
+                                                 ToolTip="Show the Launch screen on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="1" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowLaunchScreen, Mode=TwoWay}"
-                                                 ToolTip="Show the Launch screen on the Overlay." />
+                                                 ToolTip="Show the Launch screen on OVERLAY surfaces." />
 
                         <TextBlock Text="Pit Assists" Grid.Row="2" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable the Pit Limiter screen for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="2" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowPitLimiter, Mode=TwoWay}"
-                                                 ToolTip="Show the Pit Limiter screen on the Main Dash." />
+                                                 ToolTip="Show the Pit Limiter screen on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="2" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowPitLimiter, Mode=TwoWay}"
-                                                 ToolTip="Show the Pit Limiter screen on the Message Dash." />
+                                                 ToolTip="Show the Pit Limiter screen on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="2" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowPitLimiter, Mode=TwoWay}"
-                                                 ToolTip="Show the Pit Limiter screen on the Overlay." />
+                                                 ToolTip="Show the Pit Limiter screen on OVERLAY surfaces." />
 
                         <TextBlock Text="Show Automatic Pit Screen" Grid.Row="3" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable the automatic pit screen for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="3" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowPitScreen, Mode=TwoWay}"
-                                                 ToolTip="Show the automatic pit screen on the Main Dash." />
+                                                 ToolTip="Show the automatic pit screen on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="3" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowPitScreen, Mode=TwoWay}"
-                                                 ToolTip="Show the automatic pit screen on the Message Dash." />
+                                                 ToolTip="Show the automatic pit screen on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="3" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowPitScreen, Mode=TwoWay}"
-                                                 ToolTip="Show the automatic pit screen on the Overlay." />
+                                                 ToolTip="Show the automatic pit screen on OVERLAY surfaces." />
 
                         <TextBlock Text="Rejoin Assist" Grid.Row="4" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable track rejoin assist for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="4" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowRejoinAssist, Mode=TwoWay}"
-                                                 ToolTip="Show track rejoin assist on the Main Dash." />
+                                                 ToolTip="Show track rejoin assist on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="4" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowRejoinAssist, Mode=TwoWay}"
-                                                 ToolTip="Show track rejoin assist on the Message Dash." />
+                                                 ToolTip="Show track rejoin assist on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="4" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowRejoinAssist, Mode=TwoWay}"
-                                                 ToolTip="Show track rejoin assist on the Overlay." />
+                                                 ToolTip="Show track rejoin assist on OVERLAY surfaces." />
 
                         <TextBlock Text="Verbose Race Messages" Grid.Row="5" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable detailed race messages for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="5" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowVerboseMessaging, Mode=TwoWay}"
-                                                 ToolTip="Show verbose race messages on the Main Dash." />
+                                                 ToolTip="Show verbose race messages on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="5" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowVerboseMessaging, Mode=TwoWay}"
-                                                 ToolTip="Show verbose race messages on the Message Dash." />
+                                                 ToolTip="Show verbose race messages on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="5" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowVerboseMessaging, Mode=TwoWay}"
-                                                 ToolTip="Show verbose race messages on the Overlay." />
+                                                 ToolTip="Show verbose race messages on OVERLAY surfaces." />
 
                         <TextBlock Text="Race Flags" Grid.Row="6" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable race flag notifications for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="6" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowRaceFlags, Mode=TwoWay}"
-                                                 ToolTip="Show race flags on the Main Dash." />
+                                                 ToolTip="Show race flags on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="6" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowRaceFlags, Mode=TwoWay}"
-                                                 ToolTip="Show race flags on the Message Dash." />
+                                                 ToolTip="Show race flags on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="6" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowRaceFlags, Mode=TwoWay}"
-                                                 ToolTip="Show race flags on the Overlay." />
+                                                 ToolTip="Show race flags on OVERLAY surfaces." />
 
                         <TextBlock Text="Radio Messages" Grid.Row="7" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable radio message popups for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="7" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowRadioMessages, Mode=TwoWay}"
-                                                 ToolTip="Show radio messages on the Main Dash." />
+                                                 ToolTip="Show radio messages on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="7" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowRadioMessages, Mode=TwoWay}"
-                                                 ToolTip="Show radio messages on the Message Dash." />
+                                                 ToolTip="Show radio messages on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="7" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowRadioMessages, Mode=TwoWay}"
-                                                 ToolTip="Show radio messages on the Overlay." />
+                                                 ToolTip="Show radio messages on OVERLAY surfaces." />
 
                         <TextBlock Text="Show Traffic Alerts" Grid.Row="8" Grid.Column="0" Margin="0,5,12,0" VerticalAlignment="Center"
                                    ToolTip="Enable traffic alert warnings for this dash type." />
                         <styles:SHToggleCheckbox Grid.Row="8" Grid.Column="1" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.LalaDashShowTraffic, Mode=TwoWay}"
-                                                 ToolTip="Show traffic alerts on the Main Dash." />
+                                                 ToolTip="Show traffic alerts on the DRIVER dash (Lala Race Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="8" Grid.Column="2" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.MsgDashShowTraffic, Mode=TwoWay}"
-                                                 ToolTip="Show traffic alerts on the Message Dash." />
+                                                 ToolTip="Show traffic alerts on the STRATEGY dash (Lala Strategy Dash)." />
                         <styles:SHToggleCheckbox Grid.Row="8" Grid.Column="3" Content="" Margin="0,5,0,0" HorizontalAlignment="Center"
                                                  IsChecked="{Binding Settings.OverlayDashShowTraffic, Mode=TwoWay}"
-                                                 ToolTip="Show traffic alerts on the Overlay." />
+                                                 ToolTip="Show traffic alerts on OVERLAY surfaces." />
                     </Grid>
                 </StackPanel>
             </Expander>

--- a/Docs/Dashboards.md
+++ b/Docs/Dashboards.md
@@ -44,6 +44,12 @@ Dash Control is dash-oriented. Use it to manage:
 - whether pit screens appear or are manually overridden,
 - how the display behaves across different dashboard layouts.
 
+In the Dash Visibility matrix, the short release-facing headers are:
+
+- **DRIVER** = Lala Race Dash
+- **STRATEGY** = Lala Strategy Dash
+- **OVERLAY** = overlay surfaces
+
 Do **not** use Dash Control as the mental home for strategy, launch logic, or saved profile learning.
 
 ## 5. Strategy, PreRace, and display boundaries

--- a/Docs/Internal/Plugin_UI_Tooltips.md
+++ b/Docs/Internal/Plugin_UI_Tooltips.md
@@ -1,7 +1,7 @@
 ﻿# Plugin UI Tooltips
 
-Validated against commit: 3f0af12824336625dd449cc0329702ac50394396
-Last updated: 2026-03-20
+Validated against commit: HEAD
+Last updated: 2026-03-22
 Branch: work
 
 ## CopyProfileDialog.xaml
@@ -20,7 +20,8 @@ Branch: work
 - `Global Dash Functions` -> General: `Auto screen selection at session start` automatically switches dash screens when a session starts based on context.
 - `Global Dash Functions` -> Dark Mode: `Dark Mode` selector uses Off / Manual / Auto, `Dark Mode Brightness` sets base brightness, `Use Lovely True Dark` follows Lovely when available, and `Toggle Dark Mode` remains here as the dark-mode-specific binding row.
 - `Global Dash Functions` -> Fuel: `Fuel Ready Confidence` sets the live-fuel readiness threshold and `Pit-in Fuel Reserve` sets the stint reserve margin.
-- `Dash Visibility` keeps the existing main/message/overlay visibility matrix for Launch Assist, Pit Assists, Automatic Pit Screen, Rejoin Assist, Verbose Race Messages, Race Flags, Radio Messages, and Traffic Alerts.
+- `Dash Visibility` keeps the existing visibility matrix for Launch Assist, Pit Assists, Automatic Pit Screen, Rejoin Assist, Verbose Race Messages, Race Flags, Radio Messages, and Traffic Alerts, but the release-facing column headers are now `DRIVER`, `STRATEGY`, and `OVERLAY`.
+- `Dash Visibility` header tooltips make the short labels explicit: `DRIVER = Lala Race Dash`, `STRATEGY = Lala Strategy Dash`, and `OVERLAY = overlay surfaces`.
 - `Launch Mode`, `Event Marker`, and `Post-Launch Results Display Time` no longer appear in Dash Control after this tidy-up.
 
 ## FuelCalculatorView.xaml
@@ -145,6 +146,7 @@ Branch: work
 - L289: Rename the selected preset using the name box.
 - L301: Revert edits to the last saved preset values.
 - L303: Save edits to the selected preset.
+- The `PreRace Mode` combo now uses an explicit dark popup/control template so the selected value and dropdown list remain readable against the plugin’s dark theme.
 
 ## ProfilesManagerView.xaml
 - L22: Manage car profiles stored on disk.
@@ -206,6 +208,7 @@ Branch: work
 - `GlobalSettingsView.xaml` now surfaces the Friends List tools/import flow inside a collapsed `Friends List` expander first, then a collapsed `Launch Settings` expander, then the existing Debug block.
 - `GlobalSettingsView.xaml` no longer contains the duplicated per-profile `USER VARIABLES` block; the Settings tab now begins with the Friends List tools/import flow.
 - `GlobalSettingsView.xaml` DEBUG section continues to host the existing debug toggles and the moved `Event Marker` binding under `Debug Actions`; Launch Settings now sits above this block inside its own collapsed expander.
+- `GlobalSettingsView.xaml` shows the warning text `Debug mode is for troubleshooting only. Leave this off unless asked to enable it.` directly below `Enable debugging mode`.
 - `GlobalSettingsView.xaml` `Enable Debug Logging` tooltip says it enables verbose logging for troubleshooting the plugin.
 - `GlobalSettingsView.xaml` `PitExit Verbose Logging` tooltip says it adds PitExit math audit details to pit-in snapshots for troubleshooting.
 - `GlobalSettingsView.xaml` `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -8,31 +8,33 @@ Branch: work
 - Local branch present: `work`.
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
-## Documentation sync status (v1 sweep)
-- Completed a documentation-only v1 release sweep focused on the main repo docs plus the canonical subsystem docs in `Docs/Subsystems/`.
-- No runtime/plugin code, XAML behavior, JSON storage, dashboard assets, namespaces, exports, or log-producing code paths were changed in this task.
-- Re-reviewed the GitHub-facing entry points (`README.md`, `Docs/Project_Index.md`, `CHANGELOG.md`) so GitHub readers can move from the landing page to the correct user/system/subsystem page without stale navigation.
-- Re-reviewed the user-facing feature/system pages in `Docs/` to keep terminology aligned with the current plugin UI, especially **Strategy**, **Launch Analysis**, **Launch Settings**, **Dash Control**, and the current assist naming.
-- Re-reviewed the subsystem set in `Docs/Subsystems/` and refreshed the stale canonical pages where the repo had drifted from older wording, especially around **Fuel Model**, **Pace and Projection**, **Launch Mode**, and **Dash Integration**.
-- Preserved the repo's three-layer documentation structure: user-facing docs in `Docs/`, technical subsystem docs in `Docs/Subsystems/`, and internal/developer docs in `Docs/Internal/`.
-- Kept branding as **Lala Race Assist Plugin** and did not document the future/global message system as an active public feature.
+## Documentation sync status
+- Completed a release-polish pass covering Dash Control visibility labels/tooltips, the debug-mode warning copy, Preset Manager combo-box readability, and embedded shipped defaults for presets/track markers.
+- Updated both canonical subsystem docs and user-facing docs so the short dash labels map clearly back to **Lala Race Dash**, **Lala Strategy Dash**, and **overlay surfaces**.
+- Documented that shipped preset defaults and the expanded embedded track-marker defaults now live directly in the owning code paths, with invalid marker entries excluded rather than normalized into fake values and the newly added marker rows carrying fixed embedded timestamps for deterministic first-run seeding.
+- Kept scope inside the existing Dash Integration, Fuel Planner / Strategy, Track Markers, and Settings/UI ownership boundaries without changing fuel math, learning, Shift Assist logic, CarSA, H2H, or telemetry gating.
 
 ## Reviewed documentation set
 ### Changed in this sweep
-- `README.md`
 - `CHANGELOG.md`
-- `Docs/Project_Index.md`
-- `Docs/RepoStatus.md`
-- `Docs/Subsystems/Fuel_Model.md`
-- `Docs/Subsystems/Launch_Mode.md`
-- `Docs/Subsystems/Pace_And_Projection.md`
+- `DashesTabView.xaml`
+- `GlobalSettingsView.xaml`
+- `PresetsManagerView.xaml`
+- `RacePresetStore.cs`
+- `PitEngine.cs`
+- `Docs/Internal/Plugin_UI_Tooltips.md`
 - `Docs/Subsystems/Dash_Integration.md`
+- `Docs/Subsystems/Fuel_Planner_Tab.md`
+- `Docs/Subsystems/Track_Markers.md`
+- `Docs/Strategy_System.md`
+- `Docs/Dashboards.md`
+- `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
+- `README.md`
+- `Docs/Project_Index.md`
 - `Docs/Quick_Start.md`
 - `Docs/User_Guide.md`
-- `Docs/Dashboards.md`
-- `Docs/Strategy_System.md`
 - `Docs/Shift_Assist.md`
 - `Docs/Launch_System.md`
 - `Docs/Rejoin_Assist.md`
@@ -40,7 +42,6 @@ Branch: work
 - `Docs/H2H_System.md`
 - `Docs/Profiles_System.md`
 - `Docs/Fuel_Model.md`
-- `Docs/Subsystems/Fuel_Planner_Tab.md`
 - `Docs/Subsystems/Pit_Entry_Assist.md`
 - `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
 - `Docs/Subsystems/Rejoin_Assist.md`
@@ -49,15 +50,14 @@ Branch: work
 - `Docs/Subsystems/H2H.md`
 - `Docs/Subsystems/Profiles_And_PB.md`
 - `Docs/Subsystems/Trace_Logging.md`
-- `Docs/Subsystems/Track_Markers.md`
 - `Docs/Subsystems/Message_System_V1.md`
 - `Docs/Subsystems/MessageEngineV1_Notes.md`
 
 ## Delivery status highlights
-- The repo landing page now points readers toward both the user pages and the canonical subsystem layer instead of acting like the user docs are the entire documentation set.
-- The documentation map now explicitly frames the v1 GitHub doc set and reinforces which pages own user guidance versus technical truth.
-- The Fuel / Pace / Launch / Dash subsystem docs now match the current Strategy-era UI terminology and current plugin responsibilities instead of older Fuel-tab-era or placeholder references.
-- The unchanged system pages remain valid for GitHub readers and still match the current plugin navigation and workflow.
+- Dash Control now uses short release-facing visibility headers that still map clearly to the underlying dash families through updated tooltip and documentation wording.
+- The Settings debug section now carries an explicit troubleshooting-only warning next to the master toggle.
+- The Preset Manager popup now documents and implements a dark-theme combo-box fix rather than leaving the selection area dependent on the host theme.
+- Embedded default-shipping behavior for presets and track markers is now documented alongside the owning storage/runtime code paths.
 
 ## Validation note
-- Validation recorded against `HEAD` (`v1 documentation sweep for main and subsystem docs`).
+- Validation recorded against `HEAD` (`release polish pass for dash labels, debug warning, embedded defaults, track-marker seed filtering, and preset manager combo styling`).

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -77,6 +77,7 @@ Presets are part of the Strategy workflow.
 - Choose a race preset from Strategy.
 - Open **`Presets...`** to create, rename, edit, save, or delete presets.
 - Return to Strategy to apply and use them.
+- The Preset Manager popup now keeps its combo-box selection readable against the dark theme instead of relying on a washed-out host default.
 
 There is no separate top-level Presets tab.
 

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -41,11 +41,11 @@ This document is the canonical dash-facing contract layer. It does **not** redef
 ## Visibility and gating
 ### Dash visibility toggles
 Use the exported visibility families as hard gates:
-- `LalaDashShow*` = main dash visibility
-- `MsgDashShow*` = message dash visibility
-- `OverlayDashShow*` = overlay visibility
+- `LalaDashShow*` = `DRIVER` column in Dash Control = Lala Race Dash visibility
+- `MsgDashShow*` = `STRATEGY` column in Dash Control = Lala Strategy Dash visibility
+- `OverlayDashShow*` = `OVERLAY` column in Dash Control = overlay visibility
 
-These toggles are the contract between plugin settings and dash layout visibility. Dash JSON should not fight them.
+These toggles are the contract between plugin settings and dash layout visibility. The short UI labels are only there to fit the matrix width; dashboards should still treat the exported families above as the canonical technical meaning. Dash JSON should not fight them.
 
 ### Session-reset expectations
 Hide or clear visuals when:

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -1,7 +1,7 @@
 # Fuel Planner / Strategy Tab
 
-Validated against commit: 3f0af12824336625dd449cc0329702ac50394396
-Last updated: 2026-03-20
+Validated against commit: HEAD
+Last updated: 2026-03-22
 Branch: work
 
 ## Purpose
@@ -14,7 +14,7 @@ The Fuel Planner (surfaced as the top-level **Strategy** tab in the plugin UI) i
 The planner does **not** replace the Fuel Model.  
 It consumes the Fuel Model’s **live snapshot** and produces **explicit planning outputs** that are stable unless the user changes them.
 
-Preset management remains part of the same subsystem, but it is no longer a separate top-level navigation tab. The Strategy tab keeps the inline `Race Preset` selector and opens the existing preset editor via a modal **Preset Manager** dialog beside that selector.
+Preset management remains part of the same subsystem, but it is no longer a separate top-level navigation tab. The Strategy tab keeps the inline `Race Preset` selector and opens the existing preset editor via a modal **Preset Manager** dialog beside that selector. The Preset Manager still owns preset editing only; this release-polish pass also keeps its `PreRace Mode` combo on an explicit dark theme so the selected value remains readable in the popup.
 
 Canonical references:
 - Fuel behaviour contract: `Docs/FuelProperties_Spec.md`
@@ -118,6 +118,7 @@ The planner tracks *what source is currently active* for each input:
 - **Profile mode:** `MaxFuelOverride` is clamped to the profile base tank (`BaseTankLitres`), remains manually editable, and the UI shows a percent-of-base-tank badge.
 - **Preset max fuel input:** Preset max fuel is expressed as a **percentage of base tank** (default 100%), making presets portable across cars with different base tanks.
 - **Preset application in Profile mode:** applying/selecting a preset can still set the active planner max fuel exactly as before, subject to the existing profile-side clamp.
+- **Shipped preset defaults:** when no persisted preset store exists yet, the plugin seeds the shipped default set directly from the embedded preset payload in `RacePresetStore`; there is no separate external default file dependency for repo/package shipping.
 - **Live Snapshot mode:** the planner tank basis comes only from the live detected session cap (`MaxFuel × BoP`). Manual/profile/preset max-fuel values do not remain active underneath Live Snapshot.
 - **Live Snapshot UI lock:** the max-fuel slider/input is non-editable in Live Snapshot and shows the live cap when available.
 - **Live Snapshot fallback:** if the live cap is unavailable, the planner uses `0` as the effective tank basis, surfaces an explicit “Live max fuel cap unavailable” validation error, and blocks strategy outputs rather than silently reusing an older profile/preset/manual value.

--- a/Docs/Subsystems/Track_Markers.md
+++ b/Docs/Subsystems/Track_Markers.md
@@ -1,7 +1,7 @@
 # Track Markers (Pit Entry/Exit) — Auto-Learn, Storage, MSGV1
 
-Validated against commit: 298accf  
-Last updated: 2026-02-10  
+Validated against commit: HEAD  
+Last updated: 2026-03-22  
 Branch: work
 
 ## Purpose
@@ -10,7 +10,8 @@ Capture pit entry/exit lines per track, keep them stable across sessions via per
 ## Source of truth and storage
 - **Source of truth:** Persisted markers in `PluginsData/Common/LalaPlugin/TrackMarkers.json` (`PitEngine` store). Live telemetry is only used to propose captures; stored values drive exports and UI snapshots. Legacy `LalaPlugin.TrackMarkers.json` is migrated on load if present.【F:PitEngine.cs†L948-L1034】
 - **Keys:** Canonicalised track key from SimHub (`TrackCode`, then display/config/name fallbacks). Unknown/blank keys short-circuit all marker handling.【F:PitEngine.cs†L629-L676】【F:PitEngine.cs†L821-L878】
-- **Defaults:** New tracks start **locked = true** with empty percents. Lock can be toggled via UI or actions; lock state is persisted with the markers.【F:PitEngine.cs†L586-L600】【F:PitEngine.cs†L968-L1034】
+- **Embedded seed support:** If the persisted store does not exist yet, `PitEngine` seeds defaults from an embedded in-code track-marker set. Only records with valid seeded entry and exit percents are accepted; invalid / `NaN` / incomplete entries are skipped rather than coerced. The shipped embedded rows also carry fixed stored timestamps, so first-run seeded JSON stays deterministic instead of picking up the current clock time.【F:PitEngine.cs†L1046-L1148】
+- **Defaults after seeding:** New tracks still start **locked = true** with empty percents when no valid embedded seed entry exists for that track. Lock can be toggled via UI or actions; lock state is persisted with the markers.【F:PitEngine.cs†L586-L600】【F:PitEngine.cs†L968-L1034】
 
 ## Inputs and guards
 - **Track length:** Parsed once per session from `WeekendInfo.TrackLength` (kilometres). Values outside **500–20000 m** are ignored.【F:PitEngine.cs†L126-L154】【F:PitEngine.cs†L669-L676】

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -118,6 +118,11 @@
                                          Margin="0,10,0,0"
                                          IsChecked="{Binding Settings.EnableSoftDebug, Mode=TwoWay}"
                                          ToolTip="Master toggle that enables debug UI and debug processing."/>
+                <TextBlock Margin="0,6,0,0"
+                           Foreground="LightGray"
+                           Opacity="0.9"
+                           TextWrapping="Wrap"
+                           Text="Debug mode is for troubleshooting only. Leave this off unless asked to enable it."/>
                 <Expander Header="Debug Options"
                           Margin="0,10,0,0"
                           IsExpanded="{Binding ElementName=DebugMasterToggle, Path=IsChecked}"

--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -1043,6 +1043,73 @@ namespace LaunchPlugin
             return Path.Combine(GetTrackMarkersFolderPath(), "LalaPlugin.TrackMarkers.json");
         }
 
+        private bool TryLoadEmbeddedTrackMarkerSeed(out Dictionary<string, TrackMarkerRecord> seededStore)
+        {
+            seededStore = new Dictionary<string, TrackMarkerRecord>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                AddEmbeddedTrackMarkerSeed(seededStore, "daytona 2011 road-Road Course", 0.9584953784942627, 0.09854353964328766, "2026-01-14T00:04:41.3335024Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "watkinsglen 2021 fullcourse-Boot", 0.9533379673957825, 0.040650948882102966, "2026-01-15T23:07:47.4212531Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "algarve gp-Grand Prix", 0.9851894974708557, 0.08810660988092422, "2026-01-20T19:52:37.8166586Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "roadatlanta full-Full Course", 0.9852728247642517, 0.08843562006950378, "2026-01-21T00:48:42.6644141Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "mugello gp-Grand Prix", 0.9445547461509705, 0.019067654386162758, "2026-01-21T01:32:25.8272175Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "miami gp-Grand Prix", 0.9884277582168579, 0.04780568927526474, "2026-01-22T23:04:00.7833623Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "monza full", 0.9825137257575989, 0.05763554945588112, "2026-02-02T21:07:23.8858139Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "monza combinedchicanes", 0.9900556802749634, 0.03306782245635986, "2026-02-02T23:31:27.7140271Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "virginia 2022 full-Full Course", 0.9302977919578552, 0.965314, "2026-02-10T20:02:44.9859779Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "spielberg gp-Grand Prix", 0.9823088049888611, 0.06598767638206482, "2026-02-13T21:04:01.5303566Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "imola gp", 0.932594358921051, 0.04608271270990372, "2026-02-10T10:17:17.4874821Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "sebring international-International", 0.9727578163146973, 0.048124514520168304, "2026-02-10T12:59:39.2462415Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "nurburgring gp", 0.9878191351890564, 0.062147799879312515, "2026-02-24T20:37:51.7901529Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "misano gp-Grand Prix", 0.9494248628616333, 0.07366493344306946, "2026-03-03T19:36:36.386349Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "hockenheim gp-Grand Prix", 0.98753821849823, 0.05686870589852333, "2026-03-17T23:46:11.5231502Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "okayama full", 0.9196758270263672, 0.003685770323500037, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "silverstone 2019 gp", 0.942277193069458, 0.06540275365114212, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "donington gp", 0.978685736656189, 0.04303457960486412, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "tsukuba 2kfull", 0.9532710313796997, 0.061123888939619064, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "fuji gp", 0.9919514060020447, 0.10028695315122604, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "spa 2024 up", 0.9877252578735352, 0.04072536528110504, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "zandvoort 2023 gp", 0.9934133887290955, 0.049291037023067474, "2026-03-22T00:00:00Z", true);
+                AddEmbeddedTrackMarkerSeed(seededStore, "lemans full", 0.9897839426994324, 0.027248606085777283, "2026-03-22T00:00:00Z", true);
+
+                SimHub.Logging.Current.Info($"[LalaPlugin:TrackMarkers] embedded seed load ok ({seededStore.Count} track(s))");
+                return seededStore.Count > 0;
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn($"[LalaPlugin:TrackMarkers] embedded seed load fail err='{ex.Message}'");
+                seededStore.Clear();
+                return false;
+            }
+        }
+
+        private void AddEmbeddedTrackMarkerSeed(
+            Dictionary<string, TrackMarkerRecord> seededStore,
+            string key,
+            double entryPctRaw,
+            double exitPctRaw,
+            string lastUpdatedUtc,
+            bool locked)
+        {
+            string normalizedKey = NormalizeTrackKey(key);
+            if (string.IsNullOrWhiteSpace(normalizedKey))
+                return;
+
+            double entryPct = NormalizeTrackPercent(entryPctRaw);
+            double exitPct = NormalizeTrackPercent(exitPctRaw);
+            if (!IsValidPct(entryPct) || !IsValidPct(exitPct))
+                return;
+
+            seededStore[normalizedKey] = new TrackMarkerRecord
+            {
+                PitEntryTrkPct = entryPct,
+                PitExitTrkPct = exitPct,
+                LastUpdatedUtc = string.IsNullOrWhiteSpace(lastUpdatedUtc) ? DateTime.UtcNow.ToString("o") : lastUpdatedUtc,
+                Locked = locked
+            };
+        }
+
         private bool TryLoadTrackMarkerStore(out Dictionary<string, TrackMarkerRecord> loadedStore)
         {
             loadedStore = new Dictionary<string, TrackMarkerRecord>(StringComparer.OrdinalIgnoreCase);
@@ -1065,6 +1132,15 @@ namespace LaunchPlugin
 
                 if (!File.Exists(path))
                 {
+                    if (TryLoadEmbeddedTrackMarkerSeed(out var seededStore))
+                    {
+                        loadedStore = seededStore;
+                        var seededJson = JsonConvert.SerializeObject(loadedStore, Formatting.Indented);
+                        File.WriteAllText(newPath, seededJson);
+                        SimHub.Logging.Current.Info($"[LalaPlugin:TrackMarkers] load seeded ({loadedStore.Count} track(s)) path='{path}'");
+                        return true;
+                    }
+
                     SimHub.Logging.Current.Info($"[LalaPlugin:TrackMarkers] load (new) path='{path}'");
                     return true;
                 }

--- a/PresetsManagerView.xaml
+++ b/PresetsManagerView.xaml
@@ -27,6 +27,8 @@
         <SolidColorBrush x:Key="PresetManagerInputBackgroundBrush" Color="#171A20"/>
         <SolidColorBrush x:Key="PresetManagerInputBorderBrush" Color="#566171"/>
         <SolidColorBrush x:Key="PresetManagerComboItemHoverBrush" Color="#2F3743"/>
+        <SolidColorBrush x:Key="PresetManagerComboButtonBrush" Color="#20252D"/>
+        <SolidColorBrush x:Key="PresetManagerComboPopupBrush" Color="#171A20"/>
 
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
@@ -51,6 +53,75 @@
             <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
             <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
             <Setter Property="BorderBrush" Value="{StaticResource PresetManagerInputBorderBrush}"/>
+            <Setter Property="Padding" Value="8,3,30,3"/>
+            <Setter Property="SnapsToDevicePixels" Value="True"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <Border x:Name="OuterBorder"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="3"
+                                    SnapsToDevicePixels="True"/>
+                            <Grid Margin="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="28"/>
+                                </Grid.ColumnDefinitions>
+
+                                <ContentPresenter Grid.Column="0"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  HorizontalAlignment="Left"
+                                                  VerticalAlignment="Center"
+                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                  RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+
+                                <Border Grid.Column="1"
+                                        Background="{StaticResource PresetManagerComboButtonBrush}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="1,0,0,0"
+                                        CornerRadius="0,3,3,0">
+                                    <Path HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Fill="{StaticResource PresetManagerPrimaryTextBrush}"
+                                          Data="M 0 0 L 4 4 L 8 0 Z"/>
+                                </Border>
+
+                                <Popup x:Name="PART_Popup"
+                                       Placement="Bottom"
+                                       AllowsTransparency="True"
+                                       Focusable="False"
+                                       IsOpen="{TemplateBinding IsDropDownOpen}"
+                                       PopupAnimation="Slide">
+                                    <Border Margin="0,4,0,0"
+                                            MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                            Background="{StaticResource PresetManagerComboPopupBrush}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="3">
+                                        <ScrollViewer SnapsToDevicePixels="True">
+                                            <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </ScrollViewer>
+                                    </Border>
+                                </Popup>
+                            </Grid>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="OuterBorder" Property="Opacity" Value="0.6"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
 
         <Style TargetType="ComboBoxItem">

--- a/RacePresetStore.cs
+++ b/RacePresetStore.cs
@@ -24,7 +24,6 @@ namespace LaunchPlugin
 
         private const string NewFileName = "RacePresets.json";
         private const string LegacyFileName = "LalaLaunch.RacePresets.json";
-
         public static string GetFolderPath()
         {
             return PluginStorage.GetPluginFolder();
@@ -128,7 +127,7 @@ namespace LaunchPlugin
         }
 
         /// <summary>
-        /// Simple default set to prove the plumbing. Adjust values later.
+        /// Embedded shipped defaults for first-run preset seeding.
         /// </summary>
         public static List<RacePreset> DefaultPresets()
         {
@@ -136,34 +135,77 @@ namespace LaunchPlugin
             {
                 new RacePreset
                 {
-                    Name = "IMSA 40m (1 stop window)",
+                    Name = "IMSA 40m",
                     Type = RacePresetType.TimeLimited,
                     RaceMinutes = 40,
-                    MandatoryStopRequired = false,
-                    TireChangeTimeSec = 0,        // 0 = no planned tyre change
-                    MaxFuelPercent = 100,         // percent of base tank
+                    RaceLaps = null,
+                    PreRaceMode = 1,
+                    TireChangeTimeSec = 0.0,
+                    MaxFuelPercent = 49.8,
                     ContingencyInLaps = true,
-                    ContingencyValue = 1.0
+                    ContingencyValue = 1.9047486670090663
                 },
                 new RacePreset
                 {
-                    Name = "Sprint 25m (no stop)",
+                    Name = "Sprint 20m",
                     Type = RacePresetType.TimeLimited,
-                    RaceMinutes = 25,
-                    MandatoryStopRequired = false,
-                    TireChangeTimeSec = 0,
-                    MaxFuelPercent = 100,
+                    RaceMinutes = 20,
+                    RaceLaps = null,
+                    PreRaceMode = 3,
+                    TireChangeTimeSec = 0.0,
+                    MaxFuelPercent = null,
+                    LegacyMaxFuelLitres = 55.079360442729552,
                     ContingencyInLaps = true,
-                    ContingencyValue = 0.5
+                    ContingencyValue = 1.5
                 },
                 new RacePreset
                 {
                     Name = "Fixed 30 Laps",
                     Type = RacePresetType.LapLimited,
+                    RaceMinutes = null,
                     RaceLaps = 30,
-                    MandatoryStopRequired = false,
-                    TireChangeTimeSec = 0,
-                    MaxFuelPercent = 100,
+                    PreRaceMode = 3,
+                    TireChangeTimeSec = 0.0,
+                    MaxFuelPercent = null,
+                    LegacyMaxFuelLitres = 110.0,
+                    ContingencyInLaps = true,
+                    ContingencyValue = 1.0
+                },
+                new RacePreset
+                {
+                    Name = "Thursday SRi League",
+                    Type = RacePresetType.TimeLimited,
+                    RaceMinutes = 60,
+                    RaceLaps = null,
+                    PreRaceMode = 1,
+                    TireChangeTimeSec = 0.0,
+                    MaxFuelPercent = 70.0,
+                    ContingencyInLaps = true,
+                    ContingencyValue = 1.4331941999189148
+                },
+                new RacePreset
+                {
+                    Name = "24 Hours Endurance",
+                    Type = RacePresetType.TimeLimited,
+                    RaceMinutes = 1440,
+                    RaceLaps = null,
+                    PreRaceMode = 3,
+                    TireChangeTimeSec = 23.231592413663829,
+                    MaxFuelPercent = null,
+                    LegacyMaxFuelLitres = 119.89939586875516,
+                    ContingencyInLaps = true,
+                    ContingencyValue = 1.0
+                },
+                new RacePreset
+                {
+                    Name = "6 Hour GT3 Endurance",
+                    Type = RacePresetType.TimeLimited,
+                    RaceMinutes = 360,
+                    RaceLaps = null,
+                    PreRaceMode = 2,
+                    TireChangeTimeSec = 23.0,
+                    MaxFuelPercent = null,
+                    LegacyMaxFuelLitres = 110.0,
                     ContingencyInLaps = true,
                     ContingencyValue = 1.0
                 }


### PR DESCRIPTION
### Motivation
- Polish release-facing UI and first-run behaviour to reduce accidental debug use and improve dark-theme readability for the Preset Manager.
- Make short Dash Control column headers fit the matrix while retaining unambiguous mapping back to the underlying dash families.
- Ensure the package ships deterministic first-run data for presets and track markers so users have sensible seeded defaults without external files.

### Description
- Shortened Dash Visibility column headers from long labels to `DRIVER`, `STRATEGY`, and `OVERLAY` and added explicit header tooltips and per-cell tooltips in `DashesTabView.xaml` to keep the UI compact while preserving meaning. 
- Added a troubleshooting-only warning text under the master debug toggle in `GlobalSettingsView.xaml`. 
- Implemented an explicit dark-themed `ComboBox` control template and related brushes in `PresetsManagerView.xaml` so the `PreRace Mode` selector and combo content remain readable in dark mode. 
- Embedded shipped default presets in `RacePresetStore.DefaultPresets()` and updated several preset definitions (shortened preset names, added additional presets and adjusted fields) so the plugin seeds a usable preset set on first run. 
- Added an embedded track-marker seed loader to `PitEngine.cs` (`TryLoadEmbeddedTrackMarkerSeed` and `AddEmbeddedTrackMarkerSeed`) that seeds `TrackMarkers.json` from an in-code table only when no persisted store exists, skips invalid entries, and writes deterministic fixed timestamps for seeded rows. 
- Updated documentation and changelog (`CHANGELOG.md`, `Docs/*`, `Docs/Internal/Plugin_UI_Tooltips.md`, `Docs/RepoStatus.md`, etc.) to describe the UI changes, embedded defaults, and release notes for v1.1.

### Testing
- Built the solution locally with `msbuild`/`dotnet build` to validate the XAML and C# changes and the build completed successfully. 
- Verified first-run seeding code paths by exercising the track-marker and preset store load paths in a development environment to confirm seeded JSON is written when no persisted file exists. 
- No automated unit tests were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c013aa7fac832fb3a55f2b0dc933df)