### PR TITLE
Hotfix: persist MSGV1 unavailable-signal warnings and restore projection fallback seeding

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,12 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+## 2026-04-11 — Hotfix follow-up for fallback-removal regressions (MSGV1 + projection fallback)
+- Classification: **internal-only** (bounded runtime/logging behavior correction, no new user workflow).
+- Fixed MSGV1 removed-signal warning spam by making unavailable-signal warning state runtime-static in `Messaging/SignalProvider.cs`, so repeated `SignalProvider` construction no longer re-emits per-tick warnings.
+- Restored a non-ExtraProperties laps-remaining fallback path in `LalaLaunch.cs`: projection now seeds `simLapsRemaining` from native `DataCorePlugin.GameData.LapsRemaining` when available, then falls back to prior runtime values (`_lastSimLapsRemaining`, `_lastProjectedLapsRemaining`) instead of hardcoded `0.0`.
+- Kept `IRacingExtraProperties` fully removed; no legacy fallback reads were reintroduced.
+
 ### Pit Entry Assist aggressive fallback removal (stored-marker authority only)
 - Removed pit-entry distance fallback branches in `PitEngine.UpdatePitEntryAssist` that previously read `IRacingExtraProperties.iRacing_DistanceToPitEntry` and `IRacingExtraProperties.iRacing_PitEntryTrkPct`.
 - Pit Entry Assist distance authority is now stored/plugin-owned track markers only; when stored marker inputs are unavailable/invalid, assist is reset/off for that tick.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -39,6 +39,12 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Restored a non-ExtraProperties laps-remaining fallback path in `LalaLaunch.cs`: projection now seeds `simLapsRemaining` from native `DataCorePlugin.GameData.LapsRemaining` when available, then falls back to prior runtime values (`_lastSimLapsRemaining`, `_lastProjectedLapsRemaining`) instead of hardcoded `0.0`.
 - Kept `IRacingExtraProperties` fully removed; no legacy fallback reads were reintroduced.
 
+## 2026-04-11 — Hotfix follow-up for stale laps-remaining fallback leakage across session reset
+- Classification: **internal-only** (runtime reset-state correction).
+- Fixed stale prior-session laps-remaining reuse by clearing projection fallback carry state (`_lastSimLapsRemaining`, `_lastProjectedLapsRemaining`, `_lastProjectionLapSecondsUsed`) in both `ResetLiveFuelModelForNewSession(...)` and `ManualRecoveryReset(...)`.
+- This preserves current-session fallback reuse during temporary native dropouts while preventing prior-session leakage into fresh sessions.
+- Kept `ResolveSimLapsRemaining()` fallback concept intact and did not reintroduce `IRacingExtraProperties`.
+
 ### Pit Entry Assist aggressive fallback removal (stored-marker authority only)
 - Removed pit-entry distance fallback branches in `PitEngine.UpdatePitEntryAssist` that previously read `IRacingExtraProperties.iRacing_DistanceToPitEntry` and `IRacingExtraProperties.iRacing_PitEntryTrkPct`.
 - Pit Entry Assist distance authority is now stored/plugin-owned track markers only; when stored marker inputs are unavailable/invalid, assist is reset/off for that tick.

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -3,8 +3,8 @@
 **CANONICAL OBSERVABILITY MAP**
 
 Validated against: HEAD
