### PR TITLE
Fix Preset Manager combo behavior and popup stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,5 +57,6 @@ Main user-facing changes since the late-February documentation baseline include:
 
 - Shortened Dash Control visibility column labels to **`DRIVER`**, **`STRATEGY`**, and **`OVERLAY`** while keeping tooltip wording explicit.
 - Added a release-facing warning below the debug-mode master toggle so troubleshooting features are less likely to be left on accidentally.
-- Kept Strategy preset editing in the existing Preset Manager popup but fixed the dark-theme combo-box readability issue for the `PreRace Mode` selector.
+- Fixed the Preset Manager `PreRace Mode` selector by reusing the same working ComboBox behavior as the main Strategy tab, restoring normal dropdown interaction while keeping dark-theme readability.
+- Hardened the Strategy `Presets...` modal open flow against null preset entries and open-time popup failures so the editor no longer hard-fails as easily.
 - Embedded the shipped preset defaults and expanded track-marker defaults directly in the owning code paths so the repo/package ships with the intended first-run data, including the shorter `IMSA 40m` / `Sprint 20m` preset names and additional seeded tracks.

--- a/Docs/Internal/Plugin_UI_Tooltips.md
+++ b/Docs/Internal/Plugin_UI_Tooltips.md
@@ -146,7 +146,7 @@ Branch: work
 - L289: Rename the selected preset using the name box.
 - L301: Revert edits to the last saved preset values.
 - L303: Save edits to the selected preset.
-- The `PreRace Mode` combo now uses an explicit dark popup/control template so the selected value and dropdown list remain readable against the plugin’s dark theme.
+- The `PreRace Mode` combo now reuses the same standard ComboBox interaction pattern as the main Strategy tab while keeping the selected value readable against the plugin’s dark theme.
 
 ## ProfilesManagerView.xaml
 - L22: Manage car profiles stored on disk.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,25 +9,20 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Completed a release-polish pass covering Dash Control visibility labels/tooltips, the debug-mode warning copy, Preset Manager combo-box readability, and embedded shipped defaults for presets/track markers.
-- Updated both canonical subsystem docs and user-facing docs so the short dash labels map clearly back to **Lala Race Dash**, **Lala Strategy Dash**, and **overlay surfaces**.
-- Documented that shipped preset defaults and the expanded embedded track-marker defaults now live directly in the owning code paths, with invalid marker entries excluded rather than normalized into fake values and the newly added marker rows carrying fixed embedded timestamps for deterministic first-run seeding.
-- Kept scope inside the existing Dash Integration, Fuel Planner / Strategy, Track Markers, and Settings/UI ownership boundaries without changing fuel math, learning, Shift Assist logic, CarSA, H2H, or telemetry gating.
+- Fixed the Preset Manager `PreRace Mode` combo by removing the fragile custom popup template and reusing the same standard ComboBox interaction pattern already working on the main Strategy page.
+- Hardened the Strategy `Presets...` popup open path so null preset entries are skipped before binding and open-time failures are caught/logged instead of bubbling out as a host-level hard fail.
+- Kept scope inside the existing Fuel Planner / Strategy and Settings/UI ownership boundaries without changing fuel math, learning, Shift Assist logic, CarSA, H2H, track-marker behavior, or telemetry gating.
 
 ## Reviewed documentation set
 ### Changed in this sweep
 - `CHANGELOG.md`
-- `DashesTabView.xaml`
-- `GlobalSettingsView.xaml`
+- `FuelCalculatorView.xaml.cs`
+- `FuelCalcs.cs`
 - `PresetsManagerView.xaml`
-- `RacePresetStore.cs`
-- `PitEngine.cs`
+- `PresetsManagerView.xaml.cs`
 - `Docs/Internal/Plugin_UI_Tooltips.md`
-- `Docs/Subsystems/Dash_Integration.md`
 - `Docs/Subsystems/Fuel_Planner_Tab.md`
-- `Docs/Subsystems/Track_Markers.md`
 - `Docs/Strategy_System.md`
