### PR TITLE
Docs: refresh subsystem docs, expand MSGV1 notes, and clarify subsystem behaviors

### DIFF
--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -1,7 +1,7 @@
 # Fuel Planner / Strategy Tab
 
 Validated against commit: HEAD
-Last updated: 2026-03-22
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose
@@ -11,7 +11,7 @@ The Fuel Planner (surfaced as the top-level **Strategy** tab in the plugin UI) i
 - Computes a **deterministic pit plan** using planner inputs, independent of live volatility.
 - Exposes “readiness” gates so dashboards can safely auto-apply or inhibit live suggestions.
 
-The planner does **not** replace the Fuel Model.  
+The planner does **not** replace the Fuel Model.
 It consumes the Fuel Model’s **live snapshot** and produces **explicit planning outputs** that are stable unless the user changes them.
 
 Preset management remains part of the same subsystem, but it is no longer a separate top-level navigation tab. The Strategy tab keeps the inline `Race Preset` selector and opens the existing preset editor via a modal **Preset Manager** dialog beside that selector. The Preset Manager still owns preset editing only; its `PreRace Mode` combo now reuses the same standard WPF ComboBox pattern already working on the main Strategy page so the selected value stays readable without breaking normal dropdown interaction.
@@ -302,6 +302,6 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 
 ## TODO / VERIFY
 
-- TODO/VERIFY: Confirm exact confidence threshold used to set `IsFuelReady` and whether it differs for lap time vs fuel.  
-- TODO/VERIFY: Confirm whether planner pit loss always prefers DTL or falls back to direct lane loss when DTL unavailable.  
+- TODO/VERIFY: Confirm exact confidence threshold used to set `IsFuelReady` and whether it differs for lap time vs fuel.
+- TODO/VERIFY: Confirm whether planner pit loss always prefers DTL or falls back to direct lane loss when DTL unavailable.
 - TODO/VERIFY: Confirm which planner outputs are exported as `_S` (smoothed) vs numeric only.

--- a/Docs/Subsystems/MessageEngineV1_Notes.md
+++ b/Docs/Subsystems/MessageEngineV1_Notes.md
@@ -1,10 +1,28 @@
 # Message Engine v1 (SimHub exports)
 
-Validated against commit: 9f784a9  
-Last updated: 2026-01-14  
+Validated against commit: 9f784a9
+Last updated: 2026-03-24
 Branch: work
 
-This plugin now exposes a v1 message engine driven by the v5 message catalog and signal mappings. Dashboards can bind to the following SimHub properties:
+## Purpose
+Message Engine v1 is the dashboard-facing message selection/output layer for the v5 message catalog.
+It decides which message is currently visible on each dash lane and exposes styling + stack telemetry via `MSGV1.*` exports.
+
+> Status note: MSGV1 is still under active development and is **not** part of the shipped plugin v1.0 runtime contract.
+
+## Core behavior
+- The engine keeps an active stack of eligible messages.
+- Active message selection is priority-first, then recency-aware within the same priority tier.
+- Lala and Msg dash lanes each get their own active text/id/priority/style exports.
+- Msg cancel (`MsgCxPressed`) is shared with legacy behavior for compatibility.
+
+## Selection and clear logic (quick math/logic)
+- **Priority ordering:** `High > Med > Low`.
+- **Single press cancel:** remove the current top message; next eligible stack entry becomes active.
+- **Repeated single press:** keeps walking down the stack until empty.
+- **Double-tap clear:** if two presses arrive within ~350 ms, clear all active entries (`ClearAllPulse = true` briefly).
+
+## Export contract
 
 | Property | Description |
 | --- | --- |
@@ -24,23 +42,26 @@ This plugin now exposes a v1 message engine driven by the v5 message catalog and
 | `MSGV1.ActiveFontSize_Msg` | Absolute font size for the Msg dash message. |
 | `MSGV1.ActiveCount` | Number of active messages in the engine. |
 | `MSGV1.LastCancelMsgId` | MsgId of the last message canceled via MsgCx. |
-| `MSGV1.ClearAllPulse` | True for a short pulse when a double‑tap clear occurs. |
+| `MSGV1.ClearAllPulse` | True for a short pulse when a double-tap clear occurs. |
 | `MSGV1.StackCsv` | Debug view of the stack in most-recently-shown order (`msgId|Priority;...`). |
 
-Backwards compatibility: the legacy `MsgCxPressed` property is unchanged and MsgCx still routes to the old dash lanes. The v1 engine listens to the same button:
+## Styling rules
+- MessageDefinition JSON fields:
+  - `TextColor`, `BgColor`, `OutlineColor` (`#AARRGGBB`, blank = use priority default)
+  - `FontSize` (absolute; default 24)
+- Priority defaults (when explicit style is blank):
+  - High: red background, yellow text/outline
+  - Med: yellow background, blue text/outline
+  - Low: transparent background, white text/outline
+- Flag messages can override background with the active flag color while keeping readable text/outline.
 
-- Single press: cancels the last-shown message (falls back to the most recently updated if none shown).
-- Repeated presses step back through the stack until empty.
-- Double-tap within ~350 ms: clears all active messages (suppression rules still apply).
+## Compatibility and migration notes
+- Since MSGV1 is not shipped in plugin v1.0 yet, treat this page as forward-looking technical notes for test/dev builds.
+- Legacy `MsgCxPressed` remains the control input; no new button wiring is required.
+- Legacy `MSG.*` lanes remain exported for compatibility, but `MSGV1.*` is the canonical dash contract.
+- `MSG.OtherClassBehindGap` is available; there is no `MSGOtherClassBehindGap` alias.
+- Fuel "push OK" is one-shot per race session when no more fuel stops are required.
+- Pit messages are mutually exclusive: `PIT_NOW` (`<= 0 laps`) overrides `PIT_SOON` (`< 2 laps`) and neither loops while state is unchanged.
 
-Migration tips
---------------
-- Point existing dashboard “active message” labels at `MSGV1.ActiveText_Lala` (Lala dash) or `MSGV1.ActiveText_Msg` (Msg dash) to pick up the new stack-based selection.
-- Bind any cancel/clear button to the existing `MsgCxPressed` trigger; no new inputs are required.
-- Keep legacy `MSG.*` lanes intact for now; they remain exported but are no longer required for the new engine. (`MSG.OtherClassBehindGap` is available; there is no `MSGOtherClassBehindGap` alias.)
-- Fuel “push OK” now fires once per session (race only) when no further fuel stops are required.
-- Pit messages are mutually exclusive: `PIT_NOW` (<=0 laps) overrides `PIT_SOON` (<2 laps) in races and neither loops while their state holds.
-- Style fields in JSON (MessageDefinition): `TextColor`, `BgColor`, `OutlineColor` (format `#AARRGGBB`, empty = use defaults) and `FontSize` (absolute, default 24).
-- Priority defaults (used when a color field is blank): High = red bg / yellow text+outline; Med = yellow bg / blue text+outline; Low = transparent bg / white text+outline.
-- Flag messages override background to match the flag color (e.g., yellow/blue/green/red/white/black/meatball/checkered) while keeping readable text/outline.
-- Missing evaluators are surfaced via a stub, logged once, and exported as `MSGV1.MissingEvaluatorsCsv` (e.g., `Eval_X|msg1,msg2`); this prevents silent skips when a catalog entry references an unimplemented evaluator.
+## Diagnostics
+- Missing evaluators are surfaced via stub handling (one-time log) and exported in `MSGV1.MissingEvaluatorsCsv` (e.g. `Eval_X|msg1,msg2`) so unresolved definitions are visible instead of silently skipped.

--- a/Docs/Subsystems/Message_System_V1.md
+++ b/Docs/Subsystems/Message_System_V1.md
@@ -1,11 +1,13 @@
 # Message System V1
 
-Validated against commit: 9f784a9  
-Last updated: 2026-01-14  
+Validated against commit: 9f784a9
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose
 Evaluate message definitions against telemetry and plugin signals, maintain an active stack, and publish styled SimHub exports for Lala/Msg dashes.
+
+> Status note: Message System V1 / `MSGV1.*` is still under active development and is **not** part of the shipped plugin v1.0 runtime contract.
 
 ---
 

--- a/Docs/Subsystems/Opponents.md
+++ b/Docs/Subsystems/Opponents.md
@@ -1,50 +1,50 @@
 # Opponents subsystem
 
 Validated against commit: HEAD
-Last updated: 2026-03-20
+Last updated: 2026-03-24
 Branch: work
 
 Purpose: own all opponent-facing calculations for strict same-class race-target selection, nearby/leaderboard pace enrichment, and pit-exit position forecasting with SimHub exports under `Opp.*` and `PitExit.*`.
 Phase-1 Head-to-Head (`H2HRace.*`) consumes Opponents only as a **race-target selector seam** (current class-ahead / class-behind identity from `Opp.Ahead1` / `Opp.Behind1`). Persistent H2H timing, live-gap, lap-summary, fixed-6-segment ownership, and canonical H2H class-color publishing remain inside the standalone H2H subsystem; if Opponents clears those race outputs, H2H should also clear/inactivate rather than revive a stale race identity. Opponents does **not** become a far-away timing engine, and any extra `CarIdx` recovery stays a narrow local fallback inside H2H/LalaLaunch rather than moving timing ownership into Opponents.
 
 ## Gating and scope
-- Runs **race sessions only**; resets caches/outputs if session leaves Race.【F:Opponents.cs†L42-L155】
-- No additional completed-lap gate is currently applied; once the session is Race, Opp and PitExit outputs may publish immediately. The subsystem-active log still fires once per activation.【F:Opponents.cs†L58-L155】
-- Uses **IRacingExtraProperties only**; no Dahl DLL or SDK arrays.【F:Opponents.cs†L42-L88】
+- Runs **race sessions only**; resets caches/outputs if session leaves Race.
+- No additional completed-lap gate is currently applied; once the session is Race, Opp and PitExit outputs may publish immediately. The subsystem-active log still fires once per activation.
+- Uses **IRacingExtraProperties only**; no Dahl DLL or SDK arrays.
 
 ## Identity model