-Last reviewed: 2026-04-10
-Last updated: 2026-04-10
+Last reviewed: 2026-04-11
+Last updated: 2026-04-11
 Branch: work
 
 Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub.Logging.Current.Warn(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
@@ -79,7 +79,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 ## H2H and messaging fallback-removal warnings
 - **`[LalaPlugin:H2H] Native class session-best lap unavailable; legacy IRacingExtraProperties fallback is removed. H2H class-best output remains 0 until native class-best is available.`** — One-time warning emitted when H2H class-best has no native authority; output remains `0` until native class-best recovers.
 - **`[LalaPlugin:Messaging] Legacy IRacingExtraProperties traffic fast-path disabled. MessagingSystem now uses native/session opponent context only; output may remain empty when no native context is available.`** — One-time warning emitted when the old ExtraProperties traffic fast-path is intentionally disabled.
-- **`[LalaPlugin:MSGV1] Signal '<signalId>' has no native/plugin-owned authority. Legacy IRacingExtraProperties fallback is removed; signal remains unavailable.`** — One-time-per-signal warning for MSGV1 signal ids previously sourced from ExtraProperties.
+- **`[LalaPlugin:MSGV1] Signal '<signalId>' has no native/plugin-owned authority. Legacy IRacingExtraProperties fallback is removed; signal remains unavailable.`** — One-time-per-signal warning for MSGV1 signal ids previously sourced from ExtraProperties; warning state is runtime-static so `SignalProvider` re-creation does not spam this line each tick.
 
 ## Pit, refuel, and PitLite
 - **`[LalaPlugin:Pit Cycle] Saved PitLaneLoss = Xs (src).`** — Persisted pit lane loss from PitLite/DTL (debounced).【F:LalaLaunch.cs†L2950-L3004】

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -16,6 +16,8 @@ Branch: work
 - Hotfix follow-up applied for fallback-removal regressions:
   - MSGV1 removed-signal warning state now persists across `SignalProvider` re-instantiation, preventing per-tick warning spam.
   - Pace/projection no longer hardcodes `simLapsRemaining=0`; timed-race projection now keeps a native/runtime fallback seed (`DataCorePlugin.GameData.LapsRemaining` then last-known runtime values) without reintroducing ExtraProperties.
+- Follow-up correction applied for stale session carry-over:
+  - Projection fallback carry-state is now cleared on session/fuel-model resets and manual recovery, preventing prior-session laps-remaining leakage into a fresh session before native laps-remaining becomes available.
 - Preserved subsystem ownership boundaries (Opponents remains native-only race-order owner, CarSA session-agnostic spatial owner, H2H consumer/publisher only).
 
 ## Reviewed documentation set
@@ -40,6 +42,11 @@ Branch: work
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
+### Changed in stale-fallback reset follow-up
+- `LalaLaunch.cs`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
 ### Reviewed and left unchanged
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
@@ -52,4 +59,4 @@ Branch: work
 - Warning logs are bounded (one-time or recovery-driven) for removed fallback authorities in H2H, Pit Entry Assist, MessagingSystem, and MSGV1 signal provider.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Hotfix follow-up for MSGV1 warning-state persistence + projection fallback seeding`).
+- Validation recorded against `HEAD` (`Hotfix follow-up for stale laps-remaining fallback leakage across session reset`).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-10
+Last updated: 2026-04-11
 Branch: work
 
 ## Current repo/link status
@@ -13,6 +13,9 @@ Branch: work
 - H2H class-best is now native-only (`H2H*.ClassSessionBestLapSec` remains `0` when native class-best authority is unavailable) with a bounded warning log.
 - Pit Entry Assist pit-speed authority is now native session-only; legacy pit-speed fallback is removed with a bounded warning log when authority is unavailable.
 - Messaging legacy ExtraProperties traffic/signal paths are removed; unavailable signals/lanes now remain unavailable with bounded warnings instead of silent fallback.
+- Hotfix follow-up applied for fallback-removal regressions:
+  - MSGV1 removed-signal warning state now persists across `SignalProvider` re-instantiation, preventing per-tick warning spam.
+  - Pace/projection no longer hardcodes `simLapsRemaining=0`; timed-race projection now keeps a native/runtime fallback seed (`DataCorePlugin.GameData.LapsRemaining` then last-known runtime values) without reintroducing ExtraProperties.
 - Preserved subsystem ownership boundaries (Opponents remains native-only race-order owner, CarSA session-agnostic spatial owner, H2H consumer/publisher only).
 
 ## Reviewed documentation set
@@ -30,6 +33,13 @@ Branch: work
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
+### Changed in follow-up hotfix
+- `LalaLaunch.cs`
+- `Messaging/SignalProvider.cs`
+- `Docs/Internal/SimHubLogMessages.md`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
 ### Reviewed and left unchanged
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
@@ -42,4 +52,4 @@ Branch: work
 - Warning logs are bounded (one-time or recovery-driven) for removed fallback authorities in H2H, Pit Entry Assist, MessagingSystem, and MSGV1 signal provider.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Repo-wide iRacingExtraProperties runtime fallback removal sweep`).
+- Validation recorded against `HEAD` (`Hotfix follow-up for MSGV1 warning-state persistence + projection fallback seeding`).

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1825,8 +1825,17 @@ namespace LaunchPlugin
             _lastAnnouncedMaxFuel = -1;
         }
 
