### PR TITLE
docs: place release screenshots in user docs

### DIFF
--- a/Docs/Dashboards.md
+++ b/Docs/Dashboards.md
@@ -15,6 +15,9 @@ Dashboards are the display surface for the plugin. They help the driver see:
 
 The dashboards are not the source of truth for learning, storage, strategy math, or saved decisions.
 
+![Driver race dashboard](Images/DriverDashRacingOpp.png)
+*Use the race dash for fast awareness while the plugin continues to own the calculations underneath.*
+
 ## 2. Typical dashboard roles
 
 A common setup includes:
@@ -23,6 +26,9 @@ A common setup includes:
 - a **strategy/support dash** for deeper planning context,
 - an **overlay** for compact alerts,
 - optional **Lovely-based layouts** when using that ecosystem.
+
+![Strategy dashboard main page](Images/StrategyDashMainPageGrid.png)
+*Keep deeper fuel and stint detail on a support surface instead of overloading the main race dash.*
 
 ## 3. What the driver controls
 
@@ -49,6 +55,9 @@ In the Dash Visibility matrix, the short release-facing headers are:
 - **DRIVER** = Lala Race Dash
 - **STRATEGY** = Lala Strategy Dash
 - **OVERLAY** = overlay surfaces
+
+![Dash visibility options](Images/DashVisibilityOptions.png)
+*Use Dash Control to decide what is shown where, not to change how the plugin calculates it.*
 
 Do **not** use Dash Control as the mental home for strategy, launch logic, or saved profile learning.
 
@@ -77,6 +86,9 @@ Pit and rejoin surfaces are some of the most practically useful dashboard pages.
 - Rejoin alerts support decision-making, but they do not replace driver judgment.
 - If these surfaces are repeatedly wrong, the normal fix is profile or saved-data review rather than dash redesign.
 
+![Pit entry assist dash](Images/PitEntryAssist.png)
+*Pit entry cues are a good example of the dash presenting a live aid without becoming the owner of the underlying marker and timing logic.*
+
 For the feature-specific guidance, see [Rejoin Assist](Rejoin_Assist.md) and [Pit Assist](Pit_Assist.md).
 
 ## 7. H2H on dashboards
@@ -87,6 +99,15 @@ Supported dashboards may show:
 - **H2H Track** for same-class nearby on-track comparisons
 
 The dash shows them; the plugin owns the comparison outputs. See [H2H System](H2H_System.md).
+
+![H2H overlay](Images/Head2HeadOverlay.png)
+*H2H is there to improve race awareness on the dash, not to create a second planning workflow.*
+
+### Tagged drivers and Friends list
+
+If you want certain drivers to stand out more clearly, use **Settings → Friends List** in the plugin and add their iRacing customer IDs with the tag you want to apply.
+
+For most users, the practical effect is on **awareness styling** in supported nearby-car / CarSA-style dashboard surfaces: tagged drivers can be easier to spot as **Friend**, **Teammate**, or **Bad**. Treat this as a presentation aid, not as something that changes strategy or core H2H ownership.
 
 ## 8. Practical layout advice
 

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -15,7 +15,7 @@ Lala Race Assist Plugin is a SimHub plugin for **iRacing** that helps the driver
 
 ## 2. Install
 
-Go to the bottom left of the left menu and click"Add/Remove Features". Find the Lala Plugin and activate it and click show in left menu option.
+Go to the bottom left of the left menu and click "Add/Remove Features". Find the Lala Plugin, activate it, and enable the show-in-left-menu option.
 
 ### Required for now
 
@@ -61,6 +61,9 @@ Open the plugin in SimHub and confirm the main navigation order:
 3. **Dash Control**
 4. **Launch Analysis**
 5. **Settings**
+
+![Strategy tab after install](Images/StrategyTab.png)
+*After install, Strategy should be the first main tab you land on and the main place to start planning.*
 
 Important current rules:
 

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-03-22
+Last updated: 2026-03-23
 Branch: work
 
 ## Current repo/link status
@@ -9,53 +9,42 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Fixed the Preset Manager `PreRace Mode` combo by removing the fragile custom popup template and reusing the same standard ComboBox interaction pattern already working on the main Strategy page.
-- Hardened the Strategy `Presets...` popup open path so null preset entries are skipped before binding and open-time failures are caught/logged instead of bubbling out as a host-level hard fail.
-- Kept scope inside the existing Fuel Planner / Strategy and Settings/UI ownership boundaries without changing fuel math, learning, Shift Assist logic, CarSA, H2H, track-marker behavior, or telemetry gating.
+- Performed a documentation-only screenshot placement pass across the main GitHub-facing user docs using the already-added repo image assets.
+- Added a concise, release-focused Friends List / driver-tag explanation in the existing driver-facing docs where it most naturally affects dashboard awareness.
+- Kept scope limited to markdown updates only: no runtime behavior, dashboard assets, plugin UI, or image files were changed.
+- Preserved the current release-facing boundaries: Launch Analysis remains active, Launch setup still lives under Settings, and the future/global Messaging System and Race Summary are still not documented as active user features.
 
 ## Reviewed documentation set
 ### Changed in this sweep
