### PR TITLE
Replace Brake.PreviousPeakPct 40-sample capture with event-based peak detector

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### Brake previous-peak event-based detector replacement
+- Replaced the prior Dahl-style `Brake.PreviousPeakPct` 40-sample window capture with an event-based peak detector in `LalaLaunch.cs`.
+- Braking event contract is now: start when `brake > 0.05` and `throttle < 0.20`; while active track `peak = max(peak, brake)`; end when `brake <= 0.05` or `throttle >= 0.20`; on end, latch `Brake.PreviousPeakPct = peak` and reset internal event state.
+- Kept internal/runtime brake values normalized on a `0..1` basis (no in-plugin ×100 scaling), preserved manual/session reset behavior, and intentionally kept stationary testing valid by not adding a speed guard.
+
 ### Pit Entry Assist aggressive fallback removal (stored-marker authority only)
 - Removed pit-entry distance fallback branches in `PitEngine.UpdatePitEntryAssist` that previously read `IRacingExtraProperties.iRacing_DistanceToPitEntry` and `IRacingExtraProperties.iRacing_PitEntryTrkPct`.
 - Pit Entry Assist distance authority is now stored/plugin-owned track markers only; when stored marker inputs are unavailable/invalid, assist is reset/off for that tick.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -3,8 +3,8 @@
 **CANONICAL CONTRACT**
 
 Validated against: HEAD
-Last reviewed: 2026-04-10
-Last updated: 2026-04-10
+Last reviewed: 2026-04-11
+Last updated: 2026-04-11
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -14,7 +14,7 @@ Branch: work
 ## Brake
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Brake.PreviousPeakPct | double | Maximum brake input recorded during the most recent completed 40-sample braking capture (Dahl-style brake peak). Capture starts when brake rises above zero, latches on sample 40, and arms the next capture only after brake falls to ≤2% (`brake01 <= 0.02`). Manual/session recovery resets clear capture state and the latched export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake capture state + `AttachCore`. |
+| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 5% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export. Manual/session recovery resets clear active event state and set the latched export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
 
 ## Fuel
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-10
+Last updated: 2026-04-11
 Branch: work
 
 ## Current repo/link status
@@ -9,37 +9,27 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Completed a repo-wide runtime sweep removing remaining `IRacingExtraProperties` fallback reads from in-scope runtime code paths.
-- H2H class-best is now native-only (`H2H*.ClassSessionBestLapSec` remains `0` when native class-best authority is unavailable) with a bounded warning log.
-- Pit Entry Assist pit-speed authority is now native session-only; legacy pit-speed fallback is removed with a bounded warning log when authority is unavailable.
-- Messaging legacy ExtraProperties traffic/signal paths are removed; unavailable signals/lanes now remain unavailable with bounded warnings instead of silent fallback.
-- Preserved subsystem ownership boundaries (Opponents remains native-only race-order owner, CarSA session-agnostic spatial owner, H2H consumer/publisher only).
+- Replaced `Brake.PreviousPeakPct` capture from a fixed 40-sample Dahl-style window to an event-based braking detector.
+- New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.05` or `throttle >= 0.20`; latch peak on event end.
+- Brake/throttle processing remains normalized `0..1` inside plugin runtime with no in-plugin ×100 scaling, and no speed guard was added so stationary testing remains valid.
 
 ## Reviewed documentation set
 ### Changed in this sweep
 - `LalaLaunch.cs`
-- `PitEngine.cs`
-- `MessagingSystem.cs`
-- `Messaging/SignalProvider.cs`
-- `ProfilesManagerViewModel.cs`
-- `Docs/Subsystems/H2H.md`
-- `Docs/Subsystems/Pit_Entry_Assist.md`
-- `Docs/Subsystems/Message_System_V1.md`
 - `Docs/Internal/SimHubParameterInventory.md`
-- `Docs/Internal/SimHubLogMessages.md`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
 ### Reviewed and left unchanged
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
-- `Docs/Subsystems/Opponents.md`
-- `Docs/Subsystems/CarSA.md`
+- `Docs/Subsystems/Launch_Mode.md`
+- `Docs/Subsystems/Dash_Integration.md`
 
 ## Delivery status highlights
-- No in-scope runtime `IRacingExtraProperties` reads remain in C# code; removed paths now either use existing native/plugin-owned sources or intentionally publish unavailable/invalid outputs.
-- Opponents remains native-only and unchanged in ownership model.
-- Warning logs are bounded (one-time or recovery-driven) for removed fallback authorities in H2H, Pit Entry Assist, MessagingSystem, and MSGV1 signal provider.
+- Removed previous `_brakeTrigger` / `_brakeSampleCount` 40-sample latch path and replaced it with minimal event-state variables (`_brakeEventActive`, `_brakeEventPeak`, `_brakePreviousPeakPct`).
+- `Brake.PreviousPeakPct` now updates only when a braking event ends (brake release or throttle application), avoiding corner-exit throttle contamination and enabling deterministic stationary validation.
+- Manual/session recovery still clears active brake state and resets `Brake.PreviousPeakPct` to `0.0`.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Repo-wide iRacingExtraProperties runtime fallback removal sweep`).
+- Validation recorded against `HEAD` (`Brake.PreviousPeakPct event-based detector replacement`).

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4164,16 +4164,14 @@ namespace LaunchPlugin
         private DateTime _shiftAssistLearnSavedPulseUntilUtc = DateTime.MinValue;
         private ShiftAssistLearningTick _shiftAssistLastLearningTick = new ShiftAssistLearningTick { State = ShiftAssistLearningState.Off };
         private DateTime _shiftAssistRuntimeStatsLastRefreshUtc = DateTime.MinValue;