-- Stable key: `ClassColor:CarNumber`. Empty class+number returns blank identity (slot ignored).【F:Opponents.cs†L90-L100】
-- Nearby slot changes log once per rebind when active; identity caches persist pace history across slot swaps. Logging remains race-session scoped and debug-gated for slot-rebind chatter.【F:Opponents.cs†L277-L421】
-- Published race-target identity is now leaderboard-authoritative: Opponents finds the player row in `iRacing_ClassLeaderboard_Driver_XX_*`, then selects `PositionInClass - 1/-2/+1/+2` within the same class for `Opp.Ahead1/2` and `Opp.Behind1/2`. If the player row or neighbor row cannot be resolved, the published target stays empty/invalid; there is no fallback to nearby slots for race-target identity.【F:Opponents.cs†L129-L211】【F:Opponents.cs†L568-L608】
+- Stable key: `ClassColor:CarNumber`. Empty class+number returns blank identity (slot ignored).
+- Nearby slot changes log once per rebind when active; identity caches persist pace history across slot swaps. Logging remains race-session scoped and debug-gated for slot-rebind chatter.
+- Published race-target identity is now leaderboard-authoritative: Opponents finds the player row in `iRacing_ClassLeaderboard_Driver_XX_*`, then selects `PositionInClass - 1/-2/+1/+2` within the same class for `Opp.Ahead1/2` and `Opp.Behind1/2`. If the player row or neighbor row cannot be resolved, the published target stays empty/invalid; there is no fallback to nearby slots for race-target identity.
 
 ## Data inputs
-- Nearby targets: `iRacing_DriverAheadInClass_00/01_*`, `iRacing_DriverBehindInClass_00/01_*` for Name, CarNumber, ClassColor, RelativeGapToPlayer, LastLapTime, BestLapTime, IsInPit, IsConnected. These feeds are still ingested for cache continuity and debug slot-rebind logging, but they no longer determine published race-target identity for `Opp.Ahead1/2.*` or `Opp.Behind1/2.*`.【F:Opponents.cs†L277-L421】
-- Leaderboard scan (00–63 until empty row): `iRacing_ClassLeaderboard_Driver_XX_*` for Name, CarNumber, ClassColor, Position, PositionInClass, RelativeGapToLeader, IsInPit/IsConnected, LastLapTime, BestLapTime.【F:Opponents.cs†L489-L525】
-- Player identity: `iRacing_Player_ClassColor`, `iRacing_Player_CarNumber`. Pit-exit receives pit loss from LalaLaunch’s stop-loss calculation (validated to ≥0).【F:Opponents.cs†L42-L88】【F:LalaLaunch.cs†L3701-L3731】
+- Nearby targets: `iRacing_DriverAheadInClass_00/01_*`, `iRacing_DriverBehindInClass_00/01_*` for Name, CarNumber, ClassColor, RelativeGapToPlayer, LastLapTime, BestLapTime, IsInPit, IsConnected. These feeds are still ingested for cache continuity and debug slot-rebind logging, but they no longer determine published race-target identity for `Opp.Ahead1/2.*` or `Opp.Behind1/2.*`.
+- Leaderboard scan (00–63 until empty row): `iRacing_ClassLeaderboard_Driver_XX_*` for Name, CarNumber, ClassColor, Position, PositionInClass, RelativeGapToLeader, IsInPit/IsConnected, LastLapTime, BestLapTime.
+- Player identity: `iRacing_Player_ClassColor`, `iRacing_Player_CarNumber`. Pit-exit receives pit loss from LalaLaunch’s stop-loss calculation (validated to ≥0).
 
 ## Pace cache & blended pace
-- Entity cache keyed by identity; keeps best lap and a 5-lap ring buffer of valid recent laps (rejects ≤0/NaN/huge, skips laps flagged in-pit).【F:Opponents.cs†L627-L717】
-- BlendedPaceSec = 0.70×RecentAvg + 0.30×(BestLap×1.01); falls back to recent-only or best×1.01 if missing.【F:Opponents.cs†L693-L717】
+- Entity cache keyed by identity; keeps best lap and a 5-lap ring buffer of valid recent laps (rejects ≤0/NaN/huge, skips laps flagged in-pit).
+- BlendedPaceSec = 0.70×RecentAvg + 0.30×(BestLap×1.01); falls back to recent-only or best×1.01 if missing.
 
 ## Fight prediction (dash support)
-- Uses my pace (from LalaLaunch) vs opponent blended pace once active; my pace is sanitized to remove invalid/huge values.【F:Opponents.cs†L42-L88】【F:Opponents.cs†L129-L211】
-- For published race targets, GapToPlayerSec is derived from the absolute difference between the target row’s `RelativeGapToLeader` and the player row’s `RelativeGapToLeader`, so same-class neighbors remain valid even across multi-lap gaps.【F:Opponents.cs†L170-L211】
-- Ahead: closingRate = opponent − mine; requires closingRate > +0.05 s/lap and positive gap to publish LapsToFight (capped at 999). Otherwise NaN (no catch).【F:Opponents.cs†L191-L211】
-- Behind: closingRate = mine − opponent; requires closingRate > +0.05 s/lap and positive gap to publish LapsToFight (NaN when no threat/invalid).【F:Opponents.cs†L191-L211】
-- Summary strings split: `Opponents_SummaryAhead` (A1/A2) and `Opponents_SummaryBehind` (B1/B2). Per-slot variants: `Opponents_SummaryAhead1/2`, `Opponents_SummaryBehind1/2`. Format example — Ahead: `A1 #25 +0.6s Δ-0.12s/L LTF=5 | A2 #11 +1.4s Δ-0.05s/L LTF=—`; Behind: `B1 #39 -0.7s Δ+0.08s/L LTF=9 | B2 #32 -1.6s Δ+0.03s/L LTF=—`. Uses `—` when data unavailable.【F:Opponents.cs†L78-L155】
+- Uses my pace (from LalaLaunch) vs opponent blended pace once active; my pace is sanitized to remove invalid/huge values.
+- For published race targets, GapToPlayerSec is derived from the absolute difference between the target row’s `RelativeGapToLeader` and the player row’s `RelativeGapToLeader`, so same-class neighbors remain valid even across multi-lap gaps.
+- Ahead: closingRate = opponent − mine; requires closingRate > +0.05 s/lap and positive gap to publish LapsToFight (capped at 999). Otherwise NaN (no catch).
+- Behind: closingRate = mine − opponent; requires closingRate > +0.05 s/lap and positive gap to publish LapsToFight (NaN when no threat/invalid).
+- Summary strings split: `Opponents_SummaryAhead` (A1/A2) and `Opponents_SummaryBehind` (B1/B2). Per-slot variants: `Opponents_SummaryAhead1/2`, `Opponents_SummaryBehind1/2`. Format example — Ahead: `A1 #25 +0.6s Δ-0.12s/L LTF=5 | A2 #11 +1.4s Δ-0.05s/L LTF=—`; Behind: `B1 #39 -0.7s Δ+0.08s/L LTF=9 | B2 #32 -1.6s Δ+0.03s/L LTF=—`. Uses `—` when data unavailable.
 
 ## Pit-exit prediction
