### PR TITLE
docs: add optional ShakeIt Motors `TractionLoss` setup to Quick Start & User Guide

### DIFF
--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -38,6 +38,20 @@ Typical layout:
 
 Dashboards display plugin outputs. They do not learn data or replace the plugin as the source of truth. For dashboard-specific guidance, see [Dashboards](Dashboards.md).
 
+### Optional: ShakeIt Motors traction-loss export
+
+Some Lala dashboards and launch-related visuals can show wheelspin / traction-loss indications from SimHub's ShakeIt Motors output. This setup is **optional**. The plugin still works normally without it.
+
+If you want those indicators:
+
+1. Open **SimHub**.
+2. Go to **ShakeIt Motors**.
+3. Open the **Wheel slip** effect and enable it.
+4. In the **Export** section, tick **Export output value as a property**.
+5. Set the property name to exactly `TractionLoss`.
+
+That exposes `[ShakeITMotorsV3Plugin.Export.TractionLoss.All]` for dashboards or visuals that use it. Without this setup, wheelspin-related indicators may be unavailable.
+
 ## 4. First plugin check
 
 Open the plugin in SimHub and confirm the main navigation order:

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -2,8 +2,6 @@
 
 This guide is the central driver-facing overview for Lala Race Assist Plugin. It explains what the plugin owns, what the driver sees, and where to find the detailed user pages for each system.
 
-> **Scope note:** The future/global message system is not operational yet and is intentionally not documented here as an active user feature. Radio Messages can still be treated as current dashboard behavior where supported.
-
 ## 1. How to read the docs
 
 Use this page as the overview, then jump to the dedicated pages for the systems you actively use:
@@ -76,6 +74,19 @@ The fuel model learns gradually, builds confidence, and feeds Strategy with a tr
 ### Dashboards
 
 Dashboards are the display layer. They show outputs, visibility states, and context, but they do not own the calculations underneath. See [Dashboards](Dashboards.md).
+
+#### Optional: ShakeIt Motors traction-loss export
+
+Some Lala dashboards and launch/practice visuals can use SimHub's ShakeIt Motors output for wheelspin / traction-loss indications. This is **optional** and is not a core plugin requirement. If you do nothing here, the plugin still works normally.
+
+Set it up only if you want those specific indicators:
+
+1. Open **SimHub** and go to **ShakeIt Motors**.
+2. Open the **Wheel slip** effect and enable it.
+3. In the effect's **Export** section, tick **Export output value as a property**.
+4. Set the property name to exactly `TractionLoss`.
+
+This exposes `[ShakeITMotorsV3Plugin.Export.TractionLoss.All]`. Dashboards or visuals that read that property can then show wheelspin / traction-loss activity. Without this setup, those indicators may be unavailable while the rest of the plugin continues to operate normally.
 
 ### Shift Assist
 


### PR DESCRIPTION
### Motivation

- Document an optional SimHub ShakeIt Motors setup so Lala dashboards and launch/practice visuals can show wheelspin / traction-loss indications when available. 
- Make clear this is optional, describe the exact exported property (`TractionLoss`) and resulting property path, and ensure users know the plugin still works normally without the setup.

### Description

- Added a short optional setup section to `Docs/Quick_Start.md` with step-by-step instructions to enable the ShakeIt Motors Wheel slip effect and export the output as a property named `TractionLoss`.
- Added a fuller, user-facing explanation to `Docs/User_Guide.md` that repeats the steps, clarifies the setup is optional, and documents that it exposes `[ShakeITMotorsV3Plugin.Export.TractionLoss.All]` for dashboards/visuals that read it.
- Emphasised that the setup only affects wheelspin / traction-loss indicators on certain dashboards or launch/practice visuals and is not a core plugin requirement. 
- Removed a one-line outdated scope note near the top of `Docs/User_Guide.md` as a small cleanup.

### Testing

- Reviewed the diffs for `Docs/Quick_Start.md` and `Docs/User_Guide.md` with `git diff` and inspected the inserted content. 
- Committed the documentation changes and verified there are no whitespace or diff-check issues via `git diff --check` which returned clean. 
- Confirmed repository state with `git status --short` showing the changes were committed. 
- No code changes were made and no unit tests were required for this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c172a55b68832fb1b8b671154c1c40)