### PR TITLE
Split public/internal changelogs and require internal changelog upkeep in Codex rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,13 +3,14 @@
 Start with [Docs/Project_Index.md](Docs/Project_Index.md). It is the canonical documentation map and entry point for this repo.
 
 Required operating order:
-- Obey [Docs/CODEX_CONTRACT.txt](Docs/CODEX_CONTRACT.txt) as mandatory policy.
-- Use [Docs/Architecture_Guardrails.md](Docs/Architecture_Guardrails.md) for subsystem boundaries and ownership.
-- When working from an explicit task, use [Docs/CODEX_TASK_TEMPLATE.txt](Docs/CODEX_TASK_TEMPLATE.txt).
+- Obey [Docs/Internal/CODEX_CONTRACT.txt](Docs/Internal/CODEX_CONTRACT.txt) as mandatory policy.
+- Use [Docs/Internal/Architecture_Guardrails.md](Docs/Internal/Architecture_Guardrails.md) for subsystem boundaries and ownership.
+- When working from an explicit task, use [Docs/Internal/CODEX_TASK_TEMPLATE.txt](Docs/Internal/CODEX_TASK_TEMPLATE.txt).
 - Read the relevant `Docs/Subsystems/*.md` files before editing subsystem code or subsystem docs.
-- Treat [Docs/Code_Snapshot.md](Docs/Code_Snapshot.md) as orientation only; it is non-canonical.
+- Treat [Docs/Internal/Code_Snapshot.md](Docs/Internal/Code_Snapshot.md) as orientation only; it is non-canonical.
 
 Working rules:
 - Prefer subsystem-local edits over widening central file responsibilities.
 - Do not widen ownership boundaries unless the task explicitly requires it.
 - Keep documentation aligned with the final repo state, including [Docs/RepoStatus.md](Docs/RepoStatus.md) when docs or behavior change.
+- Maintain changelog split discipline: `CHANGELOG.md` is user-facing release history; `Docs/Internal/Development_Changelog.md` is the ongoing internal development log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,32 @@
-﻿# Changelog
+# Changelog
 
-This changelog is written for GitHub readers and focuses on user-facing changes.
+This changelog is user-facing release history.
 
-Dates are intentionally omitted where the repo docs available in this workspace do not establish a release date with confidence.
+For internal between-release development history, see `Docs/Internal/Development_Changelog.md`.
 
-## Initial release
+## v1.1 (Unreleased)
 
-- First public plugin package for SimHub + iRacing use.
-- Established the core plugin split between runtime calculations and dashboard presentation.
-- Included launch support, fuel tools, and dashboard package foundations.
+### Added
+- _No public release notes staged yet._
 
-## v0.1
+### Changed
+- _No public release notes staged yet._
 
-- Early user-facing launch workflow and launch dashboards.
-- Basic fuel and race-support features for live use.
-- Initial profile-based setup flow for storing repeatable car settings.
+### Fixed
+- _No public release notes staged yet._
 
-## v0.2
+## v1.0 – Initial Public Release
 
-- Expanded profile-driven workflow and saved-data usage.
-- Improved dashboard package structure for live driving support.
-- Added stronger race-session support around planning and dash presentation.
+### Added
+- Public plugin package for SimHub + iRacing users.
+- Public documentation set (`README.md` plus focused `Docs/` guides).
+- Strategy workflow documentation as the main planning story.
+- Shift Assist and H2H documentation as first-class user features.
 
-## v0.3
+### Changed
+- Consolidated planning language around the Strategy tab and Strategy preset workflow.
+- Clarified live snapshot behavior, launch settings location, and dashboard control guidance.
+- Synced user-facing and subsystem docs so navigation between user docs and technical ownership docs is coherent.
 