-- Finds player row in class leaderboard; predicted gap to leader after pit = player.RelGapToLeader + pitLossSec (pit loss forced to 0 when invalid). Each same-class, connected row computes `delta = row.RelGapToLeader − playerPredictedGapToLeaderAfterPit`. Negative delta means the car is ahead after pit; positive delta means behind.【F:Opponents.cs†L507-L553】
-- On pit entry, the predictor **locks** the player gap-to-leader and pit-loss inputs for the duration of the pit trip, preventing drift if leaderboard gaps update mid-stop. Lock clears once pitTripActive ends.【F:Opponents.cs†L783-L832】
-- PredictedPosition = 1 + count of same-class connected cars where delta < 0. Logs when validity toggles or predicted position changes while active; predicted-position-change logs require debug toggle + lap gate.【F:Opponents.cs†L532-L566】
-- Update cadence: runs every tick on pit road; off pit road, runs only when the player enters a new lap quarter (TrackPct × 4 → 0-3). Prediction is skipped near race end if reliable session time remaining is ≤120 s.【F:Opponents.cs†L612-L742】
-- Nearest ahead/behind exports come from the same scan: nearest ahead = largest negative delta (closest ahead); nearest behind = smallest positive delta (closest behind). Only same-class, connected cars are considered.【F:Opponents.cs†L532-L658】
-- Prediction-change logs are gated to reduce chatter: emits only on ≥2 place change, ≥2 s since last log, or pitTripActive/onPitRoad transitions (predictor outputs unchanged).【F:Opponents.cs†L676-L694】
-- Snapshot data (player positions, gap-to-leader, pitLoss, predicted pos, cars ahead, **locked gap/pit loss**, and derived predicted gap) is captured for one-shot pit-in/out logging in LalaLaunch. Math audit lists boundary candidates around the pit-loss compare and uses `d = (candidateGap - playerGap) - pitLoss` for the same-class set; it is emitted with the pit-in snapshot.【F:Opponents.cs†L862-L978】【F:LalaLaunch.cs†L4712-L4784】
-- A one-lap-delayed “pit-out settled” log is emitted after crossing the lap boundary following pit exit to record the final settled position and gap-to-leader at the end of the out-lap.【F:Opponents.cs†L695-L738】
-- Publishes PitExit.Valid/PredictedPositionInClass/CarsAheadAfterPitCount/Summary plus nearest ahead/behind identity/gap fields; defaults reset when invalid.【F:Opponents.cs†L507-L579】【F:Opponents.cs†L775-L789】
+- Finds player row in class leaderboard; predicted gap to leader after pit = player.RelGapToLeader + pitLossSec (pit loss forced to 0 when invalid). Each same-class, connected row computes `delta = row.RelGapToLeader − playerPredictedGapToLeaderAfterPit`. Negative delta means the car is ahead after pit; positive delta means behind.
+- On pit entry, the predictor **locks** the player gap-to-leader and pit-loss inputs for the duration of the pit trip, preventing drift if leaderboard gaps update mid-stop. Lock clears once pitTripActive ends.
+- PredictedPosition = 1 + count of same-class connected cars where delta < 0. Logs when validity toggles or predicted position changes while active; predicted-position-change logs require debug toggle + lap gate.
+- Update cadence: runs every tick on pit road; off pit road, runs only when the player enters a new lap quarter (TrackPct × 4 → 0-3). Prediction is skipped near race end if reliable session time remaining is ≤120 s.
+- Nearest ahead/behind exports come from the same scan: nearest ahead = largest negative delta (closest ahead); nearest behind = smallest positive delta (closest behind). Only same-class, connected cars are considered.
+- Prediction-change logs are gated to reduce chatter: emits only on ≥2 place change, ≥2 s since last log, or pitTripActive/onPitRoad transitions (predictor outputs unchanged).
+- Snapshot data (player positions, gap-to-leader, pitLoss, predicted pos, cars ahead, **locked gap/pit loss**, and derived predicted gap) is captured for one-shot pit-in/out logging in LalaLaunch. Math audit lists boundary candidates around the pit-loss compare and uses `d = (candidateGap - playerGap) - pitLoss` for the same-class set; it is emitted with the pit-in snapshot.
+- A one-lap-delayed “pit-out settled” log is emitted after crossing the lap boundary following pit exit to record the final settled position and gap-to-leader at the end of the out-lap.
+- Publishes PitExit.Valid/PredictedPositionInClass/CarsAheadAfterPitCount/Summary plus nearest ahead/behind identity/gap fields; defaults reset when invalid.
 
 ## Outputs
-- `Opp.Ahead1/2.*`, `Opp.Behind1/2.*` → strict same-class standings neighbors around the player row (no nearby fallback), published as Name, CarNumber, ClassColor, GapToPlayerSec (absolute leaderboard-relative gap), BlendedPaceSec, PaceDeltaSecPerLap, and LapsToFight (NaN = no fight/invalid). Summaries at `Opponents_SummaryAhead/Behind` (plus per-slot variants).【F:Opponents.cs†L129-L211】
-- Optional leader pace: `Opp.Leader.BlendedPaceSec`, `Opp.P2.BlendedPaceSec`.【F:Opponents.cs†L84-L88】【F:Opponents.cs†L720-L736】
-- Pit exit exports: `PitExit.Valid`, `PitExit.PredictedPositionInClass`, `PitExit.CarsAheadAfterPitCount`, `PitExit.Summary`, `PitExit.Ahead.*`, `PitExit.Behind.*` (Name/CarNumber/ClassColor/GapSec).【F:Opponents.cs†L507-L566】【F:Opponents.cs†L775-L789】
+- `Opp.Ahead1/2.*`, `Opp.Behind1/2.*` → strict same-class standings neighbors around the player row (no nearby fallback), published as Name, CarNumber, ClassColor, GapToPlayerSec (absolute leaderboard-relative gap), BlendedPaceSec, PaceDeltaSecPerLap, and LapsToFight (NaN = no fight/invalid). Summaries at `Opponents_SummaryAhead/Behind` (plus per-slot variants).
+- Optional leader pace: `Opp.Leader.BlendedPaceSec`, `Opp.P2.BlendedPaceSec`.
+- Pit exit exports: `PitExit.Valid`, `PitExit.PredictedPositionInClass`, `PitExit.CarsAheadAfterPitCount`, `PitExit.Summary`, `PitExit.Ahead.*`, `PitExit.Behind.*` (Name/CarNumber/ClassColor/GapSec).

--- a/Docs/Subsystems/Pit_Entry_Assist.md
+++ b/Docs/Subsystems/Pit_Entry_Assist.md
@@ -2,16 +2,16 @@
 
 **Subsystem doc**
 
-Validated against commit: b45bc8f  
-Last updated: 2026-02-12  
-Last reviewed: 2026-01-14  
+Validated against commit: b45bc8f
+Last updated: 2026-03-24
+Last reviewed: 2026-01-14
 Branch: work
 
 ## Purpose
-- **Pit Entry Assist** gives a driver-facing cue to hit pit speed at the entry line using distance, speed, and a constant-decel model. It publishes both dash-friendly properties and structured logs for post-run analysis. 
+- **Pit Entry Assist** gives a driver-facing cue to hit pit speed at the entry line using distance, speed, and a constant-decel model. It publishes both dash-friendly properties and structured logs for post-run analysis.
 - **Deceleration Capture (DecelCap)** is a developer-only instrumentation tool to empirically measure achievable braking decel per car; it is disabled by default and not part of runtime behaviour.
 
-Canonical exports: `Docs/Internal/SimHubParameterInventory.md`  
+Canonical exports: `Docs/Internal/SimHubParameterInventory.md`
 Canonical logs: `Docs/Internal/SimHubLogMessages.md`
 
 ---
@@ -22,16 +22,16 @@ Canonical logs: `Docs/Internal/SimHubLogMessages.md`
 - **Arms when:**
   - `PitPhase.EnteringPits`, **OR**
   - Pit limiter **ON** **and** overspeed > **+2 kph** (`Pit.EntrySpeedDelta_kph`), **OR**
-  - Pit screen is active (auto or manual) **and** you are **on track** within **≤500 m** of the line (manual arming path).【F:PitEngine.cs†L246-L360】
+  - Pit screen is active (auto or manual) **and** you are **on track** within **≤500 m** of the line (manual arming path).
 - **Deactivates when:**
   - Driver enters pit lane (`IsInPitLane`), or
   - Arming conditions drop (limiter off / no overspeed / no entry phase), or
-  - Inputs become invalid (missing pit speed, distance >500 m, etc.).【F:PitEngine.cs†L260-L318】【F:PitEngine.cs†L376-L398】
+  - Inputs become invalid (missing pit speed, distance >500 m, etc.).
 
 ### Flow (high level)
 1. Assist arms (conditions above).
-2. Braking guidance recomputes every tick (distance, required distance, margin, cue).【F:PitEngine.cs†L260-L363】
-3. Driver crosses pit entry line → `ENTRY LINE` log fires once with debrief/time-loss fields.【F:PitEngine.cs†L460-L507】
+2. Braking guidance recomputes every tick (distance, required distance, margin, cue).
+3. Driver crosses pit entry line → `ENTRY LINE` log fires once with debrief/time-loss fields.
 4. Assist ends (pit entry or disarm).
 
 ---
@@ -53,16 +53,16 @@ If the pit screen is dismissed or resets to auto, manual arming immediately fall
   - Primary: stored track markers (entry pct + cached track length) when valid for the current track.
   - Fallback 1: `IRacingExtraProperties.iRacing_DistanceToPitEntry`.
   - Fallback 2: `(pitEntryPct − carPct) × trackLength` using `IRacingExtraProperties.iRacing_PitEntryTrkPct` and cached session track length.
-  - Clamped to **0–500 m** working window; assist resets if ≥500 m or invalid.【F:PitEngine.cs†L300-L364】
+  - Clamped to **0–500 m** working window; assist resets if ≥500 m or invalid.
 
-- **Speed delta (`Pit.EntrySpeedDelta_kph`):** Current speed − pit speed limit (session pit speed, fallback to iRacing extra).【F:PitEngine.cs†L251-L276】
+- **Speed delta (`Pit.EntrySpeedDelta_kph`):** Current speed − pit speed limit (session pit speed, fallback to iRacing extra).
 
-- **Required braking distance (`Pit.EntryRequiredDistance_m`):** Constant-decel model: `(v² − vTarget²) / (2 × decel)` when above pit speed. Uses per-profile decel (clamped 5–25 m/s²).【F:PitEngine.cs†L318-L342】
+- **Required braking distance (`Pit.EntryRequiredDistance_m`):** Constant-decel model: `(v² − vTarget²) / (2 × decel)` when above pit speed. Uses per-profile decel (clamped 5–25 m/s²).
 
-- **Margin (`Pit.EntryMargin_m`):** `distanceToLine − requiredDistance`. Positive = early/room, negative = late.【F:PitEngine.cs†L323-L343】
+- **Margin (`Pit.EntryMargin_m`):** `distanceToLine − requiredDistance`. Positive = early/room, negative = late.
 
 - **Profile parameters:**
-  - `Pit.EntryDecelProfile_mps2` and `Pit.EntryBuffer_m` come from the active car profile (Dash tab sliders). Both are clamped to sane ranges when used.【F:PitEngine.cs†L240-L259】【F:LalaLaunch.cs†L3380-L3387】【F:DashesTabView.xaml†L141-L142】
+  - `Pit.EntryDecelProfile_mps2` and `Pit.EntryBuffer_m` come from the active car profile (Dash tab sliders). Both are clamped to sane ranges when used.
 
 ---
 
@@ -78,8 +78,8 @@ Cue level is derived from **margin vs. buffer** (buffer = profile slider):
 | 3 | BRAKE NOW | Immediate braking required (≤0 margin) |
 | 4 | LATE | Cannot make pit speed at target decel (margin < −buffer) |
 
