### PR TITLE
Prune dead CarSA debug comparison scaffolding from `LalaLaunch`

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### CarSA dead debug comparison scaffold prune
+- Removed dead internal CarSA debug comparison scaffolding in `LalaLaunch.cs` that sampled legacy Dahl/iRacing relative-gap properties without feeding active debug CSV output, SimHub exports, or user-facing behavior.
+- Removed the now-orphaned comparison-gap reset helper used only by that dead scaffolding.
+- Kept active CarSA debug CSV schema/cadence behavior unchanged and left Opponents/Pit/H2H/Fuel runtime behavior untouched.
+
 ### Brake previous-peak manual/session reset hardening
 - Added a dedicated brake capture runtime reset (`ResetBrakeCaptureState`) and invoked it from `ManualRecoveryReset`, which is used by session transitions and `PrimaryDashMode` manual recovery.
 - Manual/session recovery now clears active capture progress and resets `Brake.PreviousPeakPct` to `0.0`, preventing stale peaks from previous runs/sessions from being published as fresh captures.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-09
+Last updated: 2026-04-10
 Branch: work
 
 ## Current repo/link status
@@ -9,27 +9,27 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Hardened `Brake.PreviousPeakPct` runtime recovery behavior to clear brake-capture state on manual/session resets.
-- Runtime capture still starts at brake > 0, tracks max brake for 40 samples, latches the peak at completion, and re-arms after completion once brake falls to `<= 0.02`.
-- Manual/session recovery now clears active capture progress and resets the latched export to `0.0` to prevent stale cross-session peaks.
-- No dashboard/UI behavior was changed.
+- Removed dead CarSA debug comparison scaffolding in `LalaLaunch.cs` that sampled legacy Dahl/iRacing relative-gap properties but did not feed active debug CSV schema, SimHub exports, or user-facing behavior.
+- Kept the active CarSA debug export pipeline unchanged (`CarSA_Debug_*.csv` schema and cadence behavior preserved).
+- Preserved subsystem ownership boundaries and runtime behavior (Opponents native-only unchanged, CarSA session-agnostic ownership unchanged, H2H consumer/publisher seams unchanged).
 
 ## Reviewed documentation set
 ### Changed in this sweep
 - `LalaLaunch.cs`
-- `Docs/Internal/SimHubParameterInventory.md`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
-- `Docs/Subsystems/Launch_Mode.md`
+- `Docs/Subsystems/CarSA.md`
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/SimHubLogMessages.md`
 
 ## Delivery status highlights
-- `Brake.PreviousPeakPct` publishes the maximum brake input from the most recent completed 40-sample braking capture window.
-- `ManualRecoveryReset` now clears brake-capture runtime state (trigger/max/sample count) and resets `Brake.PreviousPeakPct` to `0.0`.
-- Session transitions and `PrimaryDashMode` action recovery both use that reset path, so stale pre-reset peaks cannot complete/publish as a fresh capture.
+- Removed only dead internal CarSA debug comparison paths (legacy Dahl/iRacing relative-gap sampling arrays/property lists and their reset helper).
+- Active CarSA debug CSV header/row shape remained unchanged.
+- No release-facing exports changed and no Opponents/Pit/H2H/Fuel behavior changed.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Brake.PreviousPeakPct manual/session reset hardening + docs sync`).
+- Validation recorded against `HEAD` (`CarSA dead debug comparison scaffold prune + docs sync`).

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3956,42 +3956,6 @@ namespace LaunchPlugin
         private readonly bool[] _carSaEventLastAheadConflict = new bool[CarSaDebugExportSlotCount];
         private readonly bool[] _carSaEventLastBehindConflict = new bool[CarSaDebugExportSlotCount];
         private bool _carSaEventLastStateInitialized;