-- Added fuller quick-start and user-guide material for testers.
-- Strengthened plugin learning/store/lock workflow around fuel and track data.
-- Expanded practical dash usage guidance for race sessions.
-
-## v0.4
-
-- Pit entry and pit-loss workflows matured, including learned markers and cleaner pit-cycle guidance.
-- Dry/wet data separation and condition-aware storage improved long-run trust.
-- Opponent and race-context tooling expanded, including stronger same-class race support.
-- Track-scoped planning data became more practical for venue-specific strategy setup.
-
-## v1.0 – Public documentation + Strategy workflow consolidation
-
-Main user-facing changes since the late-February documentation baseline include:
-
-- Refactored the top-level planner into the **Strategy** tab story instead of older Fuel-first wording.
-- Moved preset management into Strategy through the **`Presets...`** modal workflow instead of a standalone Presets tab.
-- Clarified **Live Snapshot** auto-source behavior so the live source owns the relevant values when active and the matching manual inputs are disabled.
-- Moved **launch controls** such as launch mode and post-launch display timing into **Settings → Launch Settings**.
-- Added clear user-facing coverage for **H2H Race** and **H2H Track**.
-- Added a GitHub-facing documentation structure with the public `README.md` plus focused `Docs/` pages for quick start, user guidance, dashboards, strategy, H2H, and driver assists.
-- Added **Shift Assist** as a documented first-class user feature.
-- Kept the distinction between **observing live state** and **committing a stable plan** explicit in user docs.
-- Repositioned **PreRace** as a display/on-grid layer under Strategy without implying that it changes planner calculations.
-- Cleaned up **Dash Control** so it stays dash-oriented, centered on Cancel Message, Toggle Pit Screen, Primary Dash Mode, Declutter Mode, visibility, and grouped global dash functions.
-- Expanded practical guidance for **rejoin warnings**, **pit popups**, and **pit entry assist**.
-- Completed the v1 documentation sweep across the main repo docs and canonical subsystem docs so GitHub readers can move from user pages into technical ownership docs without stale Fuel-tab-era wording or broken responsibility boundaries.
-- Refreshed repo-facing documentation so the GitHub repo can serve as the canonical user home alongside the canonical subsystem docs.
-
-## v1.1 – Release polish pass
-
-- Shortened Dash Control visibility column labels to **`DRIVER`**, **`STRATEGY`**, and **`OVERLAY`** while keeping tooltip wording explicit.
-- Added a release-facing warning below the debug-mode master toggle so troubleshooting features are less likely to be left on accidentally.
-- Fixed the Preset Manager `PreRace Mode` selector by reusing the same working ComboBox behavior as the main Strategy tab, restoring normal dropdown interaction while keeping dark-theme readability.
-- Hardened the Strategy `Presets...` modal open flow against null preset entries and open-time popup failures so the editor no longer hard-fails as easily.
-- Embedded the shipped preset defaults and expanded track-marker defaults directly in the owning code paths so the repo/package ships with the intended first-run data, including the shorter `IMSA 40m` / `Sprint 20m` preset names and additional seeded tracks.
+### Fixed
+- Removed stale/legacy wording in public docs to match current v1 behavior and workflows.

--- a/Docs/Internal/CODEX_CONTRACT.txt
+++ b/Docs/Internal/CODEX_CONTRACT.txt
@@ -50,6 +50,11 @@ GitHub-facing user docs:
 Rules:
 - If a task changes user-facing behaviour, workflow, UI labels, tab names, settings location, dash behaviour, install steps, or practical usage guidance, GitHub-facing user docs must be reviewed and updated in the same task.
 - If a task changes only internal implementation with no user-visible effect, user docs may remain unchanged, but Codex must explicitly state that no user-facing documentation changes were required.
+- For any non-trivial task, Codex must classify changelog impact as **user-facing**, **internal-only**, or **both**.
+- For any non-trivial task that meaningfully changes repo behaviour, packaging, docs, UX, or workflows, Codex must add a concise entry to `Docs/Internal/Development_Changelog.md`.
+- Update root `CHANGELOG.md` only when the task explicitly requests public changelog staging, or when the task is clearly preparing user-facing unreleased/release notes.
+- Avoid adding internal-only refactors, housekeeping, or process-only notes to root `CHANGELOG.md` unless explicitly requested.
+- Task closeout must include a short changelog classification note in the final summary.
 - Documentation must reflect final behavior.
 - Remove outdated statements.
 - Do not mention deprecated settings unless marked `legacy (unused)`.
@@ -158,4 +163,5 @@ A task is only complete when:
 - Documentation updated.
 - `Docs/RepoStatus.md` updated with new validation commit.
 - Relevant GitHub-facing docs reviewed and updated when the task changes anything user-facing.
-- `CHANGELOG.md` updated when the task changes user-visible behaviour worth surfacing in release history.
+- `Docs/Internal/Development_Changelog.md` updated for substantive non-trivial work per changelog classification.
+- `CHANGELOG.md` updated only when public staging/release-note intent is explicit.