-- **Logic:** `margin < -buffer → LATE; margin ≤ 0 → BRAKE NOW; margin ≤ buffer → BRAKE SOON; else OK`.【F:PitEngine.cs†L334-L339】
-- **Dash string:** `Pit.EntryCueText` mirrors the cue value with dash-friendly text tokens.【F:PitEngine.cs†L19-L37】
+- **Logic:** `margin < -buffer → LATE; margin ≤ 0 → BRAKE NOW; margin ≤ buffer → BRAKE SOON; else OK`.
+- **Dash string:** `Pit.EntryCueText` mirrors the cue value with dash-friendly text tokens.
 - **Dash visuals are independent:** cue selection does not dictate how the dash renders the marker/indicator.
 
 ---
@@ -102,10 +102,10 @@ Cue level is derived from **margin vs. buffer** (buffer = profile slider):
 
 Three structured INFO logs (edge-triggered):
 
-- **`ACTIVATE`** — once when assist arms. Fields: raw + guided distance, required distance, margin, speed delta, decel, buffer, cue. Used to confirm arming context and baseline margin.【F:PitEngine.cs†L428-L446】
-- **`ENTRY LINE SAFE/NORMAL`** — once on pit lane entry when you are at/below the pit limit. Includes speed delta, first compliant distance (if captured), and **time loss vs limiter** based on the compliance distance. Used to evaluate braking timing and track-specific tuning.【F:PitEngine.cs†L460-L495】
-- **`ENTRY LINE BAD`** — once on pit lane entry when still above the limit. Includes speed delta and how late you braked (metres). Time loss is omitted/zero in this case.【F:PitEngine.cs†L496-L507】
-- **`END`** — once when assist disarms (pit entry or invalidation). Used to confirm clean teardown.【F:PitEngine.cs†L376-L398】
+- **`ACTIVATE`** — once when assist arms. Fields: raw + guided distance, required distance, margin, speed delta, decel, buffer, cue. Used to confirm arming context and baseline margin.
+- **`ENTRY LINE SAFE/NORMAL`** — once on pit lane entry when you are at/below the pit limit. Includes speed delta, first compliant distance (if captured), and **time loss vs limiter** based on the compliance distance. Used to evaluate braking timing and track-specific tuning.
+- **`ENTRY LINE BAD`** — once on pit lane entry when still above the limit. Includes speed delta and how late you braked (metres). Time loss is omitted/zero in this case.
+- **`END`** — once when assist disarms (pit entry or invalidation). Used to confirm clean teardown.
 
 ---
 
@@ -123,8 +123,8 @@ These values update **once per pit entry** and remain until the next assist acti
 ## Deceleration Capture (DecelCap)
 
 - Developer-only instrumentation to empirically measure braking decel between **200→50 kph** with straight-line filtering.
-- **Master switch:** `MASTER_ENABLED` (constant, default `false`). When false, module is inert at runtime and safe to ship compiled.【F:DecelCapture.cs†L6-L82】
-- When explicitly enabled/armed, it logs high-frequency decel samples (dv/dt and lon accel) and distance between 200–50 kph for the current car/track/session token. START/END logs bracket each run; per-tick logs emit at 20 Hz.【F:DecelCapture.cs†L23-L213】【F:DecelCapture.cs†L214-L266】
+- **Master switch:** `MASTER_ENABLED` (constant, default `false`). When false, module is inert at runtime and safe to ship compiled.
+- When explicitly enabled/armed, it logs high-frequency decel samples (dv/dt and lon accel) and distance between 200–50 kph for the current car/track/session token. START/END logs bracket each run; per-tick logs emit at 20 Hz.
 - **Not part of normal behaviour:** requires explicit enable + toggle; otherwise no logs, no side effects.
 
 ---
@@ -134,8 +134,8 @@ These values update **once per pit entry** and remain until the next assist acti
 - **Per-car profiles (Dash tab):**
   - **Pit Entry Decel (m/s²):** `Pit.EntryDecelProfile_mps2` used in required-distance calc.
   - **Pit Entry Buffer (m):** `Pit.EntryBuffer_m` used in cue thresholds.
-- **Why per-car:** braking capability and tyre/booster effects differ by car; per-class is too coarse for consistent pit entry cues.【F:CarProfiles.cs†L128-L150】【F:ProfilesManagerViewModel.cs†L547-L584】
+- **Why per-car:** braking capability and tyre/booster effects differ by car; per-class is too coarse for consistent pit entry cues.
 - **Recommended starting points:**
   - **GT3:** decel ≈ **14 m/s²**, buffer **≈15 m**.
   - **GTP:** similar decel, slightly **higher buffer** for hybrid regen variability.
-- Defaults auto-seed on profile creation/copy; adjust per track after reviewing `ENTRY LINE` logs.【F:ProfilesManagerViewModel.cs†L645-L685】【F:ProfilesManagerViewModel.cs†L503-L505】
+- Defaults auto-seed on profile creation/copy; adjust per track after reviewing `ENTRY LINE` logs.

--- a/Docs/Subsystems/Pit_Timing_And_PitLoss.md
+++ b/Docs/Subsystems/Pit_Timing_And_PitLoss.md
@@ -1,7 +1,7 @@
 # Pit Timing and Pit Loss
 
-Validated against commit: 298accf  
-Last updated: 2026-02-10  
+Validated against commit: 298accf
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose

--- a/Docs/Subsystems/Profiles_And_PB.md
+++ b/Docs/Subsystems/Profiles_And_PB.md
@@ -1,7 +1,7 @@
 # Profiles and Personal Bests
 
-Validated against commit: b45bc8f  
-Last updated: 2026-02-12  
+Validated against commit: b45bc8f
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose

--- a/Docs/Subsystems/Rejoin_Assist.md
+++ b/Docs/Subsystems/Rejoin_Assist.md
@@ -1,97 +1,97 @@
 # Rejoin Assist
 
-Validated against commit: c40b3a8fdd1df4c8c1251ff7f573812b915d726f  
-Last updated: 2026-01-04  
+Validated against commit: c40b3a8fdd1df4c8c1251ff7f573812b915d726f
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose
-- Detects and classify loss-of-control, off-track, pit-exit, and wrong-way situations, then surfaces warnings to the dash and message overlays. Alerts linger dynamically to keep the driver informed until both time and speed gates are satisfied.【F:RejoinAssistEngine.cs†L11-L170】【F:RejoinAssistEngine.cs†L521-L569】
-- Provides threat-aware messaging for spins (e.g., “HOLD BRAKES”) by blending traffic proximity with vehicle speed.【F:RejoinAssistEngine.cs†L150-L165】【F:RejoinAssistEngine.cs†L269-L444】
-- Exposes pit-phase passthroughs for HUD widgets and blocks Launch Mode when a serious incident is active to avoid conflicting driver aids.【F:LalaLaunch.cs†L2922-L2933】【F:LalaLaunch.cs†L3339-L3353】
+- Detects and classify loss-of-control, off-track, pit-exit, and wrong-way situations, then surfaces warnings to the dash and message overlays. Alerts linger dynamically to keep the driver informed until both time and speed gates are satisfied.
+- Provides threat-aware messaging for spins (e.g., “HOLD BRAKES”) by blending traffic proximity with vehicle speed.
+- Exposes pit-phase passthroughs for HUD widgets and blocks Launch Mode when a serious incident is active to avoid conflicting driver aids.
 
 ## Inputs (source + cadence)
-- Vehicle state each tick: speed, gear, yaw rate, pit-lane flag, on-track flag, lap distance %, and session type/flags (start-ready/set/go).【F:RejoinAssistEngine.cs†L452-L470】【F:RejoinAssistEngine.cs†L571-L599】
-- Surface classification from `PlayerTrackSurfaceMaterial` to detect off-track conditions (>=15).【F:RejoinAssistEngine.cs†L461-L599】
-- Pit phase from `PitEngine` (used to mark exiting pits without duplicating timers).【F:RejoinAssistEngine.cs†L466-L513】
-- Traffic scan (iRacing only): `CarIdxLapDistPct`, `CarIdxEstTime`, `CarIdxTrackSurface`, `CarIdxOnPitRoad`, player index, and track length from session data, refreshed every update tick for threat scoring.【F:RejoinAssistEngine.cs†L269-L444】
-- Profile knobs injected at construction time: linger time, minimum clear speed, and spin yaw threshold (yaw threshold scaled from `SpinYawRateThreshold / 10`).【F:LalaLaunch.cs†L3005-L3010】【F:CarProfiles.cs†L118-L125】
-- Update cadence: `RejoinAssistEngine.Update` is called once per `DataUpdate` loop after pit processing.【F:LalaLaunch.cs†L3567-L3606】
+- Vehicle state each tick: speed, gear, yaw rate, pit-lane flag, on-track flag, lap distance %, and session type/flags (start-ready/set/go).
+- Surface classification from `PlayerTrackSurfaceMaterial` to detect off-track conditions (>=15).
+- Pit phase from `PitEngine` (used to mark exiting pits without duplicating timers).
+- Traffic scan (iRacing only): `CarIdxLapDistPct`, `CarIdxEstTime`, `CarIdxTrackSurface`, `CarIdxOnPitRoad`, player index, and track length from session data, refreshed every update tick for threat scoring.
+- Profile knobs injected at construction time: linger time, minimum clear speed, and spin yaw threshold (yaw threshold scaled from `SpinYawRateThreshold / 10`).
+- Update cadence: `RejoinAssistEngine.Update` is called once per `DataUpdate` loop after pit processing.
 
 ## Internal State