-- `CHANGELOG.md`
-- `FuelCalculatorView.xaml.cs`
-- `FuelCalcs.cs`
-- `PresetsManagerView.xaml`
-- `PresetsManagerView.xaml.cs`
-- `Docs/Internal/Plugin_UI_Tooltips.md`
-- `Docs/Subsystems/Fuel_Planner_Tab.md`
-- `Docs/Strategy_System.md`
-- `Docs/RepoStatus.md`
-
-### Reviewed and left unchanged
 - `README.md`
-- `Docs/Project_Index.md`
 - `Docs/Quick_Start.md`
 - `Docs/User_Guide.md`
 - `Docs/Dashboards.md`
+- `Docs/RepoStatus.md`
+
+### Reviewed and left unchanged
+- `Docs/Project_Index.md`
+- `Docs/Strategy_System.md`
+- `Docs/H2H_System.md`
+- `Docs/Profiles_System.md`
+- `Docs/Fuel_Model.md`
 - `Docs/Shift_Assist.md`
 - `Docs/Launch_System.md`
 - `Docs/Rejoin_Assist.md`
 - `Docs/Pit_Assist.md`
-- `Docs/H2H_System.md`
-- `Docs/Profiles_System.md`
-- `Docs/Fuel_Model.md`
-- `Docs/Internal/SimHubParameterInventory.md`
-- `Docs/Internal/SimHubLogMessages.md`
-- `Docs/Subsystems/Dash_Integration.md`
-- `Docs/Subsystems/Pit_Entry_Assist.md`
-- `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
-- `Docs/Subsystems/Rejoin_Assist.md`
-- `Docs/Subsystems/Opponents.md`
+- `Docs/Internal/CODEX_CONTRACT.txt`
+- `Docs/Internal/Architecture_Guardrails.md`
+- `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
+- `Docs/Internal/Code_Snapshot.md`
 - `Docs/Subsystems/CarSA.md`