-        private bool _brakeTrigger;
-        private double _brakeMax;
-        private int _brakeSampleCount;
+        private bool _brakeEventActive;
+        private double _brakeEventPeak;
         private double _brakePreviousPeakPct;
 
         private void ResetBrakeCaptureState()
         {
-            _brakeTrigger = false;
-            _brakeMax = 0.0;
-            _brakeSampleCount = 0;
+            _brakeEventActive = false;
+            _brakeEventPeak = 0.0;
             _brakePreviousPeakPct = 0.0;
         }
 
@@ -7014,40 +7012,34 @@ namespace LaunchPlugin
                 // Throttle: your codebase treats it like 0..100, so normalise to 0..1
                 double throttleRaw = data.NewData?.Throttle ?? 0.0;
                 double throttle01 = throttleRaw > 1.5 ? (throttleRaw / 100.0) : throttleRaw;
+                throttle01 = Math.Max(0.0, Math.Min(1.0, throttle01));
 
                 // Brake: confirmed in SimHub property tab
                 double brakeRaw = SafeReadDouble(pluginManager, "DataCorePlugin.GameData.Brake", 0.0);
                 double brake01 = brakeRaw > 1.5 ? (brakeRaw / 100.0) : brakeRaw;
+                brake01 = Math.Max(0.0, Math.Min(1.0, brake01));
 
-                if (!_brakeTrigger && brake01 > 0.0)
+                bool startOrActive = brake01 > 0.05 && throttle01 < 0.20;
+                bool endEvent = brake01 <= 0.05 || throttle01 >= 0.20;
+
+                if (!_brakeEventActive && startOrActive)
                 {
-                    _brakeTrigger = true;
-                    _brakeMax = brake01;
-                    _brakeSampleCount = 0;
+                    _brakeEventActive = true;
+                    _brakeEventPeak = brake01;
                 }
 
-                if (_brakeTrigger)
+                if (_brakeEventActive)
                 {
-                    if (_brakeSampleCount < 40)
+                    if (brake01 > _brakeEventPeak)
                     {
-                        if (brake01 > _brakeMax)
-                        {
-                            _brakeMax = brake01;
-                        }
-
-                        _brakeSampleCount++;
-
-                        if (_brakeSampleCount >= 40)
-                        {
-                            _brakePreviousPeakPct = _brakeMax;
-                        }
+                        _brakeEventPeak = brake01;
                     }
 
-                    if (_brakeSampleCount >= 40 && brake01 <= 0.02)
+                    if (endEvent)
                     {
-                        _brakeTrigger = false;
-                        _brakeMax = 0.0;
-                        _brakeSampleCount = 0;
+                        _brakePreviousPeakPct = Math.Max(0.0, Math.Min(1.0, _brakeEventPeak));
+                        _brakeEventActive = false;
+                        _brakeEventPeak = 0.0;
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- The prior Dahl-style 40-sample capture produced unreliable/incorrect peak values in testing and needed to be replaced with a deterministic event-based peak detector. 
- The goal is to publish a single normalized `Brake.PreviousPeakPct` (0..1) representing the peak brake of the most-recent completed braking event using an explicit start/active/end contract.

### Description
- Replaced the old 40-sample capture internals in `LalaLaunch.cs` by removing `_brakeTrigger`, `_brakeMax`, and `_brakeSampleCount` and adding minimal event state: `bool _brakeEventActive`, `double _brakeEventPeak`, and the existing `double _brakePreviousPeakPct`.
- Implemented event logic in the runtime update loop: start when `brake > 0.05 && throttle < 0.20`, track `peak = max(peak, brake)` while active, end when `brake <= 0.05 || throttle >= 0.20`, and latch the peak into `Brake.PreviousPeakPct` on event end; clamped peak values to `0..1` and preserved in-plugin normalization (no ×100 scaling).
- Added explicit clamping for `throttle`/`brake` normalization to ensure latched peaks never exceed `1.0`, and intentionally did not add any speed guard so stationary testing remains valid.
- Updated documentation to match the new contract: `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` now describe the event-based `Brake.PreviousPeakPct` behavior and the removed 40-sample path.

### Testing
- Performed static/source checks with `rg` to confirm new symbols (`_brakeEventActive`, `_brakeEventPeak`, `startOrActive`, `endEvent`) are present and that the previous 40-sample logic is removed, which succeeded.
- Verified the `Brake.PreviousPeakPct` export is still attached in `LalaLaunch.cs` and that the latch now occurs only on event end via source inspection, which succeeded.
- Attempted to run `dotnet build` but the environment lacks `dotnet`, so a full build could not be executed in this container (build not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da77f85294832faa4d64a6f2bbab09)