-- `_currentLogicReason` vs `_detectedReason` capture the active alert and the most recent detection result (can diverge during linger/delays).【F:RejoinAssistEngine.cs†L59-L170】【F:RejoinAssistEngine.cs†L521-L569】
-- Timers: `_delayTimer` (arm delays per alert type), `_lingerTimer` (post-clear hold), `_spinHoldTimer` (3 s spin emphasis), `_msgCxTimer` (manual override hold).【F:RejoinAssistEngine.cs†L80-L115】【F:RejoinAssistEngine.cs†L475-L565】
-- Recent lap distance `_previousLapDistPct` and last speed/yaw context for wrong-way and spin detection. `_rejoinSpeed` caches speed at linger start.【F:RejoinAssistEngine.cs†L61-L67】【F:RejoinAssistEngine.cs†L585-L599】【F:RejoinAssistEngine.cs†L515-L526】
-- Threat assessor state: smoothed TTC, demotion hysteresis targets, last-good TTC timestamp, and debug string for diagnostics.【F:RejoinAssistEngine.cs†L235-L444】
-- Public flags mirrored to dashboards: pit phase, exiting-pits boolean, threat level, time-to-threat, linger/override timer readouts, and serious-incident sentinel (spin/stopped/wrong-way).【F:RejoinAssistEngine.cs†L69-L116】【F:RejoinAssistEngine.cs†L91-L104】
+- `_currentLogicReason` vs `_detectedReason` capture the active alert and the most recent detection result (can diverge during linger/delays).
+- Timers: `_delayTimer` (arm delays per alert type), `_lingerTimer` (post-clear hold), `_spinHoldTimer` (3 s spin emphasis), `_msgCxTimer` (manual override hold).
+- Recent lap distance `_previousLapDistPct` and last speed/yaw context for wrong-way and spin detection. `_rejoinSpeed` caches speed at linger start.
+- Threat assessor state: smoothed TTC, demotion hysteresis targets, last-good TTC timestamp, and debug string for diagnostics.
+- Public flags mirrored to dashboards: pit phase, exiting-pits boolean, threat level, time-to-threat, linger/override timer readouts, and serious-incident sentinel (spin/stopped/wrong-way).
 
 ## Calculation Blocks (high level)
-1) **Reason detection (pre-priority):**  
-   - Suppressed states: not in car, in pit lane, offline practice, race-start flag window, or launch mode active short-circuit the system.  
-   - Incident detection: yaw rate over threshold ⇒ `Spin`; surface >=15 ⇒ `OffTrackLow/High` based on speed threshold; speed <20 kph on track ⇒ `StoppedOnTrack`; decreasing lap distance while moving and not crossing S/F ⇒ `WrongWay`.【F:RejoinAssistEngine.cs†L571-L600】【F:RejoinAssistEngine.cs†L487-L514】
-2) **Priority resolver:**  
-   - Manual override (`MsgCx`) wins; first second also hard-resets state.  
-   - Suppressed states (including launch active) replace the current logic and clear timers.  
-   - Active timers: spin hold (3 s) and pit-exit phase trump new detections.  
-   - Linger: when an alert clears, timer runs with dynamic duration (threat-aware minimum 2 s, scaled by speed) and requires speed above the configured threshold to dismiss.  
-   - New alerts respect per-type delays (1.5 s high-speed off-track, 2 s stopped, else 1 s) before latching; spin latches immediately and starts the spin hold timer.【F:RejoinAssistEngine.cs†L475-L555】【F:RejoinAssistEngine.cs†L201-L231】
-3) **Threat assessment:**  
-   - Scans opponents up to 60 % of a lap behind; derives distance and TTC from EstTime or a fallback formula, ignores NIW/pit cars, and applies guards for far-distance/short-spike noise.  
-   - Smooths improving TTC (EMA) and applies sensitivity scaling when rejoining or slow, adjusting time/distance gates and hysteresis demotion holds.  
-   - Classifies `CLEAR/CAUTION/WARNING/DANGER` and emits debug string for trace overlays.【F:RejoinAssistEngine.cs†L269-L444】
-4) **Message selection:**  
-   - Maps logic reason to text; suppresses lingering text once the detected reason is clear.  
-   - Spin text escalates to “HOLD BRAKES” only when slow (≤50 kph) *and* threat under 6 s or WARNING/DANGER.【F:RejoinAssistEngine.cs†L128-L170】
+1) **Reason detection (pre-priority):**
+   - Suppressed states: not in car, in pit lane, offline practice, race-start flag window, or launch mode active short-circuit the system.
+   - Incident detection: yaw rate over threshold ⇒ `Spin`; surface >=15 ⇒ `OffTrackLow/High` based on speed threshold; speed <20 kph on track ⇒ `StoppedOnTrack`; decreasing lap distance while moving and not crossing S/F ⇒ `WrongWay`.
+2) **Priority resolver:**
+   - Manual override (`MsgCx`) wins; first second also hard-resets state.
+   - Suppressed states (including launch active) replace the current logic and clear timers.
+   - Active timers: spin hold (3 s) and pit-exit phase trump new detections.
+   - Linger: when an alert clears, timer runs with dynamic duration (threat-aware minimum 2 s, scaled by speed) and requires speed above the configured threshold to dismiss.
+   - New alerts respect per-type delays (1.5 s high-speed off-track, 2 s stopped, else 1 s) before latching; spin latches immediately and starts the spin hold timer.
+3) **Threat assessment:**
+   - Scans opponents up to 60 % of a lap behind; derives distance and TTC from EstTime or a fallback formula, ignores NIW/pit cars, and applies guards for far-distance/short-spike noise.
+   - Smooths improving TTC (EMA) and applies sensitivity scaling when rejoining or slow, adjusting time/distance gates and hysteresis demotion holds.
+   - Classifies `CLEAR/CAUTION/WARNING/DANGER` and emits debug string for trace overlays.
+4) **Message selection:**
+   - Maps logic reason to text; suppresses lingering text once the detected reason is clear.
+   - Spin text escalates to “HOLD BRAKES” only when slow (≤50 kph) *and* threat under 6 s or WARNING/DANGER.
 
 ## Rejoin reasons, triggers, and priorities
-- **SettingDisabled (0):** Returned only by legacy callers; not actively produced by detection logic. Treated as suppressed (priority branch that clears timers and prevents alerting).【F:RejoinAssistEngine.cs†L11-L34】【F:RejoinAssistEngine.cs†L487-L505】
-- **NotInCar (1):** Fires when `IsOnTrack` is false; hard-resets state and clears timers during the suppressed priority path (launch mode also suppressed).【F:RejoinAssistEngine.cs†L571-L599】【F:RejoinAssistEngine.cs†L487-L505】
-- **InPit (2):** Detected via `IsInPitLane`; forces suppressed state so dash messages stay hidden while in lane. Pit-exit alerts are instead driven by `PitEngine` phase later in the priority ladder.【F:RejoinAssistEngine.cs†L452-L513】【F:RejoinAssistEngine.cs†L571-L600】
-- **OfflinePractice (3):** Session type equals “Offline Testing”; suppresses alerts so test sessions stay quiet.【F:RejoinAssistEngine.cs†L571-L600】
-- **RaceStart (4):** Session flags in start window (`SessionState` 1–3 or StartReady/Set/Go); suppresses alerts to avoid spurious warnings during grid/launch. Launch Mode active also enters the same suppressed branch.【F:RejoinAssistEngine.cs†L488-L505】【F:RejoinAssistEngine.cs†L571-L600】
-- **LaunchModeActive (5):** Applied when the launch module is active; follows suppressed-state path to avoid overlapping driver aids.【F:RejoinAssistEngine.cs†L487-L505】【F:LalaLaunch.cs†L3339-L3353】
-- **MsgCxPressed (6):** Manual cancel button. First second forces a full reset and then holds the override for up to 30 s (priority 1). During the hold, reason code stays `MsgCxPressed` and all alerts are suppressed. After 30 s, the override timer self-expires.【F:RejoinAssistEngine.cs†L475-L565】
-- **None (50):** Neutral state. Any lingering timers must clear before returning here (time + speed gates).【F:RejoinAssistEngine.cs†L515-L526】
-- **PitExit (60):** Mirrors `PitEngine` phase `ExitingPits`; outranks linger/new detections (priority 3). Dismisses when phase ends; no delay/linger timers applied.【F:RejoinAssistEngine.cs†L466-L513】
-- **StoppedOnTrack (100):** Speed <20 kph on track surface; uses a 2.0 s arming delay before latching and then obeys linger/time-to-clear rules. Message: “STOPPED ON TRACK - HAZARD!”.【F:RejoinAssistEngine.cs†L520-L553】【F:RejoinAssistEngine.cs†L142-L170】【F:RejoinAssistEngine.cs†L571-L600】
-- **OffTrackLowSpeed (110):** Off-track surface (>=15) and speed below threshold; uses 1.0 s delay before latching. Message: “OFF TRACK - REJOIN WHEN SAFE”.【F:RejoinAssistEngine.cs†L520-L553】【F:RejoinAssistEngine.cs†L144-L170】
-- **OffTrackHighSpeed (120):** Off-track surface (>=15) and speed at/above threshold; uses 1.5 s delay before latching. Message: “OFF TRACK - CHECK TRAFFIC”.【F:RejoinAssistEngine.cs†L520-L553】【F:RejoinAssistEngine.cs†L145-L170】
-- **Spin (130):** Yaw over threshold; latches immediately, starts 3 s spin-hold timer, and invokes spin-specific messaging (HOLD BRAKES gate + threat-aware linger). Message stays `Spin` during hold and linger unless MsgCx overrides.【F:RejoinAssistEngine.cs†L527-L565】【F:RejoinAssistEngine.cs†L150-L165】
-- **WrongWay (140):** Lap distance percentage decreasing outside S/F crossing (with forward gear and speed >5 kph); latches immediately (no delay) and follows normal linger rules. Message: “WRONG WAY - TURN AROUND SAFELY!”.【F:RejoinAssistEngine.cs†L585-L599】【F:RejoinAssistEngine.cs†L167-L170】
+- **SettingDisabled (0):** Returned only by legacy callers; not actively produced by detection logic. Treated as suppressed (priority branch that clears timers and prevents alerting).
+- **NotInCar (1):** Fires when `IsOnTrack` is false; hard-resets state and clears timers during the suppressed priority path (launch mode also suppressed).
+- **InPit (2):** Detected via `IsInPitLane`; forces suppressed state so dash messages stay hidden while in lane. Pit-exit alerts are instead driven by `PitEngine` phase later in the priority ladder.
+- **OfflinePractice (3):** Session type equals “Offline Testing”; suppresses alerts so test sessions stay quiet.
+- **RaceStart (4):** Session flags in start window (`SessionState` 1–3 or StartReady/Set/Go); suppresses alerts to avoid spurious warnings during grid/launch. Launch Mode active also enters the same suppressed branch.
+- **LaunchModeActive (5):** Applied when the launch module is active; follows suppressed-state path to avoid overlapping driver aids.
+- **MsgCxPressed (6):** Manual cancel button. First second forces a full reset and then holds the override for up to 30 s (priority 1). During the hold, reason code stays `MsgCxPressed` and all alerts are suppressed. After 30 s, the override timer self-expires.
+- **None (50):** Neutral state. Any lingering timers must clear before returning here (time + speed gates).
+- **PitExit (60):** Mirrors `PitEngine` phase `ExitingPits`; outranks linger/new detections (priority 3). Dismisses when phase ends; no delay/linger timers applied.
+- **StoppedOnTrack (100):** Speed <20 kph on track surface; uses a 2.0 s arming delay before latching and then obeys linger/time-to-clear rules. Message: “STOPPED ON TRACK - HAZARD!”.
+- **OffTrackLowSpeed (110):** Off-track surface (>=15) and speed below threshold; uses 1.0 s delay before latching. Message: “OFF TRACK - REJOIN WHEN SAFE”.
+- **OffTrackHighSpeed (120):** Off-track surface (>=15) and speed at/above threshold; uses 1.5 s delay before latching. Message: “OFF TRACK - CHECK TRAFFIC”.
+- **Spin (130):** Yaw over threshold; latches immediately, starts 3 s spin-hold timer, and invokes spin-specific messaging (HOLD BRAKES gate + threat-aware linger). Message stays `Spin` during hold and linger unless MsgCx overrides.
+- **WrongWay (140):** Lap distance percentage decreasing outside S/F crossing (with forward gear and speed >5 kph); latches immediately (no delay) and follows normal linger rules. Message: “WRONG WAY - TURN AROUND SAFELY!”.
 
 ### MsgCx (cancel) behaviour per reason
