### PR TITLE
Add Overview landing tab (UI + docs) with lightweight status and release check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For internal between-release development history, see `Docs/Internal/Development
 ## v1.1 (Unreleased)
 
 ### Added
-- _No public release notes staged yet._
+- Added a new **Overview** top-level plugin tab as a landing/front-door page with quick links, lightweight status, release-check awareness, and dashboard preview placeholders.
 
 ### Changed
 - _No public release notes staged yet._

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -45,3 +45,8 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Hardened Strategy `Presets...` modal open flow against null preset entries and popup open failures.
 - Fixed Preset Manager `PreRace Mode` dropdown behavior by reusing the validated ComboBox interaction pattern.
 - Embedded shipped preset defaults and expanded track-marker defaults in owning code paths for predictable first-run packaging.
+
+### Plugin UI
+- Added a new top-level `OVERVIEW` tab as the plugin landing page/front door.
+- Added quick-link buttons, lightweight runtime status text, and a fail-soft GitHub latest-release check (`Check Now` + `Open Releases`).
+- Added dashboard preview placeholders that document the exact drop-in paths/names for future images (`Assets/Overview/*.png`) without shipping binaries in this branch.

--- a/Docs/Internal/Plugin_UI_Tooltips.md
+++ b/Docs/Internal/Plugin_UI_Tooltips.md
@@ -213,3 +213,12 @@ Branch: work
 - `GlobalSettingsView.xaml` `PitExit Verbose Logging` tooltip says it adds PitExit math audit details to pit-in snapshots for troubleshooting.
 - `GlobalSettingsView.xaml` `Shift Assist Debug CSV` tooltip explains per-tick diagnostic CSV logging.
 - `GlobalSettingsView.xaml` `Shift Assist Debug Max Hz` textbox tooltip documents valid range (1..60 Hz).
+
+## OverviewTabView.xaml
+- Top-level `OVERVIEW` tab is now the plugin landing/front-door page before `STRATEGY`.
+- Header displays plugin name, installed version string, tagline, and a reserved logo placeholder area.
+- `Quick Links` section includes buttons for Quick Start, User Guide, GitHub repo, Releases, and Report Issue.
+- `Status` section shows lightweight runtime state (game, plugin, profiles, track markers, current car/track) without deep subsystem wiring.
+- `Updates` section shows installed version, latest release tag, status (`Up to date`/`Update available`/`Unable to check`), and `Check Now`/`Open Releases` actions.
+- `Dashboard Previews` section now provides placeholder cards with exact expected file paths (`Assets/Overview/*.png`) so preview images can be dropped in later without layout changes.
+- `Help / Notes` section contains concise driver reminders for touch vs bindings, Next/Previous screen behavior, Primary Dash Mode placeholder status, and optional `TractionLoss` export setup.

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -71,17 +71,19 @@ That exposes `[ShakeITMotorsV3Plugin.Export.TractionLoss.All]` for dashboards or
 
 Open the plugin in SimHub and confirm the main navigation order:
 
-1. **Strategy**
-2. **Profiles**
-3. **Dash Control**
-4. **Launch Analysis**
-5. **Settings**
+1. **Overview**
+2. **Strategy**
+3. **Profiles**
+4. **Dash Control**
+5. **Launch Analysis**
+6. **Settings**
 
 ![Strategy tab after install](Images/StrategyTab.png)
-*After install, Strategy should be the first main tab you land on and the main place to start planning.*
+*After install, Overview is the landing tab; use it for quick links and status, then move to Strategy for planning.*
 
 Important current rules:
 
+- **Overview** is the landing/front-door tab (links, status, and update check).
 - **Strategy** is the main planner.
 - Presets are managed from **Strategy** through **`Presets...`**.
 - Launch setup lives in **Settings → Launch Settings**.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,29 +9,31 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Split changelog responsibilities into public release history (`CHANGELOG.md`) and internal between-release development history (`Docs/Internal/Development_Changelog.md`).
-- Reset root changelog structure to `v1.1 (Unreleased)` staging plus `v1.0 – Initial Public Release`.
-- Added internal changelog governance to Codex contract and task template so substantive work keeps the internal changelog current by default.
-- Synced entry-point documentation (`AGENTS.md`, `Docs/Project_Index.md`) to the internal docs path layout and changelog split.
+- Added a new top-level plugin `OVERVIEW` tab as the front-door landing page before Strategy.
+- Synced user-facing docs to the new tab order and overview-first workflow wording.
+- Synced internal UI tooltip inventory and internal development changelog for the new Overview surface.
 
 ## Reviewed documentation set
 ### Changed in this sweep
 - `CHANGELOG.md`
-- `Docs/Internal/Development_Changelog.md` (new)
-- `Docs/Internal/CODEX_CONTRACT.txt`
-- `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
-- `AGENTS.md`
-- `Docs/Project_Index.md`
+- `Docs/Quick_Start.md`
+- `Docs/User_Guide.md`
+- `Docs/Internal/Plugin_UI_Tooltips.md`
+- `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
+- `Docs/Project_Index.md`
+- `Docs/Internal/CODEX_CONTRACT.txt`
 - `Docs/Internal/Architecture_Guardrails.md`
+- `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
 - `Docs/Internal/Code_Snapshot.md`
+- `Docs/Subsystems/Dash_Integration.md`
 
 ## Delivery status highlights
-- Public changelog now remains focused on user-visible release notes.
-- Internal changelog is now the canonical running development log between releases.
-- Codex process docs now require changelog classification and internal changelog maintenance for substantive non-trivial tasks.
+- Plugin settings UI now has a dedicated onboarding/overview tab with quick links, status, update awareness, and dashboard preview placeholders.
+- Version awareness is fail-soft and manual/low-frequency (`Check Now` plus one startup check path), and preview image file paths are documented for later drop-in assets.
+- Existing tabs keep their prior responsibilities (`Strategy`, `Profiles`, `Dash Control`, `Launch Analysis`, `Settings`) unchanged.
 
 ## Validation note
-- Validation recorded against `HEAD` (`public/internal changelog split + Codex workflow enforcement update`).
+- Validation recorded against `HEAD` (`Overview tab polish + lightweight release-check awareness + docs sync`).

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -49,14 +49,16 @@ Dashboards do **not** become the source of truth for strategy, fuel math, H2H se
 
 The current top-level plugin order is:
 
-1. **Strategy**
-2. **Profiles**
-3. **Dash Control**
-4. **Launch Analysis**
-5. **Settings**
+1. **Overview**
+2. **Strategy**
+3. **Profiles**
+4. **Dash Control**
+5. **Launch Analysis**
+6. **Settings**
 
 Important workflow rules:
 
+- **Overview** is the landing tab for quick orientation, links, and update status.
 - The main planning tab is **Strategy**, not Fuel.
 - There is **no separate Presets tab**.
 - Presets are managed from **Strategy** using the **`Presets...`** modal flow.

--- a/LaunchPlugin.csproj
+++ b/LaunchPlugin.csproj
@@ -107,6 +107,9 @@
     <Compile Include="GlobalSettingsView.xaml.cs">
       <DependentUpon>GlobalSettingsView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="OverviewTabView.xaml.cs">
+      <DependentUpon>OverviewTabView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="LaunchSummaryExpander.xaml.cs">
       <DependentUpon>LaunchSummaryExpander.xaml</DependentUpon>
     </Compile>
@@ -177,6 +180,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="GlobalSettingsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="OverviewTabView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/LaunchPluginCombinedSettingsControl.xaml.cs
+++ b/LaunchPluginCombinedSettingsControl.xaml.cs
@@ -10,6 +10,13 @@ namespace LaunchPlugin
         {
             InitializeComponent();
 
+            var overviewTab = new SHTabItem
+            {
+                Header = "OVERVIEW",
+                Content = new OverviewTabView(mainPluginInstance)
+            };
+            MainTabControl.Items.Add(overviewTab);
+
             var strategyTab = new SHTabItem
             {
                 Header = "STRATEGY",

--- a/OverviewTabView.xaml
+++ b/OverviewTabView.xaml
@@ -1,0 +1,142 @@
+<UserControl x:Class="LaunchPlugin.OverviewTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins"
+             mc:Ignorable="d"
+             d:DesignWidth="900" d:DesignHeight="1100">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="10">
+            <Border BorderBrush="#3A3A3A" BorderThickness="1" CornerRadius="6" Padding="10" Margin="0,0,0,10">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="120"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="Lala Race Assist" FontSize="20" FontWeight="Bold" Foreground="White"/>
+                        <TextBlock Text="Race engineering tools and dashboards for iRacing on SimHub"
+                                   Margin="0,4,0,0" Foreground="LightGray" TextWrapping="Wrap"/>
+                        <TextBlock Margin="0,8,0,0" Foreground="LightGray"
+                                   Text="{Binding InstalledVersionText, StringFormat=Installed version: {0}}"/>
+                    </StackPanel>
+                    <Border Grid.Column="1" Margin="12,0,0,0" BorderBrush="#555" BorderThickness="1" CornerRadius="4" Height="62" VerticalAlignment="Top">
+                        <TextBlock Text="Logo placeholder" Foreground="#9A9A9A" HorizontalAlignment="Center" VerticalAlignment="Center" FontStyle="Italic"/>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <styles:SHSection Title="QUICK LINKS" ShowSeparator="True">
+                <WrapPanel Margin="0,6,0,0">
+                    <styles:SHButtonPrimary Content="Quick Start" Margin="0,0,8,8" Padding="10,4" Click="QuickStart_Click"/>
+                    <styles:SHButtonPrimary Content="User Guide" Margin="0,0,8,8" Padding="10,4" Click="UserGuide_Click"/>
+                    <styles:SHButtonPrimary Content="GitHub Repository" Margin="0,0,8,8" Padding="10,4" Click="Repository_Click"/>
+                    <styles:SHButtonPrimary Content="Releases" Margin="0,0,8,8" Padding="10,4" Click="Releases_Click"/>
+                    <styles:SHButtonPrimary Content="Report Issue" Margin="0,0,8,8" Padding="10,4" Click="Issues_Click"/>
+                </WrapPanel>
+                <TextBlock Margin="0,4,0,0" Foreground="LightGray" Text="{Binding LinkStatusText}"/>
+            </styles:SHSection>
+
+            <styles:SHSection Title="STATUS" ShowSeparator="True">
+                <Grid Margin="0,6,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="210"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Game" Foreground="LightGray" Margin="0,0,8,4"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding CurrentGameText}" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Plugin" Foreground="LightGray" Margin="0,0,8,4"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding PluginLoadedText}" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Profiles" Foreground="LightGray" Margin="0,0,8,4"/>
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ProfilesStatusText}" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Track markers" Foreground="LightGray" Margin="0,0,8,4"/>
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding TrackMarkersStatusText}" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Current car" Foreground="LightGray" Margin="0,0,8,4"/>
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding CurrentCarText}" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Current track" Foreground="LightGray" Margin="0,0,8,0"/>
+                    <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding CurrentTrackText}"/>
+                </Grid>
+            </styles:SHSection>
+
+            <styles:SHSection Title="UPDATES" ShowSeparator="True">
+                <StackPanel Margin="0,6,0,0">
+                    <TextBlock Text="{Binding InstalledVersionText, StringFormat=Installed: {0}}" Margin="0,0,0,2"/>
+                    <TextBlock Text="{Binding LatestVersionText, StringFormat=Latest release: {0}}" Margin="0,0,0,2"/>
+                    <TextBlock Text="{Binding UpdateStateText, StringFormat=Status: {0}}" Margin="0,0,0,8"/>
+                    <WrapPanel>
+                        <styles:SHButtonPrimary Content="Check Now" Padding="10,4" Margin="0,0,8,0" Click="CheckNow_Click"/>
+                        <styles:SHButtonPrimary Content="Open Releases" Padding="10,4" Click="OpenReleases_Click"/>
+                    </WrapPanel>
+                </StackPanel>
+            </styles:SHSection>
+
+            <styles:SHSection Title="INCLUDED SYSTEMS" ShowSeparator="True">
+                <WrapPanel Margin="0,6,0,0">
+                    <Border Margin="0,0,8,8" Padding="8,3" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4"><TextBlock Text="Launch Assist"/></Border>
+                    <Border Margin="0,0,8,8" Padding="8,3" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4"><TextBlock Text="Strategy Tools"/></Border>
+                    <Border Margin="0,0,8,8" Padding="8,3" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4"><TextBlock Text="Shift Assist"/></Border>
+                    <Border Margin="0,0,8,8" Padding="8,3" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4"><TextBlock Text="Pit Assist"/></Border>
+                    <Border Margin="0,0,8,8" Padding="8,3" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4"><TextBlock Text="Rejoin Assist"/></Border>
+                    <Border Margin="0,0,8,8" Padding="8,3" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4"><TextBlock Text="Head-to-Head"/></Border>
+                </WrapPanel>
+            </styles:SHSection>
+
+            <styles:SHSection Title="DASHBOARD PREVIEWS" ShowSeparator="True">
+                <StackPanel Margin="0,6,0,0">
+                    <TextBlock Foreground="LightGray" TextWrapping="Wrap" Margin="0,0,0,8"
+                               Text="Preview images are optional in this workspace. To enable them, place PNG files in Assets/Overview with the filenames below, then bind those paths in this section."/>
+                    <WrapPanel>
+                        <Border Margin="0,0,10,10" Width="220" Height="120" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4" Padding="8">
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="Driver dashboard" FontWeight="SemiBold"/>
+                                <TextBlock Text="Assets/Overview/driver-preview.png" Foreground="LightGray" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                        <Border Margin="0,0,10,10" Width="220" Height="120" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4" Padding="8">
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="Strategy dashboard" FontWeight="SemiBold"/>
+                                <TextBlock Text="Assets/Overview/strategy-preview.png" Foreground="LightGray" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                        <Border Margin="0,0,10,10" Width="220" Height="120" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4" Padding="8">
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="Pit popup example" FontWeight="SemiBold"/>
+                                <TextBlock Text="Assets/Overview/pit-popup-preview.png" Foreground="LightGray" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                        <Border Margin="0,0,10,10" Width="220" Height="120" BorderBrush="#4A4A4A" BorderThickness="1" CornerRadius="4" Padding="8">
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="Rejoin assist example" FontWeight="SemiBold"/>
+                                <TextBlock Text="Assets/Overview/rejoin-preview.png" Foreground="LightGray" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                    </WrapPanel>
+                </StackPanel>
+            </styles:SHSection>
+
+            <styles:SHSection Title="HELP / NOTES" ShowSeparator="True">
+                <StackPanel Margin="0,6,0,0">
+                    <TextBlock Text="• Dashboards can be used by touch, but bindings are recommended." TextWrapping="Wrap" Margin="0,0,0,3"/>
+                    <TextBlock Text="• Next Screen flips main pages; Previous Screen flips internal/sub-pages." TextWrapping="Wrap" Margin="0,0,0,3"/>
+                    <TextBlock Text="• Primary Dash Mode is reserved for future use and currently does nothing." TextWrapping="Wrap" Margin="0,0,0,3"/>
+                    <TextBlock Text="• Optional wheelspin indicators require SimHub ShakeIt Motors 'TractionLoss' export." TextWrapping="Wrap" Margin="0,0,0,3"/>
+                </StackPanel>
+            </styles:SHSection>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/OverviewTabView.xaml.cs
+++ b/OverviewTabView.xaml.cs
@@ -1,0 +1,240 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace LaunchPlugin
+{
+    public partial class OverviewTabView : UserControl, INotifyPropertyChanged
+    {
+        private const string RepositoryUrl = "https://github.com/Lalabot77/LalaRaceAssist";
+        private const string ReleasesUrl = "https://github.com/Lalabot77/LalaRaceAssist/releases";
+        private const string IssuesUrl = "https://github.com/Lalabot77/LalaRaceAssist/issues";
+        private const string QuickStartUrl = "https://github.com/Lalabot77/LalaRaceAssist/blob/main/Docs/Quick_Start.md";
+        private const string UserGuideUrl = "https://github.com/Lalabot77/LalaRaceAssist/blob/main/Docs/User_Guide.md";
+        private const string LatestReleaseApiUrl = "https://api.github.com/repos/Lalabot77/LalaRaceAssist/releases/latest";
+
+        private readonly LalaLaunch _plugin;
+        private readonly DispatcherTimer _statusTimer;
+        private static readonly HttpClient ReleaseClient = CreateReleaseClient();
+        private DateTime _lastCheckUtc = DateTime.MinValue;
+
+        private string _installedVersionText;
+        private string _latestVersionText = "Unknown";
+        private string _updateStateText = "Unable to check";
+        private string _linkStatusText = string.Empty;
+        private string _currentGameText = "Not detected";
+        private string _pluginLoadedText = "Loaded";
+        private string _profilesStatusText = "Unknown";
+        private string _trackMarkersStatusText = "Unknown";
+        private string _currentCarText = "Not detected";
+        private string _currentTrackText = "Not detected";
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public string InstalledVersionText { get => _installedVersionText; private set { _installedVersionText = value; OnPropertyChanged(nameof(InstalledVersionText)); } }
+        public string LatestVersionText { get => _latestVersionText; private set { _latestVersionText = value; OnPropertyChanged(nameof(LatestVersionText)); } }
+        public string UpdateStateText { get => _updateStateText; private set { _updateStateText = value; OnPropertyChanged(nameof(UpdateStateText)); } }
+        public string LinkStatusText { get => _linkStatusText; private set { _linkStatusText = value; OnPropertyChanged(nameof(LinkStatusText)); } }
+        public string CurrentGameText { get => _currentGameText; private set { _currentGameText = value; OnPropertyChanged(nameof(CurrentGameText)); } }
+        public string PluginLoadedText { get => _pluginLoadedText; private set { _pluginLoadedText = value; OnPropertyChanged(nameof(PluginLoadedText)); } }
+        public string ProfilesStatusText { get => _profilesStatusText; private set { _profilesStatusText = value; OnPropertyChanged(nameof(ProfilesStatusText)); } }
+        public string TrackMarkersStatusText { get => _trackMarkersStatusText; private set { _trackMarkersStatusText = value; OnPropertyChanged(nameof(TrackMarkersStatusText)); } }
+        public string CurrentCarText { get => _currentCarText; private set { _currentCarText = value; OnPropertyChanged(nameof(CurrentCarText)); } }
+        public string CurrentTrackText { get => _currentTrackText; private set { _currentTrackText = value; OnPropertyChanged(nameof(CurrentTrackText)); } }
+
+        public OverviewTabView(LalaLaunch plugin)
+        {
+            InitializeComponent();
+            _plugin = plugin;
+            InstalledVersionText = GetInstalledVersionText();
+
+            DataContext = this;
+            RefreshStatusSnapshot();
+
+            _statusTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
+            _statusTimer.Tick += (s, e) => RefreshStatusSnapshot();
+            _statusTimer.Start();
+
+            _ = CheckLatestReleaseAsync(force: false);
+        }
+
+        private static HttpClient CreateReleaseClient()
+        {
+            var client = new HttpClient();
+            client.Timeout = TimeSpan.FromSeconds(5);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("LalaRaceAssist-OverviewTab/1.1");
+            return client;
+        }
+
+        private static string GetInstalledVersionText()
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            return version == null ? "Unknown" : version.ToString();
+        }
+
+        private void RefreshStatusSnapshot()
+        {
+            if (_plugin == null)
+            {
+                PluginLoadedText = "Not loaded";
+                ProfilesStatusText = "Unavailable";
+                TrackMarkersStatusText = "Unavailable";
+                CurrentCarText = "Unavailable";
+                CurrentTrackText = "Unavailable";
+                CurrentGameText = "Unavailable";
+                return;
+            }
+
+            PluginLoadedText = "Loaded";
+
+            var profileCount = _plugin.ProfilesViewModel?.CarProfiles?.Count ?? 0;
+            ProfilesStatusText = profileCount > 0 ? profileCount + " profile(s)" : "No profiles found";
+
+            var trackKey = _plugin.CurrentTrackKey;
+            if (!string.IsNullOrWhiteSpace(trackKey))
+            {
+                var marker = _plugin.GetTrackMarkersSnapshot(trackKey);
+                TrackMarkersStatusText = marker.HasData ? "Available" : "No markers yet";
+            }
+            else
+            {
+                TrackMarkersStatusText = "No track loaded";
+            }
+
+            CurrentCarText = string.IsNullOrWhiteSpace(_plugin.CurrentCarModel) ? "Not detected" : _plugin.CurrentCarModel;
+            CurrentTrackText = string.IsNullOrWhiteSpace(_plugin.CurrentTrackName) ? "Not detected" : _plugin.CurrentTrackName;
+
+            var currentGame = _plugin.PluginManager?.GetPropertyValue("DataCorePlugin.CurrentGame");
+            CurrentGameText = currentGame == null ? "Not detected" : currentGame.ToString();
+        }
+
+        private async Task CheckLatestReleaseAsync(bool force)
+        {
+            if (!force && (DateTime.UtcNow - _lastCheckUtc) < TimeSpan.FromMinutes(10))
+            {
+                return;
+            }
+
+            try
+            {
+                UpdateStateText = "Checking...";
+                var response = await ReleaseClient.GetAsync(LatestReleaseApiUrl);
+                if (!response.IsSuccessStatusCode)
+                {
+                    UpdateStateText = "Unable to check";
+                    return;
+                }
+
+                var payload = await response.Content.ReadAsStringAsync();
+                var latestTag = ExtractLatestTag(payload);
+                if (string.IsNullOrWhiteSpace(latestTag))
+                {
+                    UpdateStateText = "Unable to check";
+                    return;
+                }
+
+                LatestVersionText = latestTag;
+                UpdateStateText = CompareVersionStrings(InstalledVersionText, latestTag);
+                _lastCheckUtc = DateTime.UtcNow;
+            }
+            catch
+            {
+                UpdateStateText = "Unable to check";
+            }
+        }
+
+        private static string ExtractLatestTag(string json)
+        {
+            var obj = JObject.Parse(json);
+            var tag = obj.Value<string>("tag_name");
+            if (!string.IsNullOrWhiteSpace(tag))
+            {
+                return tag.Trim();
+            }
+
+            var name = obj.Value<string>("name");
+            return string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+        }
+
+        private static string CompareVersionStrings(string installedText, string latestText)
+        {
+            if (!TryParseVersion(installedText, out var installedVersion) || !TryParseVersion(latestText, out var latestVersion))
+            {
+                return "Unable to check";
+            }
+
+            return installedVersion >= latestVersion ? "Up to date" : "Update available";
+        }
+
+        private static bool TryParseVersion(string value, out Version version)
+        {
+            var cleaned = (value ?? string.Empty).Trim();
+            if (cleaned.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                cleaned = cleaned.Substring(1);
+            }
+
+            return Version.TryParse(cleaned, out version);
+        }
+
+        private void OpenUrlSafe(string url)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+                LinkStatusText = string.Empty;
+            }
+            catch
+            {
+                LinkStatusText = "Unable to open link on this system.";
+            }
+        }
+
+        private async void CheckNow_Click(object sender, RoutedEventArgs e)
+        {
+            await CheckLatestReleaseAsync(force: true);
+        }
+
+        private void OpenReleases_Click(object sender, RoutedEventArgs e)
+        {
+            OpenUrlSafe(ReleasesUrl);
+        }
+
+        private void QuickStart_Click(object sender, RoutedEventArgs e)
+        {
+            OpenUrlSafe(QuickStartUrl);
+        }
+
+        private void UserGuide_Click(object sender, RoutedEventArgs e)
+        {
+            OpenUrlSafe(UserGuideUrl);
+        }
+
+        private void Repository_Click(object sender, RoutedEventArgs e)
+        {
+            OpenUrlSafe(RepositoryUrl);
+        }
+
+        private void Releases_Click(object sender, RoutedEventArgs e)
+        {
+            OpenUrlSafe(ReleasesUrl);
+        }
+
+        private void Issues_Click(object sender, RoutedEventArgs e)
+        {
+            OpenUrlSafe(IssuesUrl);
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a front-door landing/overview tab to orient users, surface quick links, show lightweight runtime status, and expose update-awareness without deep subsystem wiring.
- Give a documented placeholder area for dashboard preview images so assets can be dropped in later without layout changes.
- Reflect the UI change in user docs and internal changelogs so onboarding and repo status remain accurate.

### Description
- Added a new `OverviewTabView.xaml` UI and backing viewmodel/logic in `OverviewTabView.xaml.cs` that shows plugin name/version, quick links, runtime status, update state, dashboard preview placeholders, and help notes. 
- Implemented a fail-soft GitHub latest-release check via an `HttpClient` to `https://api.github.com/.../releases/latest` with `Check Now`/`Open Releases` actions and version comparison logic in `OverviewTabView.xaml.cs`.
- Wired the new tab into the main UI by appending an `OVERVIEW` `SHTabItem` in `LaunchPluginCombinedSettingsControl.xaml.cs` so `Overview` becomes the first main tab. 
- Updated `LaunchPlugin.csproj` to include the new XAML/page and code-behind entries (`OverviewTabView.xaml` and `OverviewTabView.xaml.cs`).
- Updated documentation and metadata files to reflect the new tab order and feature: `CHANGELOG.md`, `Docs/Internal/Development_Changelog.md`, `Docs/Internal/Plugin_UI_Tooltips.md`, `Docs/Quick_Start.md`, `Docs/User_Guide.md`, and `Docs/RepoStatus.md` to document the overview-first workflow and preview asset paths.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a6605f20832f92b09778727c5225)