-- `Docs/Dashboards.md`
 - `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
@@ -35,6 +30,7 @@ Branch: work
 - `Docs/Project_Index.md`
 - `Docs/Quick_Start.md`
 - `Docs/User_Guide.md`
+- `Docs/Dashboards.md`
 - `Docs/Shift_Assist.md`
 - `Docs/Launch_System.md`
 - `Docs/Rejoin_Assist.md`
@@ -42,6 +38,9 @@ Branch: work
 - `Docs/H2H_System.md`
 - `Docs/Profiles_System.md`
 - `Docs/Fuel_Model.md`
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/SimHubLogMessages.md`
+- `Docs/Subsystems/Dash_Integration.md`
 - `Docs/Subsystems/Pit_Entry_Assist.md`
 - `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
 - `Docs/Subsystems/Rejoin_Assist.md`
@@ -49,15 +48,14 @@ Branch: work
 - `Docs/Subsystems/CarSA.md`
 - `Docs/Subsystems/H2H.md`
 - `Docs/Subsystems/Profiles_And_PB.md`
+- `Docs/Subsystems/Track_Markers.md`
 - `Docs/Subsystems/Trace_Logging.md`
 - `Docs/Subsystems/Message_System_V1.md`
 - `Docs/Subsystems/MessageEngineV1_Notes.md`
 
 ## Delivery status highlights
-- Dash Control now uses short release-facing visibility headers that still map clearly to the underlying dash families through updated tooltip and documentation wording.
-- The Settings debug section now carries an explicit troubleshooting-only warning next to the master toggle.
-- The Preset Manager popup now documents and implements a dark-theme combo-box fix rather than leaving the selection area dependent on the host theme.
-- Embedded default-shipping behavior for presets and track markers is now documented alongside the owning storage/runtime code paths.
+- The Preset Manager `PreRace Mode` selector now uses the same working ComboBox interaction model as the main Strategy tab, restoring normal open/select behavior while staying readable on the popup’s dark theme.
+- The Strategy `Presets...` modal open flow now skips null preset rows during binding and shows a logged warning dialog instead of hard-failing if window creation still throws.
 
 ## Validation note
-- Validation recorded against `HEAD` (`release polish pass for dash labels, debug warning, embedded defaults, track-marker seed filtering, and preset manager combo styling`).
+- Validation recorded against `HEAD` (`preset manager combo behavior and popup-open hardening`).

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -77,7 +77,7 @@ Presets are part of the Strategy workflow.
 - Choose a race preset from Strategy.
 - Open **`Presets...`** to create, rename, edit, save, or delete presets.
 - Return to Strategy to apply and use them.
-- The Preset Manager popup now keeps its combo-box selection readable against the dark theme instead of relying on a washed-out host default.
+- The Preset Manager popup now uses the same working ComboBox behavior as the main Strategy page, keeping the selected value readable against the dark theme without breaking dropdown selection.
 
 There is no separate top-level Presets tab.
 

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -14,7 +14,7 @@ The Fuel Planner (surfaced as the top-level **Strategy** tab in the plugin UI) i
 The planner does **not** replace the Fuel Model.  
 It consumes the Fuel Model’s **live snapshot** and produces **explicit planning outputs** that are stable unless the user changes them.
 
-Preset management remains part of the same subsystem, but it is no longer a separate top-level navigation tab. The Strategy tab keeps the inline `Race Preset` selector and opens the existing preset editor via a modal **Preset Manager** dialog beside that selector. The Preset Manager still owns preset editing only; this release-polish pass also keeps its `PreRace Mode` combo on an explicit dark theme so the selected value remains readable in the popup.
+Preset management remains part of the same subsystem, but it is no longer a separate top-level navigation tab. The Strategy tab keeps the inline `Race Preset` selector and opens the existing preset editor via a modal **Preset Manager** dialog beside that selector. The Preset Manager still owns preset editing only; its `PreRace Mode` combo now reuses the same standard WPF ComboBox pattern already working on the main Strategy page so the selected value stays readable without breaking normal dropdown interaction.
 
 Canonical references:
 - Fuel behaviour contract: `Docs/FuelProperties_Spec.md`
@@ -61,6 +61,7 @@ These are **authoritative** once set by the user:
 - **Race Preset selection**
   - The Strategy tab keeps the inline preset combo as the active apply/select control.
   - The adjacent `Presets...` button opens the modal Preset Manager for create/rename/delete/edit/save-current flows without introducing a second preset-editing path.
+  - Preset load/open paths now defensively skip null preset entries before binding the modal editor so malformed persisted rows do not hard-fail the popup open flow.
 
 ### Track-scoped planner persistence
 These planner inputs persist on the selected `TrackStats` record rather than on the car profile:

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2689,6 +2689,11 @@ namespace LaunchPlugin
 
         foreach (var preset in presets ?? Array.Empty<RacePreset>())
         {
+            if (preset == null)
+            {
+                continue;
+            }
+
             _availablePresets.Add(preset);
         }
     }

--- a/FuelCalculatorView.xaml.cs
+++ b/FuelCalculatorView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 namespace LaunchPlugin
 {
@@ -42,14 +43,27 @@ namespace LaunchPlugin
                     MinHeight = 620,
                     ResizeMode = ResizeMode.CanResize,
                     Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x1F, 0x23, 0x2B)),
-                    WindowStartupLocation = owner != null ? WindowStartupLocation.CenterOwner : WindowStartupLocation.CenterScreen,
-                    Owner = owner,
+                    WindowStartupLocation = owner != null && owner.IsVisible ? WindowStartupLocation.CenterOwner : WindowStartupLocation.CenterScreen,
                     ShowInTaskbar = false
                 };
+
+                if (owner != null && owner.IsVisible)
+                {
+                    dialog.Owner = owner;
+                }
 
                 presetManager.Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x1F, 0x23, 0x2B));
 
                 dialog.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Error("[LalaPlugin:Fuel Burn] Failed to open Preset Manager: " + ex.Message);
+                MessageBox.Show(
+                    "Unable to open the Preset Manager. See SimHub logs for details.",
+                    "Preset Manager",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
             }
             finally
             {

--- a/PresetsManagerView.xaml
+++ b/PresetsManagerView.xaml
@@ -27,8 +27,6 @@
         <SolidColorBrush x:Key="PresetManagerInputBackgroundBrush" Color="#171A20"/>
         <SolidColorBrush x:Key="PresetManagerInputBorderBrush" Color="#566171"/>
         <SolidColorBrush x:Key="PresetManagerComboItemHoverBrush" Color="#2F3743"/>
-        <SolidColorBrush x:Key="PresetManagerComboButtonBrush" Color="#20252D"/>
-        <SolidColorBrush x:Key="PresetManagerComboPopupBrush" Color="#171A20"/>
 
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
@@ -49,82 +47,15 @@
             <Setter Property="CaretBrush" Value="White"/>
         </Style>
 
-        <Style TargetType="ComboBox">
+        <Style x:Key="PresetManagerComboBoxStyle" TargetType="ComboBox">
             <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
             <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
             <Setter Property="BorderBrush" Value="{StaticResource PresetManagerInputBorderBrush}"/>
-            <Setter Property="Padding" Value="8,3,30,3"/>
+            <Setter Property="Padding" Value="4,2"/>
             <Setter Property="SnapsToDevicePixels" Value="True"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ComboBox">
-                        <Grid>
-                            <Border x:Name="OuterBorder"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="3"
-                                    SnapsToDevicePixels="True"/>
-                            <Grid Margin="0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="28"/>
-                                </Grid.ColumnDefinitions>
-
-                                <ContentPresenter Grid.Column="0"
-                                                  Margin="{TemplateBinding Padding}"
-                                                  HorizontalAlignment="Left"
-                                                  VerticalAlignment="Center"
-                                                  Content="{TemplateBinding SelectionBoxItem}"
-                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                                  RecognizesAccessKey="True"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-
-                                <Border Grid.Column="1"
-                                        Background="{StaticResource PresetManagerComboButtonBrush}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="1,0,0,0"
-                                        CornerRadius="0,3,3,0">
-                                    <Path HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"
-                                          Fill="{StaticResource PresetManagerPrimaryTextBrush}"
-                                          Data="M 0 0 L 4 4 L 8 0 Z"/>
-                                </Border>
-
-                                <Popup x:Name="PART_Popup"
-                                       Placement="Bottom"
-                                       AllowsTransparency="True"
-                                       Focusable="False"
-                                       IsOpen="{TemplateBinding IsDropDownOpen}"
-                                       PopupAnimation="Slide">
-                                    <Border Margin="0,4,0,0"
-                                            MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
-                                            Background="{StaticResource PresetManagerComboPopupBrush}"
-                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                            BorderThickness="1"
-                                            CornerRadius="3">
-                                        <ScrollViewer SnapsToDevicePixels="True">
-                                            <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                        </ScrollViewer>
-                                    </Border>
-                                </Popup>
-                            </Grid>
-                        </Grid>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="OuterBorder" Property="Opacity" Value="0.6"/>
-                            </Trigger>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
         </Style>
 
-        <Style TargetType="ComboBoxItem">
+        <Style x:Key="PresetManagerComboBoxItemStyle" TargetType="ComboBoxItem">
             <Setter Property="Foreground" Value="{StaticResource PresetManagerPrimaryTextBrush}"/>
             <Setter Property="Background" Value="{StaticResource PresetManagerInputBackgroundBrush}"/>
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
@@ -327,9 +258,8 @@
                         <TextBlock Text="PreRace Mode" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,16,0"
                                    ToolTip="Preset PreRace mode for on-grid outputs only. It is persisted with the preset and affects LalaLaunch.PreRace.* outputs, not planner calculations."/>
                         <ComboBox Width="170"
-                                  Foreground="{StaticResource PresetManagerPrimaryTextBrush}"
-                                  Background="{StaticResource PresetManagerInputBackgroundBrush}"
-                                  BorderBrush="{StaticResource PresetManagerInputBorderBrush}"
+                                  Style="{StaticResource PresetManagerComboBoxStyle}"
+                                  ItemContainerStyle="{StaticResource PresetManagerComboBoxItemStyle}"
                                   VerticalAlignment="Center"
                                   SelectedValuePath="Tag"
                                   SelectedValue="{Binding PreRaceMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/PresetsManagerView.xaml.cs
+++ b/PresetsManagerView.xaml.cs
@@ -107,14 +107,14 @@ namespace LaunchPlugin
             if (active != null)
             {
                 var activeMatch = presets.FirstOrDefault(x =>
-                    string.Equals(x.Name, active.Name, StringComparison.OrdinalIgnoreCase));
+                    x != null && string.Equals(x.Name, active.Name, StringComparison.OrdinalIgnoreCase));
                 if (activeMatch != null)
                 {
                     return activeMatch;
                 }
             }
 
-            return presets.FirstOrDefault();
+            return presets.FirstOrDefault(x => x != null);
         }
 
         private void OnVmPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Motivation
- The Preset Manager used a fragile custom ComboBox ControlTemplate to get dark-theme readability which broke normal dropdown interaction and prevented selection changes.
- Opening the `Presets...` modal could hard-fail when malformed/null preset rows existed or when the owner window was not in a safe state, causing occasional crash/host-level failures.

### Description
- Replaced the Preset Manager’s custom ComboBox ControlTemplate with a scoped style-only approach that reuses the standard WPF ComboBox interaction pattern used on the main Strategy page, and applied an ItemContainerStyle for consistent dark-theme item rendering (`PresetsManagerView.xaml`).
- Removed brittle popup-template-specific brushes and kept only style-level visual brushes so dropdown behavior returns to the proven standard WPF model (`PresetsManagerView.xaml`).
- Hardened preset loading and selection by skipping null entries in `ReplacePresetCollection` and when resolving the initial editor selection (`FuelCalcs.cs` and `PresetsManagerView.xaml.cs`).
- Made the `Presets...` modal open path more robust by only assigning `Owner` when visible and wrapping `ShowDialog()` creation in a try/catch that logs the error and shows a friendly message box instead of letting exceptions bubble up (`FuelCalculatorView.xaml.cs`).
- Updated user and subsystem docs, tooltips, changelog, and `Docs/RepoStatus.md` to reflect the restored ComboBox behavior and the popup stability fixes (`Docs/*`, `CHANGELOG.md`).

### Testing
- Ran XAML parse check for `PresetsManagerView.xaml` which succeeded (`ElementTree.parse` returned OK).
- Performed repository checks (`git diff --check`) and file-read validations for changed files which succeeded.
- Attempted to run a build with `dotnet build` and `msbuild` but both were unavailable in this environment (commands failed due to missing toolchain), so no compiled binary smoke test was possible here.
- No automated UI/runtime SimHub tests were available in this environment, so runtime click-level verification is recommended as the final manual smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03a2fe344832f835a03eb68cb56cb)