-- Triggers priority 1 override: replaces the active logic reason with `MsgCxPressed`, suppresses all alert text, and zeros timers during the first second (full Reset).【F:RejoinAssistEngine.cs†L475-L505】
-- While active (<30 s), the reason code published to SimHub remains `MsgCxPressed`, preventing downstream dashboards from showing rejoin warnings regardless of prior state. After expiry, detection/priorities resume as normal at the next `Update` tick.【F:RejoinAssistEngine.cs†L475-L565】
+- Triggers priority 1 override: replaces the active logic reason with `MsgCxPressed`, suppresses all alert text, and zeros timers during the first second (full Reset).
+- While active (<30 s), the reason code published to SimHub remains `MsgCxPressed`, preventing downstream dashboards from showing rejoin warnings regardless of prior state. After expiry, detection/priorities resume as normal at the next `Update` tick.
 
 ## Outputs (exports + logs)
-- SimHub exports: `RejoinAlertReasonCode/Name/Message`, pit phase (`RejoinCurrentPitPhase(Name)`, `RejoinIsExitingPits`), and threat metrics (`RejoinThreatLevel/Name`, `RejoinTimeToThreat`).【F:LalaLaunch.cs†L2922-L2933】
-- Serious-incident flag (`IsSeriousIncidentActive`) feeds Launch Mode blocker to cancel/deny launches when spin/stopped/wrong-way is detected.【F:LalaLaunch.cs†L3339-L3353】
-- Dash visibility toggles (`LalaDashShowRejoinAssist`, `MsgDashShowRejoinAssist`) live alongside other dash controls so users can hide the overlay without disabling logic.【F:LalaLaunch.cs†L2935-L2953】
-- Log: manual cancel trigger logs `[LalaPlugin:Rejoin Assist] MsgCx override triggered.` via `TriggerMsgCxOverride()`.【F:RejoinAssistEngine.cs†L602-L605】
+- SimHub exports: `RejoinAlertReasonCode/Name/Message`, pit phase (`RejoinCurrentPitPhase(Name)`, `RejoinIsExitingPits`), and threat metrics (`RejoinThreatLevel/Name`, `RejoinTimeToThreat`).
+- Serious-incident flag (`IsSeriousIncidentActive`) feeds Launch Mode blocker to cancel/deny launches when spin/stopped/wrong-way is detected.
+- Dash visibility toggles (`LalaDashShowRejoinAssist`, `MsgDashShowRejoinAssist`) live alongside other dash controls so users can hide the overlay without disabling logic.
+- Log: manual cancel trigger logs `[LalaPlugin:Rejoin Assist] MsgCx override triggered.` via `TriggerMsgCxOverride()`.
 
 ## Dependencies / ordering assumptions
-- Requires `PitEngine` instance to mirror pit phases; rejoin update runs after pit update so pit-exit state is current before evaluating priorities.【F:LalaLaunch.cs†L3044-L3053】【F:LalaLaunch.cs†L3567-L3606】
-- Traffic/threat block is iRacing-only; non-iRacing titles remain at `CLEAR` with default TTC.【F:RejoinAssistEngine.cs†L284-L288】
-- Profile inputs must stay within defensive bounds: linger time is clamped to 0.5–10 s when wiring `PitEngine`; spin yaw threshold is divided by 10 before passing to the engine.【F:LalaLaunch.cs†L3005-L3052】【F:CarProfiles.cs†L118-L125】
+- Requires `PitEngine` instance to mirror pit phases; rejoin update runs after pit update so pit-exit state is current before evaluating priorities.
+- Traffic/threat block is iRacing-only; non-iRacing titles remain at `CLEAR` with default TTC.
+- Profile inputs must stay within defensive bounds: linger time is clamped to 0.5–10 s when wiring `PitEngine`; spin yaw threshold is divided by 10 before passing to the engine.
 
 ## Reset Rules
-- Session-token change resets the engine, pit phase, lap-distance tracking, and threat state to defaults before continuing the new session.【F:LalaLaunch.cs†L3529-L3555】
-- Manual cancel (`MsgCx`) resets state during the first second of the override; leaving the car (`NotInCar`) also clears timers and reasons.【F:RejoinAssistEngine.cs†L475-L505】【F:RejoinAssistEngine.cs†L571-L599】
-- Spin hold and manual override timers self-expire at 3 s and 30 s respectively; linger clears once both time and speed gates are met.【F:RejoinAssistEngine.cs†L521-L565】
+- Session-token change resets the engine, pit phase, lap-distance tracking, and threat state to defaults before continuing the new session.
+- Manual cancel (`MsgCx`) resets state during the first second of the override; leaving the car (`NotInCar`) also clears timers and reasons.
+- Spin hold and manual override timers self-expire at 3 s and 30 s respectively; linger clears once both time and speed gates are met.
 
 ## Failure Modes / Safeguards
-- Threat scan falls back to `CLEAR` if required iRacing arrays or lap distance data are missing; debug string records the guard cause for diagnostics.【F:RejoinAssistEngine.cs†L284-L298】【F:RejoinAssistEngine.cs†L442-L444】
-- Wrong-way detection guards against start/finish crossings (lap pct wrap) to avoid false positives; still relies on forward gear check to reduce reverse-stint noise.【F:RejoinAssistEngine.cs†L585-L599】
-- High-speed off-track and stopped-on-track alerts require a minimum delay before latching, reducing transient false alarms but delaying the first warning slightly.【F:RejoinAssistEngine.cs†L527-L555】
-- Linger dismissal requires both time and speed gates; if the car is kept below the configured clear-speed threshold, the visible alert will persist longer by design.【F:RejoinAssistEngine.cs†L515-L526】
+- Threat scan falls back to `CLEAR` if required iRacing arrays or lap distance data are missing; debug string records the guard cause for diagnostics.
+- Wrong-way detection guards against start/finish crossings (lap pct wrap) to avoid false positives; still relies on forward gear check to reduce reverse-stint noise.
+- High-speed off-track and stopped-on-track alerts require a minimum delay before latching, reducing transient false alarms but delaying the first warning slightly.
+- Linger dismissal requires both time and speed gates; if the car is kept below the configured clear-speed threshold, the visible alert will persist longer by design.
 
 ## Test Checklist