-        private static readonly string[] CarSaDebugAheadDahlProperties =
-        {
-            "DahlDesign.CarAhead01Relative",
-            "DahlDesign.CarAhead02Relative",
-            "DahlDesign.CarAhead03Relative",
-            "DahlDesign.CarAhead04Relative",
-            "DahlDesign.CarAhead05Relative"
-        };
-        private static readonly string[] CarSaDebugBehindDahlProperties =
-        {
-            "DahlDesign.CarBehind01Relative",
-            "DahlDesign.CarBehind02Relative",
-            "DahlDesign.CarBehind03Relative",
-            "DahlDesign.CarBehind04Relative",
-            "DahlDesign.CarBehind05Relative"
-        };
-        private static readonly string[] CarSaDebugAheadIRacingProperties =
-        {
-            "IRacingExtraProperties.iRacing_DriverAhead_00_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverAhead_01_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverAhead_02_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverAhead_03_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverAhead_04_RelativeGapToPlayer"
-        };
-        private static readonly string[] CarSaDebugBehindIRacingProperties =
-        {
-            "IRacingExtraProperties.iRacing_DriverBehind_00_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverBehind_01_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverBehind_02_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverBehind_03_RelativeGapToPlayer",
-            "IRacingExtraProperties.iRacing_DriverBehind_04_RelativeGapToPlayer"
-        };
-        private readonly double[] _carSaDebugAheadDahlRelativeGapSec = new double[CarSaDebugExportSlotCount];
-        private readonly double[] _carSaDebugBehindDahlRelativeGapSec = new double[CarSaDebugExportSlotCount];
-        private readonly double[] _carSaDebugAheadIRacingRelativeGapSec = new double[CarSaDebugExportSlotCount];
-        private readonly double[] _carSaDebugBehindIRacingRelativeGapSec = new double[CarSaDebugExportSlotCount];
         private Dictionary<string, int> _carSaClassRankByColor;
         private string _carSaClassRankToken;
         private string _carSaClassRankSource;
@@ -6529,14 +6493,6 @@ namespace LaunchPlugin
                 bool carSaDebugExportEnabled = debugMaster && Settings?.EnableCarSADebugExport == true;
                 if (carSaDebugExportEnabled)
                 {
-                    for (int i = 0; i < CarSaDebugExportSlotCount; i++)
-                    {
-                        _carSaDebugAheadDahlRelativeGapSec[i] = SafeReadDouble(pluginManager, CarSaDebugAheadDahlProperties[i], double.NaN);
-                        _carSaDebugBehindDahlRelativeGapSec[i] = SafeReadDouble(pluginManager, CarSaDebugBehindDahlProperties[i], double.NaN);
-                        _carSaDebugAheadIRacingRelativeGapSec[i] = SafeReadDouble(pluginManager, CarSaDebugAheadIRacingProperties[i], double.NaN);
-                        _carSaDebugBehindIRacingRelativeGapSec[i] = SafeReadDouble(pluginManager, CarSaDebugBehindIRacingProperties[i], double.NaN);
-                    }
-
                     UpdateCarSaDebugCadenceState(trackPct, _carSaEngine.Outputs.Debug);
                 }
 
@@ -9420,23 +9376,6 @@ namespace LaunchPlugin
             _carSaEventsExportBuffer.Clear();
             _carSaEventsExportPendingLines = 0;
             _carSaEventLastStateInitialized = false;
-            ResetCarSaDebugGapArray(_carSaDebugAheadDahlRelativeGapSec);
-            ResetCarSaDebugGapArray(_carSaDebugBehindDahlRelativeGapSec);
-            ResetCarSaDebugGapArray(_carSaDebugAheadIRacingRelativeGapSec);
-            ResetCarSaDebugGapArray(_carSaDebugBehindIRacingRelativeGapSec);
-        }
-
-        private static void ResetCarSaDebugGapArray(double[] values)
-        {
-            if (values == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < values.Length; i++)
-            {
-                values[i] = double.NaN;
-            }
         }
 
         private void ResetCarSaIdentityState()


### PR DESCRIPTION
### Motivation
- Remove unused internal CarSA debug comparison scaffolding that sampled legacy Dahl/iRacing relative-gap properties but did not feed active debug CSV exports or any user-facing behavior.
- Simplify `LalaLaunch` state by removing orphaned arrays and helpers that were only used by the dead comparison paths.

### Description
- Deleted legacy property-name arrays and matching per-slot storage arrays that referenced Dahl and iRacing relative-gap keys from `LalaLaunch.cs` and removed the unused read loop that populated them. 
- Removed the now-orphaned `ResetCarSaDebugGapArray` helper and the corresponding reset calls from `ResetCarSaDebugExportState`. 
- Preserved active CarSA debug export pipeline and runtime behavior (the `CarSA_Debug_*.csv` schema/cadence and Opponents/H2H/Fuel runtime semantics remain unchanged). 
- Updated documentation files to reflect the change, including `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, and related doc index entries, and bumped repository status date. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e37e2988832f8b76bee1b071625b)