### PR TITLE
docs: clarify dashboard navigation bindings

### DIFF
--- a/Docs/Dashboards.md
+++ b/Docs/Dashboards.md
@@ -38,12 +38,46 @@ The main controls most users care about are:
 
 - **Cancel Message**
 - **Toggle Pit Screen**
-- **Primary Dash Mode**
+- **Next Dash**
+- **Previous Dash**
 - **Declutter Mode**
 
-These controls affect **presentation and visibility**. They do not change the ownership of the underlying plugin systems.
+These controls affect **presentation and visibility**. They do not change the ownership of the underlying plugin systems. The dashboards can be used by touch, but binding controls is strongly recommended.
 
-## 4. Dash Control philosophy
+## 4. Navigation patterns in the released dash set
+
+The released dashboards are designed to work with SimHub's standard dash navigation commands:
+
+- **Next Dash**
+- **Previous Dash**
+
+Best practice is to bind those commands to physical controls instead of relying only on touch. By default, **Next Screen** moves through the main pages and **Previous Screen** moves through internal/sub-pages. If you prefer, SimHub/Dash Studio also lets you bind individual dashes directly with separate commands per dash, but that is an advanced setup rather than the default expectation.
+
+### Main driver dash
+
+On the main driver dash, touch navigation is broadly based on screen regions rather than tiny exact buttons:
+
+- the left outer region usually moves to the previous main page,
+- the right outer region usually moves to the next main page,
+- the middle region is used for context actions,
+- on some pages, middle upper/lower areas are used for page-specific secondary actions.
+
+In practical use, that means the centre press might change a secondary source on one page, while on another page it might zoom or expand ahead/behind information. Touch areas on the driver and strategy dashboards allow page changes and context actions, but their exact function depends on the current page.
+
+### Strategy dash
+
+The strategy dash follows the same release philosophy, but its touch navigation is more side-oriented:
+
+- touch regions down the side are used for navigation between screens or sections,
+- the centre area often exits a sub-screen or moves on to the next main screen depending on context.
+
+Treat the strategy dash touch zones as practical shortcuts, not as a promise that every page uses the exact same split. Some pages need slightly different context actions, so the touch behaviour varies a little by page.
+
+### Important current limitation
+
+The **Primary Dash Mode** binding shown in the plugin UI is reserved for future use and does not currently perform any action. Users do not need to bind it for the released dash set.
+
+## 5. Dash Control philosophy
 
 Dash Control is dash-oriented. Use it to manage:
 
@@ -64,7 +98,7 @@ In the Dash Visibility matrix, the short release-facing headers are:
 
 Do **not** use Dash Control as the mental home for strategy, launch logic, or saved profile learning.
 
-## 5. Strategy, PreRace, and display boundaries
+## 6. Strategy, PreRace, and display boundaries
 
 Dashboards can show:
 
@@ -80,7 +114,7 @@ Keep the roles straight:
 
 Seeing a value on a dash does not mean the dash owns that calculation.
 
-## 6. Pit and rejoin screens
+## 7. Pit and rejoin screens
 
 Pit and rejoin surfaces are some of the most practically useful dashboard pages.
 
@@ -95,7 +129,7 @@ Pit and rejoin surfaces are some of the most practically useful dashboard pages.
 
 For the feature-specific guidance, see [Rejoin Assist](Rejoin_Assist.md) and [Pit Assist](Pit_Assist.md).
 
-## 7. H2H on dashboards
+## 8. H2H on dashboards
 
 Supported dashboards may show:
 
@@ -114,7 +148,7 @@ If you want certain drivers to stand out more clearly, use **Settings → Friend
 
 For most users, the practical effect is on **awareness styling** in supported nearby-car / CarSA-style dashboard surfaces: tagged drivers can be easier to spot as **Friend**, **Teammate**, or **Bad**. Treat this as a presentation aid, not as something that changes strategy or core H2H ownership.
 
-## 8. Practical layout advice
+## 9. Practical layout advice
 
 A simple setup usually works best:
 
@@ -122,4 +156,4 @@ A simple setup usually works best:
 - **Support dash:** extra strategy and race-context detail
 - **Overlay:** compact alerts and helper widgets
 
-If a screen feels too busy, use **Primary Dash Mode**, **Declutter Mode**, and visibility choices before assuming a subsystem is wrong.
+If a screen feels too busy, use **Declutter Mode**, your dash visibility choices, and a cleaner dash layout before assuming a subsystem is wrong. The **Primary Dash Mode** binding shown in the plugin UI is currently inactive and can be ignored.

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -82,8 +82,18 @@ For a new car/track combination:
 5. Add only the core controls you need at first:
    - **Cancel Message**
    - **Toggle Pit Screen**