-- Trigger each alert path (spin, wrong-way, stopped, off-track high/low, pit exit) and verify correct message text and delay/linger behaviour.  
-- Confirm threat levels climb and decay with nearby traffic during a rejoin (including spin “HOLD BRAKES” gating).  
-- Validate MsgCx override clears messages immediately and holds suppression for up to 30 s.  
-- Verify session change resets state (reason code/time-to-threat clear) and Launch Mode refuses to arm during active serious incidents.  
-- Check pit-exit flagging matches PitEngine phases on dash exports while on-track alerts remain suppressed in pit lane.  
-- Adjust profile knobs (linger time, clear speed, yaw threshold) and ensure changes flow through without restart.【F:LalaLaunch.cs†L3005-L3010】【F:CarProfiles.cs†L118-L125】
+- Trigger each alert path (spin, wrong-way, stopped, off-track high/low, pit exit) and verify correct message text and delay/linger behaviour.
+- Confirm threat levels climb and decay with nearby traffic during a rejoin (including spin “HOLD BRAKES” gating).
+- Validate MsgCx override clears messages immediately and holds suppression for up to 30 s.
+- Verify session change resets state (reason code/time-to-threat clear) and Launch Mode refuses to arm during active serious incidents.
+- Check pit-exit flagging matches PitEngine phases on dash exports while on-track alerts remain suppressed in pit lane.
+- Adjust profile knobs (linger time, clear speed, yaw threshold) and ensure changes flow through without restart.
 
 ## TODO / VERIFY
-- TODO/VERIFY: Validate spin yaw-rate threshold scaling (`/10`) against telemetry units to ensure cross-sim correctness.【F:LalaLaunch.cs†L3005-L3010】
-- TODO/VERIFY: Threat assessor currently ignores cars more than 60 % of a lap behind; confirm this window is sufficient on ultra-short tracks.【F:RejoinAssistEngine.cs†L321-L339】
+- TODO/VERIFY: Validate spin yaw-rate threshold scaling (`/10`) against telemetry units to ensure cross-sim correctness.
+- TODO/VERIFY: Threat assessor currently ignores cars more than 60 % of a lap behind; confirm this window is sufficient on ultra-short tracks.

--- a/Docs/Subsystems/Trace_Logging.md
+++ b/Docs/Subsystems/Trace_Logging.md
@@ -1,7 +1,7 @@
 # Trace Logging
 
 Validated against commit: 298accf
-Last updated: 2026-02-10
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose
@@ -57,9 +57,9 @@ One row per lap crossing:
 
 ## Outputs
 
-- Summary file: `SessionSummary.csv` under `Logs/LalaPluginData/LalaSessionSummaries` (or configured path). Rows are only written once green + checkered are seen and include planner, profile, and actual race stats in schema version `v2`.【F:SessionSummaryLogger.cs†L31-L176】【F:SessionSummaryModel.cs†L9-L137】
-- Per-lap trace files: `SessionTrace_<car>_<track>_<timestamp>.csv` under `.../LalaSessionSummaries/Traces`. Trace rows include `PitStopIndex` and `PitStopPhase` alongside lap/fuel snapshots.【F:SessionSummaryLogger.cs†L41-L131】【F:SessionTraceLapRow.cs†L7-L33】
-- Summary embedded in trace: the summary row can be appended inside the trace file between `#[SessionSummary]` markers for later parsing.【F:SessionSummaryLogger.cs†L133-L178】
+- Summary file: `SessionSummary.csv` under `Logs/LalaPluginData/LalaSessionSummaries` (or configured path). Rows are only written once green + checkered are seen and include planner, profile, and actual race stats in schema version `v2`.
+- Per-lap trace files: `SessionTrace_<car>_<track>_<timestamp>.csv` under `.../LalaSessionSummaries/Traces`. Trace rows include `PitStopIndex` and `PitStopPhase` alongside lap/fuel snapshots.
+- Summary embedded in trace: the summary row can be appended inside the trace file between `#[SessionSummary]` markers for later parsing.
 
 ---
 