--- a/Docs/Internal/CODEX_TASK_TEMPLATE.txt
+++ b/Docs/Internal/CODEX_TASK_TEMPLATE.txt
@@ -33,6 +33,12 @@ Identify:
 
 Do not edit during this phase.
 
+Changelog impact
+
+- Internal development changelog update required? <yes/no>
+- Public changelog update required? <yes/no>
+- If applicable, user-facing summary for release notes: <1-3 concise bullets>
+
 System invariants
 
 - <List behaviour, export, logging, UI, JSON/profile, and compatibility rules that must remain unchanged.>
@@ -90,7 +96,9 @@ Confirm:
 - docs match the final repo state
 - `Docs/RepoStatus.md` reflects the task
 - relevant GitHub-facing docs were reviewed
-- `CHANGELOG.md` was updated if the change is user-visible
+- changelog classification is stated (user-facing, internal-only, or both)
+- `Docs/Internal/Development_Changelog.md` was updated when required
+- `CHANGELOG.md` was updated only when public staging/release-note intent applied
 - no unrelated behaviour changed
 
 Output format

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,0 +1,47 @@
+# Development Changelog
+
+This file tracks internal development history between releases.
+The public user-facing release history is maintained in the root `CHANGELOG.md`.
+
+## Pre-v1 public development history
+
+### Initial release foundations
+- Established the first public plugin packaging path for SimHub + iRacing testing.
+- Set the core split between runtime calculations and dashboard presentation.
+- Landed early launch support, fuel tooling, and dashboard package foundations.
+
+### v0.1
+- Early user-facing launch workflow and launch dashboards.
+- Basic fuel and race-support features for live use.
+- Initial profile-based setup flow for repeatable car settings.
+
+### v0.2
+- Expanded profile-driven workflow and saved-data usage.
+- Improved dashboard package structure for live driving support.
+- Added stronger race-session support around planning and dash presentation.
+
+### v0.3
+- Added fuller quick-start and user-guide material for testers.
+- Strengthened learning/store/lock workflow around fuel and track data.
+- Expanded practical dash usage guidance for race sessions.
+
+### v0.4
+- Matured pit entry and pit-loss workflows, including learned markers and cleaner pit-cycle guidance.
+- Improved dry/wet data separation and condition-aware storage.
+- Expanded opponent and race-context tooling, including stronger same-class race support.
+- Made track-scoped planning data more practical for venue-specific strategy setup.
+
+## Post-v1.0 development
+
+### Dashboard packaging
+- Updated dash control visibility labels to `DRIVER`, `STRATEGY`, and `OVERLAY` while preserving clear tooltips.
+- Added a release-facing warning below the debug-mode master toggle to reduce accidental always-on troubleshooting.
+
+### Documentation
+- Continued v1 documentation alignment between public guides and subsystem ownership docs.
+- Kept Strategy-first wording and live-vs-committed plan distinctions explicit in user-facing docs.
+
+### Release preparation
+- Hardened Strategy `Presets...` modal open flow against null preset entries and popup open failures.
+- Fixed Preset Manager `PreRace Mode` dropdown behavior by reusing the validated ComboBox interaction pattern.
+- Embedded shipped preset defaults and expanded track-marker defaults in owning code paths for predictable first-run packaging.

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -69,12 +69,14 @@ These pages support maintainers, support work, and Codex tasks. They are not par
 - [Internal/SimHubLogMessages.md](Internal/SimHubLogMessages.md)
 - [Internal/Code_Snapshot.md](Internal/Code_Snapshot.md)
 - [Internal/Release_Checklist.md](Internal/Release_Checklist.md)
+- [Internal/Development_Changelog.md](Internal/Development_Changelog.md)
 
 ## v1 documentation notes
 - `README.md` is the public landing page.
 - `Docs/*.md` are the reader-facing feature/system pages.
 - `Docs/Subsystems/*.md` are the canonical technical ownership docs.
 - `Docs/RepoStatus.md` records the latest documentation sweep and validation note.