-- `Docs/Subsystems/H2H.md`
-- `Docs/Subsystems/Profiles_And_PB.md`
-- `Docs/Subsystems/Track_Markers.md`
-- `Docs/Subsystems/Trace_Logging.md`
-- `Docs/Subsystems/Message_System_V1.md`
-- `Docs/Subsystems/MessageEngineV1_Notes.md`
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/Plugin_UI_Tooltips.md`
 
 ## Delivery status highlights
-- The Preset Manager `PreRace Mode` selector now uses the same working ComboBox interaction model as the main Strategy tab, restoring normal open/select behavior while staying readable on the popup’s dark theme.
-- The Strategy `Presets...` modal open flow now skips null preset rows during binding and shows a logged warning dialog instead of hard-failing if window creation still throws.
+- README now uses a smaller landing-page image set focused on first-impression systems rather than trying to show every dashboard surface.
+- Quick Start now includes a single setup-oriented screenshot to confirm the expected first plugin landing view without turning setup into a full visual manual.
+- User Guide and Dashboards now include a limited number of inline screenshots with short captions to clarify planning, profile trust, dashboard roles, and active Launch Analysis coverage.
+- Friends List / driver tags now have a short practical explanation for where users manage them and the dashboard-awareness effect they should expect.
 
 ## Validation note
-- Validation recorded against `HEAD` (`preset manager combo behavior and popup-open hardening`).
+- Validation recorded against `HEAD` (`docs-only screenshot placement and friends-list user guidance pass`).

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -63,9 +63,15 @@ Important workflow rules:
 
 Strategy is the main planning workflow. It lets you choose between stable profile/manual planning and live-driven snapshot planning without confusing those two jobs. See [Strategy System](Strategy_System.md).
 
+![Strategy dashboard main page](Images/StrategyDashMainPageGrid.png)
+*Use Strategy as the main planning surface; the dashboard view mirrors that workflow rather than replacing it.*
+
 ### Profiles
 
 Profiles are the plugin’s long-term memory for car, track, and condition-specific data. They are what make the other systems become trustworthy over time. See [Profiles System](Profiles_System.md).
+
+![Profiles car settings](Images/ProfilesCar.png)
+*Profiles are where you review and lock the saved values that should become trustworthy for a combo.*
 
 ### Fuel model
 
@@ -74,6 +80,15 @@ The fuel model learns gradually, builds confidence, and feeds Strategy with a tr
 ### Dashboards
 
 Dashboards are the display layer. They show outputs, visibility states, and context, but they do not own the calculations underneath. See [Dashboards](Dashboards.md).
+
+![Driver dashboard race context](Images/DriverDashRacingOpp.png)
+*The driver dash is there to keep race context readable at speed without moving ownership away from the plugin.*
+
+#### Friends list and driver tags
+
+If you use the Friends list, manage it in **Settings → Friends List**. Add iRacing customer IDs there and assign the practical tag you want to use, such as **Friend**, **Teammate**, or **Bad**.
+
+Those tags are mainly for **awareness and presentation** on supported nearby-car / CarSA-style surfaces. They help known drivers stand out more clearly on dashboards, but they do **not** change strategy math, fuel calculations, or the core H2H comparisons.
 
 #### Optional: ShakeIt Motors traction-loss export
 
@@ -95,6 +110,9 @@ Shift Assist gives RPM-based driver cues and becomes more trustworthy once its l
 ### Launch
 
 Launch setup is handled in Settings, while Launch Analysis is used afterwards to review saved starts. See [Launch System](Launch_System.md).
+
+![Launch Analysis review tab](Images/LaunchAnalysis.png)
+*Launch Analysis is the active review surface for saved launches after the run, not a future or placeholder feature.*
 
 ### Rejoin and pit aids
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ It is built to help with the practical race workflow: plan stints, trust learned
 
 Version **1.0** documentation is now organized so GitHub readers can move from a quick user overview into the canonical subsystem docs without guessing which page owns which truth.
 
+## At a glance
+
+![Strategy tab overview](Docs/Images/StrategyTab.png)
+*Strategy is the main plugin home for planning, live snapshot inputs, and preset-driven race setup.*
+
+![Strategy dashboard overview](Docs/Images/StrategyDashMainPageGrid.png)
+*The strategy dashboard focuses on fuel, stint, and race-context decisions without moving that logic out of the plugin.*
+
+![Driver dashboard awareness view](Docs/Images/DriverDashRacingOpp.png)
+*The driver-facing dash keeps nearby race context visible while you stay focused on driving.*
+
+![Pit entry assist dashboard cue](Docs/Images/PitEntryAssist.png)
+*Pit entry guidance is presented on the dash, while the plugin continues to own the underlying timing and marker logic.*
+
+![Launch Analysis tab](Docs/Images/LaunchAnalysis.png)
+*Launch Analysis remains the active post-run review surface for saved starts and launch traces.*
+
 ## Core Systems
 
 - **Strategy** - stable planning workflow for race fuel, stint, and context decisions
@@ -131,4 +148,3 @@ Copyright © 2026 Lalabot77
 
 This project is released under the MIT License.  
 See the LICENSE file for details.
-


### PR DESCRIPTION
### Motivation

- Provide a first-pass, release-focused placement of the newly added dashboard and plugin screenshots so the public docs show a small curated visual story without overcrowding the README.  
- Improve clarity for new users during install and early use by adding a single setup screenshot in the Quick Start.  
- Surface a short, practical Friends list / driver-tag note in the driver-facing docs so users know where to manage tags and what presentation effect to expect.  
- Keep scope strictly documentation-only and avoid claiming features that are not active (e.g., future/global Messaging System or Race Summary).

### Description

- Added a concise, curated image strip to the README landing page using existing repo images only to highlight Strategy, Strategy dashboard, driver dash, Pit Entry Assist, and Launch Analysis.  
- Inserted a single setup-oriented screenshot in `Docs/Quick_Start.md` to confirm the expected first plugin tab after activation and tightened one install sentence for clarity.  
- Added a small number of supporting screenshots and short italic captions to `Docs/User_Guide.md` and `Docs/Dashboards.md` to clarify Strategy, Profiles, dashboard roles, Launch Analysis, and Pit Entry cues.  
- Added a short user-facing note about the Friends list (where to manage it and that tags affect dashboard awareness/presentation only) in both `Docs/User_Guide.md` and `Docs/Dashboards.md`.  
- Updated `Docs/RepoStatus.md` to record this documentation-only sweep and list the files reviewed/changed; no code, image files, dashboard packages, or runtime behavior were modified.

### Testing

- Ran `git diff --check` to detect whitespace/diff issues, which passed with no errors.  
- Executed a Python check to verify every newly referenced markdown image path exists in the repository via a script that finds `![...]()` references and confirms the files, which succeeded (`All referenced images exist.`).  
- Performed a repository status verification to confirm only the intended markdown files were modified, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c19afc8c2c832fb8e031e2ef2eb78e)