@@ -125,7 +125,7 @@ The values above map directly to `SessionSummaryModel` fields, and the `SchemaVe
 ---
 
 ## Pit stop index semantics
-- `PitStopIndex` is **1-based** and increments once per completed pit cycle (first stop => 1). The maximum index seen is used as the session’s `Actual_PitStops` value in the summary output.【F:LalaLaunch.cs†L3927-L3942】【F:SessionSummaryRuntime.cs†L152-L245】
+- `PitStopIndex` is **1-based** and increments once per completed pit cycle (first stop => 1). The maximum index seen is used as the session’s `Actual_PitStops` value in the summary output.
 
 ## TODO / VERIFY
 

--- a/Docs/Subsystems/Track_Markers.md
+++ b/Docs/Subsystems/Track_Markers.md
@@ -1,61 +1,62 @@
 # Track Markers (Pit Entry/Exit) — Auto-Learn, Storage, MSGV1
 
-Validated against commit: HEAD  
-Last updated: 2026-03-22  
+Validated against commit: HEAD
+Last updated: 2026-03-24
 Branch: work
 
 ## Purpose
 Capture pit entry/exit lines per track, keep them stable across sessions via persisted storage, and surface lifecycle notifications through MSGV1. The pattern is intentionally reusable: **auto-learn → lock → notify**.
 
 ## Source of truth and storage
-- **Source of truth:** Persisted markers in `PluginsData/Common/LalaPlugin/TrackMarkers.json` (`PitEngine` store). Live telemetry is only used to propose captures; stored values drive exports and UI snapshots. Legacy `LalaPlugin.TrackMarkers.json` is migrated on load if present.【F:PitEngine.cs†L948-L1034】
-- **Keys:** Canonicalised track key from SimHub (`TrackCode`, then display/config/name fallbacks). Unknown/blank keys short-circuit all marker handling.【F:PitEngine.cs†L629-L676】【F:PitEngine.cs†L821-L878】
-- **Embedded seed support:** If the persisted store does not exist yet, `PitEngine` seeds defaults from an embedded in-code track-marker set. Only records with valid seeded entry and exit percents are accepted; invalid / `NaN` / incomplete entries are skipped rather than coerced. The shipped embedded rows also carry fixed stored timestamps, so first-run seeded JSON stays deterministic instead of picking up the current clock time.【F:PitEngine.cs†L1046-L1148】
-- **Defaults after seeding:** New tracks still start **locked = true** with empty percents when no valid embedded seed entry exists for that track. Lock can be toggled via UI or actions; lock state is persisted with the markers.【F:PitEngine.cs†L586-L600】【F:PitEngine.cs†L968-L1034】
+- **Source of truth:** Persisted markers in `PluginsData/Common/LalaPlugin/TrackMarkers.json` (`PitEngine` store). Live telemetry is only used to propose captures; stored values drive exports and UI snapshots. Legacy `LalaPlugin.TrackMarkers.json` is migrated on load if present.
+- **Keys:** Canonicalised track key from SimHub (`TrackCode`, then display/config/name fallbacks). Unknown/blank keys short-circuit all marker handling.
+- **Embedded seed support:** If the persisted store does not exist yet, `PitEngine` seeds defaults from an embedded in-code track-marker set. Only records with valid seeded entry and exit percents are accepted; invalid / `NaN` / incomplete entries are skipped rather than coerced. The shipped embedded rows also carry fixed stored timestamps, so first-run seeded JSON stays deterministic instead of picking up the current clock time.
+- **Defaults after seeding:** New tracks still start **locked = true** with empty percents when no valid embedded seed entry exists for that track. Lock can be toggled via UI or actions; lock state is persisted with the markers.
 
 ## Inputs and guards
-- **Track length:** Parsed once per session from `WeekendInfo.TrackLength` (kilometres). Values outside **500–20000 m** are ignored.【F:PitEngine.cs†L126-L154】【F:PitEngine.cs†L669-L676】
-- **Position:** Normalised `TrackPositionPercent`, clamped to [0,1]; entry captures require **≥0.50**, exit captures require **≤0.50** to avoid cross-lap confusion.【F:PitEngine.cs†L630-L714】
-- **Speed / stall guards:** Entry capture requires **>5 kph** and not in stall; exit capture requires **>10 kph** and not in stall.【F:PitEngine.cs†L606-L642】
+- **Track length:** Parsed once per session from `WeekendInfo.TrackLength` (kilometres). Values outside **500–20000 m** are ignored.
+- **Position:** Normalised `TrackPositionPercent`, clamped to [0,1]; entry captures require **≥0.50**, exit captures require **≤0.50** to avoid cross-lap confusion.
+- **Speed / stall guards:** Entry capture requires **>5 kph** and not in stall; exit capture requires **>10 kph** and not in stall.
 
 ## Auto-learn flow
-1) **Edge detection:** Entry edge = pit-lane flag rising; exit edge = pit-lane flag falling. Both run even on the first valid lap after start.【F:PitEngine.cs†L600-L642】
-2) **Overwrite rules:**  
-   - Missing marker → capture.  
-   - Track-length refresh pending → capture and clear refresh flag.  
-   - Unlocked marker with delta **>0.1 %** (`TrackMarkerDeltaTolerancePct`) → capture.  
-   - Locked marker remains unless refresh forced; mismatches trigger MSGV1 (below).【F:PitEngine.cs†L669-L769】
-3) **First complete pair:** When both entry and exit are valid, emit a `FirstCapture` trigger (latched per session).【F:PitEngine.cs†L752-L769】
-4) **Persistence:** Writes immediately to JSON on every accepted capture or lock toggle; reload restores previous in-memory state on failure.【F:PitEngine.cs†L968-L1034】
+1) **Edge detection:** Entry edge = pit-lane flag rising; exit edge = pit-lane flag falling. Both run even on the first valid lap after start.
+2) **Overwrite rules:**
+   - Missing marker → capture.
+   - Track-length refresh pending → capture and clear refresh flag.
+   - Unlocked marker with delta **>0.1 %** (`TrackMarkerDeltaTolerancePct`) → capture.
+   - Locked marker remains unless refresh forced; mismatches trigger MSGV1 (below).
+3) **First complete pair:** When both entry and exit are valid, emit a `FirstCapture` trigger (latched per session).
+4) **Persistence:** Writes immediately to JSON on every accepted capture or lock toggle; reload restores previous in-memory state on failure.
 
 ## Track length handling
-- **Session baseline:** First valid track length per session is latched as `SessionStartTrackLengthM`. Live length is tracked thereafter.【F:PitEngine.cs†L126-L154】【F:PitEngine.cs†L669-L676】
-- **Change detection:** Delta **>50 m** marks `TrackLengthChanged`, forces **unlock**, and flags both edges for refresh. A MSGV1 length-delta trigger is enqueued with start/current/delta metres.【F:PitEngine.cs†L669-L714】
-- **Refresh completion:** When both refreshed edges are captured after a length change, a `LinesRefreshed` trigger fires (latched once per session).【F:PitEngine.cs†L741-L769】
+- **Session baseline:** First valid track length per session is latched as `SessionStartTrackLengthM`. Live length is tracked thereafter.
+- **Change detection:** Delta **>50 m** marks `TrackLengthChanged`, forces **unlock**, and flags both edges for refresh. A MSGV1 length-delta trigger is enqueued with start/current/delta metres.
+- **Refresh completion:** When both refreshed edges are captured after a length change, a `LinesRefreshed` trigger fires (latched once per session).
 - **Accepted limitation:** Replay/session-identity quirks can surface inconsistent track lengths; length-delta messages are informational and do not block use.
 
 ## Lock semantics
-- **Locked = true:** Stored markers are authoritative. Live captures only notify on mismatch (MSGV1) unless a track-length refresh forced unlock already.【F:PitEngine.cs†L669-L769】
+- **Locked = true:** Stored markers are authoritative. Live captures only notify on mismatch (MSGV1) unless a track-length refresh forced unlock already.
 - **Locked = false:** Live captures that differ by >0.1 % overwrite and persist immediately.
-- **Auto-unlock:** Track-length change (>50 m) clears lock before refresh to ensure updated markers can be stored.【F:PitEngine.cs†L669-L714】
-- **Manual control:** Lock checkbox in Profiles → Tracks panel writes through to store; actions `TrackMarkersLock/Unlock` mirror the same setter.【F:ProfilesManagerView.xaml†L450-L488】【F:LalaLaunch.cs†L134-L179】
+- **Auto-unlock:** Track-length change (>50 m) clears lock before refresh to ensure updated markers can be stored.
+- **Manual control:** Lock checkbox in Profiles → Tracks panel writes through to store; actions `TrackMarkersLock/Unlock` mirror the same setter.
 
 ## UI behaviour (Profiles → Tracks panel)
-- **Snapshot fields:** Stored pit entry %, stored pit exit %, last-updated UTC, and lock checkbox. Values reflect the **selected track** snapshot and auto-refresh when the selection changes.【F:ProfilesManagerView.xaml†L450-L488】【F:ProfilesManagerViewModel.cs†L887-L927】
-- **Lock toggle:** Writes immediately to the store (debounced via `_suppressTrackMarkersLockAction` to avoid recursive refresh).【F:ProfilesManagerViewModel.cs†L425-L439】
-- **Reload button:** Forces `TrackMarkers.json` reload from disk (for manual edits), then rebinds the snapshot view.【F:ProfilesManagerView.xaml†L450-L488】【F:ProfilesManagerViewModel.cs†L927-L937】
+- **Snapshot fields:** Stored pit entry %, stored pit exit %, last-updated UTC, and lock checkbox. Values reflect the **selected track** snapshot and auto-refresh when the selection changes.
+- **Lock toggle:** Writes immediately to the store (debounced via `_suppressTrackMarkersLockAction` to avoid recursive refresh).
+- **Reload button:** Forces `TrackMarkers.json` reload from disk (for manual edits), then rebinds the snapshot view.
 
 ## MSGV1 messaging behaviour
-- **Pulses produced by `PitEngine` → `LalaLaunch` → `SignalProvider`:**  
-  - `TrackMarkers.Pulse.Captured` (first full pair captured)【F:LalaLaunch.cs†L3118-L3179】【F:Messaging/SignalProvider.cs†L94-L101】  
-  - `TrackMarkers.Pulse.LengthDelta` (track length changed)【F:LalaLaunch.cs†L3118-L3179】【F:Messaging/SignalProvider.cs†L94-L101】  
-  - `TrackMarkers.Pulse.LockedMismatch` (locked store differs from live detection beyond tolerance)【F:LalaLaunch.cs†L3118-L3179】【F:Messaging/SignalProvider.cs†L94-L101】
-- **Evaluators:** `Eval_TrackMarkersCaptured`, `Eval_TrackMarkersLengthDelta`, `Eval_TrackMarkersLockedMismatch` consume the pulses once per track key and latch tokens to avoid repetition.【F:Messaging/MessageEvaluators.cs†L401-L476】
-- **Definitions:** Messages are definition-driven in `MessageDefinitionStore`/`Messages.json` (`MsgId`: `trackmarkers.captured`, `trackmarkers.length_delta`, `trackmarkers.lock_mismatch`); no legacy/adhoc messaging paths are used.【F:Messaging/MessageDefinitionStore.cs†L393-L452】
-- **Active behaviour:** MSGV1 displays a low/med priority toast per trigger; payload includes track key and stored vs candidate values (for mismatch) for log clarity. Pulses expire after ~3 s if not consumed.【F:LalaLaunch.cs†L2635-L3179】
+- **Release status:** These MSGV1 toasts are development-track behavior and are not part of the shipped plugin v1.0 runtime contract.
+- **Pulses produced by `PitEngine` → `LalaLaunch` → `SignalProvider`:**
+  - `TrackMarkers.Pulse.Captured` (first full pair captured)
+  - `TrackMarkers.Pulse.LengthDelta` (track length changed)
+  - `TrackMarkers.Pulse.LockedMismatch` (locked store differs from live detection beyond tolerance)
+- **Evaluators:** `Eval_TrackMarkersCaptured`, `Eval_TrackMarkersLengthDelta`, `Eval_TrackMarkersLockedMismatch` consume the pulses once per track key and latch tokens to avoid repetition.
+- **Definitions:** Messages are definition-driven in `MessageDefinitionStore`/`Messages.json` (`MsgId`: `trackmarkers.captured`, `trackmarkers.length_delta`, `trackmarkers.lock_mismatch`); no legacy/adhoc messaging paths are used.
+- **Active behaviour:** MSGV1 displays a low/med priority toast per trigger; payload includes track key and stored vs candidate values (for mismatch) for log clarity. Pulses expire after ~3 s if not consumed.
 
 ## Pit-exit HUD exports (distance/time)
-- `LalaLaunch` derives `PitExit.DistanceM` and `PitExit.TimeS` from the stored exit marker, cached track length, live car track position, and speed. Outputs are zeroed when not in pit lane and update on the 250 ms poll cadence using the `inLane` flag already computed for PitLite, avoiding unnecessary churn while running on track.【F:LalaLaunch.cs†L3743-L3759】【F:LalaLaunch.cs†L4077-L4104】
+- `LalaLaunch` derives `PitExit.DistanceM` and `PitExit.TimeS` from the stored exit marker, cached track length, live car track position, and speed. Outputs are zeroed when not in pit lane and update on the 250 ms poll cadence using the `inLane` flag already computed for PitLite, avoiding unnecessary churn while running on track.
 - Calculations preserve prior wrapping/clamping behaviour (forward delta, wrap at S/F, integer rounding) and reuse the existing speed epsilon for time estimates; only the gating/cadence changed.
 
 ## Reuse guidance

--- a/Docs/Subsystems/_Template.md
+++ b/Docs/Subsystems/_Template.md
@@ -1,7 +1,7 @@
 # Subsystem Template
 
-Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1  
-Last updated: 2025-12-28  
+Validated against commit: 8618f167efb6ed4f89b7fe60b69a25dd4da53fd1
+Last updated: 2026-03-24
 Branch: docs/refresh-index-subsystems
 
 Fill each section with concise, technician-focused details. Use TODO/VERIFY where validation is incomplete and cite evidence (file/class/method).


### PR DESCRIPTION
### Motivation
- Bring multiple subsystem documentation pages up to date with recent design clarifications and a uniform last‑updated timestamp. 
- Surface the in-development v1 message engine (`MSGV1.*`) behavior, exports, styling, and migration notes for dashboard/integration work.
- Clarify operational rules and precedence (e.g., Opponents leaderboard-selection, Pit Entry Assist cues, Track Markers auto-learn/lock behavior) so implementers and integrators have unambiguous references.

### Description
- Updated metadata and editorial fixes across many subsystem docs, including `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Subsystems/MessageEngineV1_Notes.md`, `Docs/Subsystems/Message_System_V1.md`, `Docs/Subsystems/Opponents.md`, `Docs/Subsystems/Pit_Entry_Assist.md`, `Docs/Subsystems/Pit_Timing_And_PitLoss.md`, `Docs/Subsystems/Profiles_And_PB.md`, `Docs/Subsystems/Rejoin_Assist.md`, `Docs/Subsystems/Trace_Logging.md`, `Docs/Subsystems/Track_Markers.md`, and `Docs/Subsystems/_Template.md` to reflect the current design state and date. 
- Expanded `MessageEngineV1` and `Message_System_V1` notes with Purpose, Core behavior, Selection/Clear logic, Export contract, Styling rules, Compatibility/migration guidance, and Diagnostics for `MSGV1.*` exports and evaluator handling. 
- Clarified operational semantics for subsystems: leaderboard‑authoritative opponent selection in `Opponents`, pit entry cue logic and logging in `Pit_Entry_Assist`, auto‑learn/lock/MSGV1 notify flow and release status in `Track_Markers`, and other small wording/formatting fixes for consistency. 
- Normalized formatting (bullets, tables, hyphenation) and TODO/VERIFY lines to improve readability and maintainability in the docs. 

### Testing
- No automated tests were run because this is a documentation-only change; no runtime code was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e2115018832f8e3067186dfb106c)