+        private void ResetProjectionFallbackState()
+        {
+            _lastProjectedLapsRemaining = 0.0;
+            _lastSimLapsRemaining = 0.0;
+            _lastProjectionLapSecondsUsed = 0.0;
+        }
+
         private void ResetLiveFuelModelForNewSession(string newSessionType, bool applySeeds)
         {
+            ResetProjectionFallbackState();
+
             // Clear per-lap / model state
             ResetLiveMaxFuelTracking();
             _recentDryFuelLaps.Clear();
@@ -5986,6 +5995,7 @@ namespace LaunchPlugin
         {
             string reasonLabel = string.IsNullOrWhiteSpace(reason) ? "unspecified" : reason.Trim();
             SimHub.Logging.Current.Info($"[LalaPlugin:Runtime] manual recovery reset triggered (reason: {reasonLabel}).");
+            ResetProjectionFallbackState();
 
             _rejoinEngine?.Reset();
             _pit?.Reset();

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3137,7 +3137,7 @@ namespace LaunchPlugin
             {
                 LapsRemainingInTank = currentFuel / fuelPerLapForCalc;
 
-                double simLapsRemaining = 0.0;
+                double simLapsRemaining = ResolveSimLapsRemaining();
 
                 bool isTimedRace = !double.IsNaN(sessionTimeRemain);
                 double projectionLapSeconds = GetProjectionLapSeconds(data);
@@ -13161,6 +13161,27 @@ namespace LaunchPlugin
 
             LiveProjectedDriveSecondsRemaining = projectedSeconds;
             return projectedLaps;
+        }
+
+        private double ResolveSimLapsRemaining()
+        {
+            double simLapsRemaining = SafeReadDouble(PluginManager, "DataCorePlugin.GameData.LapsRemaining", double.NaN);
+            if (!double.IsNaN(simLapsRemaining) && simLapsRemaining > 0.0)
+            {
+                return simLapsRemaining;
+            }
+
+            if (_lastSimLapsRemaining > 0.0)
+            {
+                return _lastSimLapsRemaining;
+            }
+
+            if (_lastProjectedLapsRemaining > 0.0)
+            {
+                return _lastProjectedLapsRemaining;
+            }
+
+            return 0.0;
         }
 
         private double ComputeLiveMaxFuelFromSimhub(PluginManager pluginManager)

--- a/Messaging/SignalProvider.cs
+++ b/Messaging/SignalProvider.cs
@@ -15,7 +15,8 @@ namespace LaunchPlugin.Messaging
         private readonly PluginManager _pluginManager;
         private readonly LalaLaunch _plugin;
         private readonly Dictionary<string, Func<object>> _accessors;
-        private readonly HashSet<string> _legacyExtraSignalWarned = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> LegacyExtraSignalWarned = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object LegacyExtraSignalWarnedLock = new object();
 
         public SignalProvider(PluginManager pluginManager, LalaLaunch plugin)
         {
@@ -118,9 +119,18 @@ namespace LaunchPlugin.Messaging
 
         private object LegacyExtraSignalUnavailable(string signalId)
         {
-            if (!_legacyExtraSignalWarned.Contains(signalId))
+            bool shouldWarn = false;
+            lock (LegacyExtraSignalWarnedLock)
             {
-                _legacyExtraSignalWarned.Add(signalId);
+                if (!LegacyExtraSignalWarned.Contains(signalId))
+                {
+                    LegacyExtraSignalWarned.Add(signalId);
+                    shouldWarn = true;
+                }
+            }
+
+            if (shouldWarn)
+            {
                 SimHub.Logging.Current.Warn(
                     $"[LalaPlugin:MSGV1] Signal '{signalId}' has no native/plugin-owned authority. " +
                     "Legacy IRacingExtraProperties fallback is removed; signal remains unavailable.");


### PR DESCRIPTION
### Motivation
- Fix two regressions from the ExtraProperties fallback removal: MSGV1 removed-signal warnings were re-logging every tick due to instance-local cache churn, and projection fallback was weakened by a hardcoded `simLapsRemaining = 0.0` which can collapse strategy/fuel outputs when stronger native inputs exist.
- Keep the ExtraProperties removal direction intact while restoring bounded warning semantics and a safe native/runtime fallback for laps-remaining.

### Description
- Make MSGV1 removed-signal warning state runtime-static by switching the per-instance warning set to a `static` `HashSet<string>` with a lock in `Messaging/SignalProvider.cs`, so each unavailable signal logs one runtime-scoped warning only.
- Restore a non-ExtraProperties projection seed in `LalaLaunch.cs` by replacing the hardcoded `0.0` with `ResolveSimLapsRemaining()` and using that value when calling `ComputeProjectedLapsRemaining`; the resolver prefers `DataCorePlugin.GameData.LapsRemaining` then `_lastSimLapsRemaining` then `_lastProjectedLapsRemaining` before falling back to `0.0`.
- Update internal docs to reflect the hotfix: `Docs/Internal/SimHubLogMessages.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` were edited to record the behavioral change and validation stamps.
- Confirmed no `IRacingExtraProperties` runtime reads were reintroduced; all fixes use native/plugin-owned sources or preserved runtime state only.

### Testing
- Verified provider churn root cause and usage points with repository searches using `rg` (checked `new SignalProvider` and tick instantiation places), and confirmed `MessageEngine.Tick(...)` still constructs `SignalProvider` per tick (searches succeeded).
- Verified replacement projection seed usage with `rg` and file inspections to ensure `ResolveSimLapsRemaining()` is used where `simLapsRemaining` was previously hardcoded (searches/inspections succeeded).
- Confirmed no `IRacingExtraProperties` reads were reintroduced by searching for `IRacingExtraProperties` in modified files using `rg` (success).
- Attempted to run a full build with `dotnet build LaunchPlugin.sln -c Release` but the environment lacked the `dotnet` CLI, so a local build could not be completed (failure due to missing tool, not code).
- Changes were committed on branch HEAD (`ee57749`) and unit/functional smoke-checks via `rg`/file inspection succeeded; `dotnet` build not executed due to environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7514aa18832fb64b18d8408d96d3)