+- Changelog split: root `CHANGELOG.md` is public release-facing, while `Docs/Internal/Development_Changelog.md` is the internal between-release history.
 - If user-facing pages and subsystem docs ever disagree, update both in the same task so GitHub readers do not get split truths.
 
 ## Freshness

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,25 +9,29 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Added a new maintainer-facing internal release process checklist based on the workflow that produced the first successful public release.
-- Captured repeatable go/no-go checks for planning, build/readiness, clean install validation, dashboard import validation, runtime/log review, docs/assets verification, GitHub release prep, and post-release follow-up.
-- Kept changes documentation-only and scoped to internal process discoverability.
+- Split changelog responsibilities into public release history (`CHANGELOG.md`) and internal between-release development history (`Docs/Internal/Development_Changelog.md`).
+- Reset root changelog structure to `v1.1 (Unreleased)` staging plus `v1.0 – Initial Public Release`.
+- Added internal changelog governance to Codex contract and task template so substantive work keeps the internal changelog current by default.
+- Synced entry-point documentation (`AGENTS.md`, `Docs/Project_Index.md`) to the internal docs path layout and changelog split.
 
 ## Reviewed documentation set
 ### Changed in this sweep
-- `Docs/Internal/Release_Checklist.md` (new)
+- `CHANGELOG.md`
+- `Docs/Internal/Development_Changelog.md` (new)
+- `Docs/Internal/CODEX_CONTRACT.txt`
+- `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
+- `AGENTS.md`
 - `Docs/Project_Index.md`
 - `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
-- `Docs/Internal/CODEX_CONTRACT.txt`
 - `Docs/Internal/Architecture_Guardrails.md`
-- `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
 - `Docs/Internal/Code_Snapshot.md`
 
 ## Delivery status highlights
-- Future releases now have a concrete internal checklist that reflects practical first-release learnings rather than generic boilerplate.
-- Project index now exposes the checklist in the canonical documentation map for maintainers.
+- Public changelog now remains focused on user-visible release notes.
+- Internal changelog is now the canonical running development log between releases.
+- Codex process docs now require changelog classification and internal changelog maintenance for substantive non-trivial tasks.
 
 ## Validation note
-- Validation recorded against `HEAD` (`internal release checklist + project index discoverability update`).
+- Validation recorded against `HEAD` (`public/internal changelog split + Codex workflow enforcement update`).


### PR DESCRIPTION
### Motivation
- Keep the public `CHANGELOG.md` focused on end-user release notes and avoid polluting it with internal development noise. 
- Provide a canonical internal running history for between-release work so maintainers and agents can record granular, process- and implementation-level changes. 
- Make changelog upkeep part of the Codex task workflow so future substantive tasks consistently classify and record their changelog impact.

### Description
- Rebuilt `CHANGELOG.md` as a user-facing release changelog with `v1.1 (Unreleased)` (staging buckets: `Added`/`Changed`/`Fixed`) and `v1.0 – Initial Public Release`, and removed pre-v1 sections from the public file. 
- Added `Docs/Internal/Development_Changelog.md` and migrated the pre-v1 narrative into it, plus seeded a structured `Post-v1.0` section (e.g., `Dashboard packaging`, `Documentation`, `Release preparation`). 
- Updated Codex policy to require changelog classification and maintenance by editing `Docs/Internal/CODEX_CONTRACT.txt` so non-trivial tasks must classify changes as `user-facing`, `internal-only`, or `both`, add concise entries to `Docs/Internal/Development_Changelog.md` for substantive work, and only update root `CHANGELOG.md` when public staging/release-note intent is explicit. 
- Updated the Codex task template `Docs/Internal/CODEX_TASK_TEMPLATE.txt` to include a `Changelog impact` checklist (`internal yes/no`, `public yes/no`, optional user-facing bullets) and to verify classification and required changelog updates at task close. 
- Minor consistency edits to `AGENTS.md`, `Docs/Project_Index.md`, and `Docs/RepoStatus.md` to point agents to the `Docs/Internal/` paths and document the public/internal changelog split. 
- Changelog classification for this change: **both** (internal governance + explicit public changelog restructuring).

### Testing
- Verified working tree and staged changes with `git status --short`, which reported the modified/created files successfully. 
- Inspected diffs with `git diff` for the edited docs (`Docs/Internal/CODEX_CONTRACT.txt`, `Docs/Internal/CODEX_TASK_TEMPLATE.txt`, `CHANGELOG.md`, `Docs/Internal/Development_Changelog.md`, `AGENTS.md`, `Docs/Project_Index.md`, `Docs/RepoStatus.md`) and confirmed the intended edits were present. 
- Committed the updated files successfully; commit completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c25262efe8832fbdc0835a4e6f87fd)