### PR TITLE
docs: add v1.x constraints and improve support visibility

### DIFF
--- a/Docs/Dashboards.md
+++ b/Docs/Dashboards.md
@@ -63,7 +63,14 @@ Practical expectations for the current Primary Dash package:
 
 Overlays are **temporary surfaces**, not part of the normal left/right page loop. They appear independently from normal page navigation when their conditions are active.
 
-## 4. Primary Driver Dash
+## 4. Current dashboard constraints (v1.x)
+
+- Some dashboard behavior depends on optional SimHub-side configuration or optional exports; if those are not configured, related indicators may be missing.
+- Wheelspin / traction-loss indications depend on optional ShakeIt Motors export setup (`TractionLoss` property).
+- Primary Dash navigation behavior is still being refined and may evolve over upcoming releases.
+- In plugin UI, **Primary Dash Mode** binding is currently a placeholder and does not perform an action.
+
+## 5. Primary Driver Dash
 
 ### Primary Dash overview
 
@@ -225,7 +232,7 @@ Think of LalaAlerts as a **temporary alert surface** that sits alongside the nor
 
 *LalaAlerts overlay showing the separate temporary alert layer used by the Primary Dash package.*
 
-## 5. Shared widgets / overlays
+## 6. Shared widgets / overlays
 
 These shared widgets belong to the dashboard package, but the plugin still owns the underlying calculations and activation rules.
 
@@ -253,7 +260,7 @@ LaunchAssist surfaces launch-related driver information on supported dashboards.
 
 StallWidget is a compact helper surface for stalling/restart awareness where the relevant dashboard layout includes it.
 
-## 6. Remaining dashboard package sections
+## 7. Remaining dashboard package sections
 
 ### Strategy Dash
 
@@ -263,7 +270,7 @@ Documentation pending.
 
 Documentation pending.
 
-## 7. Screenshot notes
+## 8. Screenshot notes
 
 The screenshots embedded above are limited to images that are already present in the repo under `Docs/Images/PrimaryDash/`.
 

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -59,6 +59,14 @@ If you want those indicators:
 
 That exposes `[ShakeITMotorsV3Plugin.Export.TractionLoss.All]` for dashboards or visuals that use it. Without this setup, wheelspin-related indicators may be unavailable.
 
+### Current constraints (v1.x)
+
+- Some dashboard indicators and behaviors depend on optional SimHub exports or optional setup steps.
+- Wheelspin / traction-loss visuals require the optional `TractionLoss` ShakeIt export above.
+- Primary Dash navigation behavior may continue to evolve during early public releases.
+- In plugin UI, **Primary Dash Mode** binding is currently a placeholder and does not perform an action.
+- **`RSC.iRacingExtraProperties.dll` is still required**.
+
 ## 4. First plugin check
 
 Open the plugin in SimHub and confirm the main navigation order:

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,35 +9,32 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Performed a follow-up documentation-only pass to add a shared post-install SimHub walkthrough video link across the key user docs.
-- Added the YouTube walkthrough link to `Docs/User_Guide.md` plus the tab/feature docs for Strategy, Profiles, Launch, Shift Assist, Pit Assist, Rejoin Assist, and Fuel Model.
-- Kept the link out of `Docs/Quick_Start.md` because Quick Start owns installation/onboarding, while the linked video is explicitly post-install guidance.
+- Performed a bounded documentation-only release-readiness pass across public/user-facing docs.
+- Confirmed `README.md` already covers project description, core systems/features, and supported scope/platform.
+- Added concise v1.x expectation-setting constraints to `README.md`, `Docs/Quick_Start.md`, `Docs/User_Guide.md`, and `Docs/Dashboards.md`.
+- Moved README support/feedback guidance higher on the page to improve visibility for early tester support flow.
 - Kept scope limited to markdown updates only: no runtime behavior, plugin settings, exports, logs, or image assets were changed.
 
 ## Reviewed documentation set
 ### Changed in this sweep
+- `README.md`
+- `Docs/Quick_Start.md`
 - `Docs/User_Guide.md`