-   - **Primary Dash Mode**
+   - **Next Dash**
+   - **Previous Dash**
    - **Declutter Mode**
+
+### Dash navigation quick setup
+
+The dashboards can be used by touch, but binding controls is strongly recommended. For a first usable setup:
+
+- Bind SimHub's **Next Dash** and **Previous Dash** commands to physical controls you can reach easily.
+- By default, **Next Screen** moves through the main pages and **Previous Screen** moves through internal/sub-pages.
+- The driver and strategy dashboards also have touch areas for page changes and context actions, but their exact function depends on the current page.
+- The **Primary Dash Mode** binding shown in the plugin UI is reserved for future use and does not currently perform any action, so you do not need to bind it.
 
 ## 6. What to trust early vs later
 

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -90,6 +90,21 @@ If you use the Friends list, manage it in **Settings → Friends List**. Add iRa
 
 Those tags are mainly for **awareness and presentation** on supported nearby-car / CarSA-style surfaces. They help known drivers stand out more clearly on dashboards, but they do **not** change strategy math, fuel calculations, or the core H2H comparisons.
 
+#### Dashboard navigation and bindings
+
+The dashboards can be used by touch, but binding controls is strongly recommended. The released dash set is built around SimHub's main dash navigation commands:
+
+- **Next Dash**
+- **Previous Dash**
+
+In normal use, bind those to physical buttons, wheel inputs, or other controls you can use without hunting for touch targets. By default, **Next Screen** moves through the main pages and **Previous Screen** moves through internal/sub-pages. Advanced users can also bind specific dashes directly in SimHub/Dash Studio if they prefer dedicated commands per dash.
+
+On the main driver dash, the screen is broadly split into thirds. The outer left and right regions are mainly used to move between main screens, while the middle region, or middle upper/lower areas on some pages, is used for context actions such as changing a secondary source or zooming/expanding ahead/behind information on the strategy-style pages.
+
+On the strategy dash, navigation is usually handled by touch regions down the side. The centre area often exits a sub-screen or advances to the next main screen depending on context. Touch areas on the driver and strategy dashboards allow page changes and context actions, but their exact function depends on the current page.
+
+The **Primary Dash Mode** binding shown in the plugin UI is reserved for future use and does not currently perform any action. You do not need to bind it for the released dash set.
+
 #### Optional: ShakeIt Motors traction-loss export
 
 Some Lala dashboards and launch/practice visuals can use SimHub's ShakeIt Motors output for wheelspin / traction-loss indications. This is **optional** and is not a core plugin requirement. If you do nothing here, the plugin still works normally.
@@ -149,6 +164,7 @@ If a system is wrong once, keep driving. If it is wrong repeatedly, review the s
 - Keep the difference between **live observation** and **stable planning** clear in your workflow.
 - Lock only values that have settled and make sense.
 - Use **Dash Control** for visibility and presentation, not to fix calculation logic.
+- Treat touch navigation as a backup or convenience layer; for race use, bind **Next Dash** and **Previous Dash** to physical controls.
 - Review profile-backed data when a driver aid is repeatedly wrong.
 
 ## 7. Recommended reading order


### PR DESCRIPTION
### Motivation

- Document how the released dash set is navigated (touch regions and recommended control bindings) so first-time users can get moving quickly. 
- Make explicit the current limitation that the `Primary Dash Mode` binding shown in the plugin UI is a placeholder and does not perform any action. 

### Description

- Updated `Docs/Quick_Start.md` to add a concise "Dash navigation quick setup" section that recommends binding SimHub `Next Dash` and `Previous Dash` and notes touch areas and the inactive `Primary Dash Mode` placeholder. 
- Expanded `Docs/User_Guide.md` with a fuller `Dashboard navigation and bindings` section describing the main driver-dash thirds layout, strategy-dash side-region navigation, the default `Next Screen` / `Previous Screen` behaviour, and the recommendation to bind physical controls. 
- Added a new `Navigation patterns in the released dash set` section to `Docs/Dashboards.md` describing driver-dash and strategy-dash touch behaviours, the SimHub `Next Dash`/`Previous Dash` contract, guidance on advanced per-dash bindings, and a clear note that `Primary Dash Mode` is currently unused. 
- Replaced the previous `Primary Dash Mode` entry in control lists with `Next Dash`/`Previous Dash` and adjusted a few section headings numbering within `Docs/Dashboards.md` to keep ordering correct. 

### Testing

- Ran `git diff --check` to validate whitespace/diff issues and it passed. 
- Verified changes with `git status --short` and inspected the last commit via `git log -1 --stat --oneline`. 
- Committed the documentation-only change on the working branch as `docs: clarify dashboard navigation bindings` and produced the PR metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a139a148832fa72560c297864637)