-- `Docs/Fuel_Model.md`
-- `Docs/Launch_System.md`
-- `Docs/Pit_Assist.md`
-- `Docs/Profiles_System.md`
-- `Docs/Rejoin_Assist.md`
-- `Docs/Shift_Assist.md`
-- `Docs/Strategy_System.md`
+- `Docs/Dashboards.md`
 - `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
 - `Docs/Project_Index.md`
-- `Docs/Quick_Start.md`
+- `Docs/Internal/Code_Snapshot.md`
 - `Docs/H2H_System.md`
 - `Docs/Internal/CODEX_CONTRACT.txt`
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
 
 ## Delivery status highlights
-- The overview guide and key plugin tab/feature docs now include a consistent, high-visibility pointer to the same full post-install walkthrough video.
-- The video callout is positioned near the top of each page so users can choose long-form walkthrough guidance immediately.
-- Quick Start remains focused on installation and first setup, without mixing in post-install deep-dive material.
+- User-facing docs now set clearer early-release expectations for optional dashboard dependencies and current placeholders.
+- README now includes a compact `Current Constraints (v1.x)` section without duplicating existing strong sections.
+- README support guidance appears earlier for faster issue/feedback routing from small tester cohorts.
 
 ## Validation note
-- Validation recorded against `HEAD` (`docs-only video-link placement pass across key user docs`).
+- Validation recorded against `HEAD` (`docs-only release-readiness consistency pass with v1.x constraints`).

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -63,7 +63,15 @@ Important workflow rules:
 - Launch controls belong under **Settings → Launch Settings**.
 - **Launch Analysis** remains the separate post-run review tab.
 
-## 4. The main user-facing systems
+## 4. Current constraints (v1.x)
+
+- Some dashboard indicators depend on optional SimHub-side setup or optional exports.
+- Wheelspin / traction-loss visuals depend on optional ShakeIt Motors export setup (`TractionLoss` property).
+- Primary Dash navigation behavior may evolve as dashboard workflows are refined.
+- In plugin UI, **Primary Dash Mode** binding is currently a placeholder and does not perform an action.
+- `RSC.iRacingExtraProperties.dll` remains required for now.
+
+## 5. The main user-facing systems
 
 ### Strategy
 
@@ -144,7 +152,7 @@ Lala Race Assist Plugin includes separate driver-facing pages for recovery/rejoi
 
 H2H is a read-only race-context aid that helps the driver compare race-order and local-track threats without becoming a separate planning workflow. See [H2H System](H2H_System.md).
 
-## 5. Trust model
+## 6. Trust model
 
 A good mental model for the whole plugin is:
 
@@ -161,7 +169,7 @@ Use that pattern for:
 
 If a system is wrong once, keep driving. If it is wrong repeatedly, review the saved data or thresholds behind it instead of assuming the dashboard art is the problem.
 
-## 6. Practical best practice
+## 7. Practical best practice
 
 - Start each new car/track combination by gathering clean laps.
 - Use **Strategy** as the single planning entry point.
@@ -171,7 +179,7 @@ If a system is wrong once, keep driving. If it is wrong repeatedly, review the s
 - Treat touch navigation as a backup or convenience layer; for race use, bind **Next Dash** and **Previous Dash** to physical controls.
 - Review profile-backed data when a driver aid is repeatedly wrong.
 
-## 7. Recommended reading order
+## 8. Recommended reading order
 
 For most drivers, this order works well:
 

--- a/README.md
+++ b/README.md
@@ -63,49 +63,13 @@ The dashboard docs now include a dedicated Primary Driver Dash guide covering th
 5. Open the plugin and begin with **Strategy**, then review **Profiles**, **Dash Control**, and **Settings**.
 6. For more detailed instructions and help refer to the main user guide or quick start guide in links below.
 
-## Documentation
+## Current Constraints (v1.x)
 
-### Getting Started
-
-- [Quick Start](Docs/Quick_Start.md)
-- [User Guide](Docs/User_Guide.md)
-
-### Driver Systems
-
-- [Strategy System](Docs/Strategy_System.md)
-- [Shift Assist](Docs/Shift_Assist.md)
-- [Launch System](Docs/Launch_System.md)
-- [Rejoin Assist](Docs/Rejoin_Assist.md)
-- [Pit Assist](Docs/Pit_Assist.md)
-- [H2H System](Docs/H2H_System.md)
-- [Profiles System](Docs/Profiles_System.md)
-- [Fuel Model](Docs/Fuel_Model.md)
-
-### Technical / Canonical Subsystems
-
-- [Project Index](Docs/Project_Index.md) - documentation map and ownership guide
-- [Subsystem docs](Docs/Subsystems/) - canonical subsystem behavior, boundaries, and export-level contracts
-- [Dash integration notes](Docs/Subsystems/Dash_Integration.md)
-- [Changelog](CHANGELOG.md)
-
-## Current UI Structure
-
-The current top-level plugin navigation is:
-
-1. **Strategy**
-2. **Profiles**
-3. **Dash Control**
-4. **Launch Analysis**
-5. **Settings**
-
-Presets are managed from **Strategy** through the **`Presets...`** modal flow. There is no separate top-level Presets tab.
-
-## Notes / Important Boundaries
-
-- **PreRace** is display-only. It does not replace the planner or change the live fuel model.
-- **Live Snapshot** can auto-drive relevant planning values. When it is active, the corresponding manual controls are disabled.
-- Launch controls live under **Settings -> Launch Settings**. **Launch Analysis** remains the saved-run review tab.
-- The future/global message system is not documented here as an active user feature.
+- Some dashboard behaviors depend on optional SimHub-side setup and optional dashboard exports. If those are not configured, affected indicators or overlays may be missing while core plugin systems still work.
+- Wheelspin / traction-loss indicators depend on optional **ShakeIt Motors** export setup (`TractionLoss` property). Without that optional export, those indicators are unavailable.
+- Primary Dash navigation behavior is still evolving as the dashboard package is refined for early testers.
+- In plugin UI, **Primary Dash Mode** binding is currently a future placeholder and does not perform an action yet.
+- **`RSC.iRacingExtraProperties.dll` remains required** in this release line.
 
 ## Support and Feedback
 
@@ -149,6 +113,50 @@ If you encounter a problem specifically with a dashboard layout or behaviour, op
 ---
 
 Using Issues and Discussions helps keep the documentation, plugin behaviour, and user feedback aligned.
+
+## Documentation
+
+### Getting Started
+
+- [Quick Start](Docs/Quick_Start.md)
+- [User Guide](Docs/User_Guide.md)
+
+### Driver Systems
+
+- [Strategy System](Docs/Strategy_System.md)
+- [Shift Assist](Docs/Shift_Assist.md)
+- [Launch System](Docs/Launch_System.md)
+- [Rejoin Assist](Docs/Rejoin_Assist.md)
+- [Pit Assist](Docs/Pit_Assist.md)
+- [H2H System](Docs/H2H_System.md)
+- [Profiles System](Docs/Profiles_System.md)
+- [Fuel Model](Docs/Fuel_Model.md)
+
+### Technical / Canonical Subsystems
+
+- [Project Index](Docs/Project_Index.md) - documentation map and ownership guide
+- [Subsystem docs](Docs/Subsystems/) - canonical subsystem behavior, boundaries, and export-level contracts
+- [Dash integration notes](Docs/Subsystems/Dash_Integration.md)
+- [Changelog](CHANGELOG.md)
+
+## Current UI Structure
+
+The current top-level plugin navigation is:
+
+1. **Strategy**
+2. **Profiles**
+3. **Dash Control**
+4. **Launch Analysis**
+5. **Settings**
+
+Presets are managed from **Strategy** through the **`Presets...`** modal flow. There is no separate top-level Presets tab.
+
+## Notes / Important Boundaries
+
+- **PreRace** is display-only. It does not replace the planner or change the live fuel model.
+- **Live Snapshot** can auto-drive relevant planning values. When it is active, the corresponding manual controls are disabled.
+- Launch controls live under **Settings -> Launch Settings**. **Launch Analysis** remains the saved-run review tab.
+- The future/global message system is not documented here as an active user feature.
 
 ## License
 


### PR DESCRIPTION
### Motivation

- Surface concise, practical early-release expectations so testers understand optional dashboard dependencies and current placeholders without reworking strong existing docs.
- Keep README, Quick Start, User Guide, and Dashboards aligned about v1.x constraints and make support guidance easier to find for a small tester cohort.

### Description

- Added a compact `Current Constraints (v1.x)` section to `README.md` that documents optional SimHub/export dependencies, the ShakeIt `TractionLoss` requirement for wheelspin visuals, evolving Primary Dash navigation behavior, the non-functional `Primary Dash Mode` binding placeholder, and the continued requirement for `RSC.iRacingExtraProperties.dll`.
- Added matching expectation-setting subsections to `Docs/Quick_Start.md` and `Docs/User_Guide.md` to surface the same constraints during setup and in the main overview.
- Added a focused `Current dashboard constraints (v1.x)` section to `Docs/Dashboards.md` and renumbered subsequent headings accordingly.
- Updated `Docs/RepoStatus.md` to record the documentation-only pass and list the updated files; no code, runtime, asset, or dependency changes were made.

### Testing

- Ran `git diff --check` and found no whitespace or diff-check issues (success).
- Verified working tree state with `git status --short` and committed the changes with `git commit` (commit succeeded).
- Created the PR metadata via the repository PR tooling (`mcp__make_pr__make_pr`) and recorded the PR title and body (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e7c19a1c832fb29861bebb89be6b)