### PR TITLE
Refine Brake.PreviousPeakPct detector with hysteresis and re-arm lock

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -35,7 +35,7 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ### Brake previous-peak detector hysteresis + re-arm lock refinement
 - Refined `Brake.PreviousPeakPct` event detection in `LalaLaunch.cs` to use start/end hysteresis thresholds: start at `brake > 0.05 && throttle < 0.20`, end at `brake <= 0.02 || throttle >= 0.20`.
-- Added explicit latch/re-arm behavior after publish so a completed event cannot immediately retrigger; re-arm now requires two consecutive release ticks with `brake <= 0.02`.
+- Added explicit latch/re-arm behavior after publish so a completed event cannot immediately retrigger; re-arm now requires three consecutive release ticks with `brake <= 0.02`.
 - Preserved existing external contract (`Brake.PreviousPeakPct` updates only on event end, normalized `0..1` inputs, no speed gate) and reset paths now clear active/latch/counter state together.
 
 ### Brake previous-peak event-based detector replacement

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -35,7 +35,7 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ### Brake previous-peak detector hysteresis + re-arm lock refinement
 - Refined `Brake.PreviousPeakPct` event detection in `LalaLaunch.cs` to use start/end hysteresis thresholds: start at `brake > 0.05 && throttle < 0.20`, end at `brake <= 0.02 || throttle >= 0.20`.
-- Added explicit latch/re-arm behavior after publish so a completed event cannot immediately retrigger; re-arm now requires three consecutive release ticks with `brake <= 0.02`.
+- Added explicit latch/re-arm behavior after publish so a completed event cannot immediately retrigger; re-arm now requires three consecutive release ticks where either `brake <= 0.02` or `throttle >= 0.20`.
 - Preserved existing external contract (`Brake.PreviousPeakPct` updates only on event end, normalized `0..1` inputs, no speed gate) and reset paths now clear active/latch/counter state together.
 
 ### Brake previous-peak event-based detector replacement

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### Brake previous-peak detector hysteresis + re-arm lock refinement
+- Refined `Brake.PreviousPeakPct` event detection in `LalaLaunch.cs` to use start/end hysteresis thresholds: start at `brake > 0.05 && throttle < 0.20`, end at `brake <= 0.02 || throttle >= 0.20`.
+- Added explicit latch/re-arm behavior after publish so a completed event cannot immediately retrigger; re-arm now requires two consecutive release ticks with `brake <= 0.02`.
+- Preserved existing external contract (`Brake.PreviousPeakPct` updates only on event end, normalized `0..1` inputs, no speed gate) and reset paths now clear active/latch/counter state together.
+
 ### Brake previous-peak event-based detector replacement
 - Replaced the prior Dahl-style `Brake.PreviousPeakPct` 40-sample window capture with an event-based peak detector in `LalaLaunch.cs`.
 - Braking event contract is now: start when `brake > 0.05` and `throttle < 0.20`; while active track `peak = max(peak, brake)`; end when `brake <= 0.05` or `throttle >= 0.20`; on end, latch `Brake.PreviousPeakPct = peak` and reset internal event state.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -3,8 +3,8 @@
 **CANONICAL CONTRACT**
 
 Validated against: HEAD
-Last reviewed: 2026-04-11
-Last updated: 2026-04-11
+Last reviewed: 2026-04-12
+Last updated: 2026-04-12
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -14,7 +14,7 @@ Branch: work
 ## Brake
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 5% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export. Manual/session recovery resets clear active event state and set the latched export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
+| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 2% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export and capture enters a short re-arm lock that requires at least two consecutive release ticks (`brake <= 0.02`) before a new event can start. Manual/session recovery resets clear active + latched state/counters and set the export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
 
 ## Fuel
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -14,7 +14,7 @@ Branch: work
 ## Brake
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 2% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export and capture enters a short re-arm lock that requires at least two consecutive release ticks (`brake <= 0.02`) before a new event can start. Manual/session recovery resets clear active + latched state/counters and set the export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
+| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 2% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export and capture enters a short re-arm lock that requires at least three consecutive release ticks (`brake <= 0.02`) before a new event can start. Manual/session recovery resets clear active + latched state/counters and set the export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
 
 ## Fuel
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -14,7 +14,7 @@ Branch: work
 ## Brake
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 2% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export and capture enters a short re-arm lock that requires at least three consecutive release ticks (`brake <= 0.02`) before a new event can start. Manual/session recovery resets clear active + latched state/counters and set the export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
+| Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 2% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export and capture enters a short re-arm lock that requires at least three consecutive release ticks where either `brake <= 0.02` or `throttle >= 0.20` before a new event can start. Manual/session recovery resets clear active + latched state/counters and set the export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
 
 ## Fuel
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-11
+Last updated: 2026-04-12
 Branch: work
 
 ## Current repo/link status
@@ -10,7 +10,8 @@ Branch: work
 
 ## Documentation sync status
 - Replaced `Brake.PreviousPeakPct` capture from a fixed 40-sample Dahl-style window to an event-based braking detector.
-- New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.05` or `throttle >= 0.20`; latch peak on event end.
+- New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.02` or `throttle >= 0.20`; latch peak on event end.
+- Added post-publish latch/re-arm lock for `Brake.PreviousPeakPct`: after event end, detector must observe at least two consecutive `brake <= 0.02` ticks before a new event can begin.
 - Brake/throttle processing remains normalized `0..1` inside plugin runtime with no in-plugin ×100 scaling, and no speed guard was added so stationary testing remains valid.
 
 ## Reviewed documentation set
@@ -32,6 +33,12 @@ Branch: work
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
+### Changed in brake detector hysteresis/re-arm refinement
+- `LalaLaunch.cs`
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
 ### Reviewed and left unchanged
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
@@ -40,8 +47,8 @@ Branch: work
 
 ## Delivery status highlights
 - Removed previous `_brakeTrigger` / `_brakeSampleCount` 40-sample latch path and replaced it with minimal event-state variables (`_brakeEventActive`, `_brakeEventPeak`, `_brakePreviousPeakPct`).
-- `Brake.PreviousPeakPct` now updates only when a braking event ends (brake release or throttle application), avoiding corner-exit throttle contamination and enabling deterministic stationary validation.
-- Manual/session recovery still clears active brake state and resets `Brake.PreviousPeakPct` to `0.0`.
+- `Brake.PreviousPeakPct` still updates only when a braking event ends (brake release or throttle application), while start/end hysteresis plus re-arm lock reduce trail-brake fragmentation and immediate long-corner re-triggers.
+- Manual/session recovery clears active/latch/counter brake state and resets `Brake.PreviousPeakPct` to `0.0`.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Brake.PreviousPeakPct event-based detector replacement`).
+- Validation recorded against `HEAD` (`Brake.PreviousPeakPct hysteresis + re-arm lock refinement`).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -11,7 +11,7 @@ Branch: work
 ## Documentation sync status
 - Replaced `Brake.PreviousPeakPct` capture from a fixed 40-sample Dahl-style window to an event-based braking detector.
 - New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.02` or `throttle >= 0.20`; latch peak on event end.
-- Added post-publish latch/re-arm lock for `Brake.PreviousPeakPct`: after event end, detector must observe at least three consecutive `brake <= 0.02` ticks before a new event can begin.
+- Added post-publish latch/re-arm lock for `Brake.PreviousPeakPct`: after event end, detector must observe at least three consecutive ticks where either `brake <= 0.02` or `throttle >= 0.20` before a new event can begin.
 - Brake/throttle processing remains normalized `0..1` inside plugin runtime with no in-plugin ×100 scaling, and no speed guard was added so stationary testing remains valid.
 
 ## Reviewed documentation set

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -11,7 +11,7 @@ Branch: work
 ## Documentation sync status
 - Replaced `Brake.PreviousPeakPct` capture from a fixed 40-sample Dahl-style window to an event-based braking detector.
 - New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.02` or `throttle >= 0.20`; latch peak on event end.
-- Added post-publish latch/re-arm lock for `Brake.PreviousPeakPct`: after event end, detector must observe at least two consecutive `brake <= 0.02` ticks before a new event can begin.
+- Added post-publish latch/re-arm lock for `Brake.PreviousPeakPct`: after event end, detector must observe at least three consecutive `brake <= 0.02` ticks before a new event can begin.
 - Brake/throttle processing remains normalized `0..1` inside plugin runtime with no in-plugin ×100 scaling, and no speed guard was added so stationary testing remains valid.
 
 ## Reviewed documentation set

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4175,12 +4175,16 @@ namespace LaunchPlugin
         private DateTime _shiftAssistRuntimeStatsLastRefreshUtc = DateTime.MinValue;
         private bool _brakeEventActive;
         private double _brakeEventPeak;
+        private bool _brakeLatchedWaitingForRelease;
+        private int _brakeReleaseTicks;
         private double _brakePreviousPeakPct;
 
         private void ResetBrakeCaptureState()
         {
             _brakeEventActive = false;
             _brakeEventPeak = 0.0;
+            _brakeLatchedWaitingForRelease = false;
+            _brakeReleaseTicks = 0;
             _brakePreviousPeakPct = 0.0;
         }
 
@@ -7029,13 +7033,37 @@ namespace LaunchPlugin
                 double brake01 = brakeRaw > 1.5 ? (brakeRaw / 100.0) : brakeRaw;
                 brake01 = Math.Max(0.0, Math.Min(1.0, brake01));
 
-                bool startOrActive = brake01 > 0.05 && throttle01 < 0.20;
-                bool endEvent = brake01 <= 0.05 || throttle01 >= 0.20;
+                bool canStartEvent = !_brakeEventActive
+                    && !_brakeLatchedWaitingForRelease
+                    && brake01 > 0.05
+                    && throttle01 < 0.20;
+                bool endEvent = brake01 <= 0.02 || throttle01 >= 0.20;
 
-                if (!_brakeEventActive && startOrActive)
+                if (_brakeLatchedWaitingForRelease)
+                {
+                    if (brake01 <= 0.02)
+                    {
+                        _brakeReleaseTicks++;
+                        if (_brakeReleaseTicks >= 2)
+                        {
+                            _brakeLatchedWaitingForRelease = false;
+                            _brakeReleaseTicks = 0;
+                        }
+                    }
+                    else
+                    {
+                        _brakeReleaseTicks = 0;
+                    }
+                }
+                else
+                {
+                    _brakeReleaseTicks = 0;
+                }
+
+                if (canStartEvent)
                 {
                     _brakeEventActive = true;
-                    _brakeEventPeak = brake01;
+                    _brakeEventPeak = Math.Max(0.0, Math.Min(1.0, brake01));
                 }
 
                 if (_brakeEventActive)
@@ -7050,6 +7078,8 @@ namespace LaunchPlugin
                         _brakePreviousPeakPct = Math.Max(0.0, Math.Min(1.0, _brakeEventPeak));
                         _brakeEventActive = false;
                         _brakeEventPeak = 0.0;
+                        _brakeLatchedWaitingForRelease = true;
+                        _brakeReleaseTicks = 0;
                     }
                 }
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -7041,7 +7041,7 @@ namespace LaunchPlugin
 
                 if (_brakeLatchedWaitingForRelease)
                 {
-                    if (brake01 <= 0.02)
+                    if (brake01 <= 0.02 || throttle01 >= 0.20)
                     {
                         _brakeReleaseTicks++;
                         if (_brakeReleaseTicks >= 3)

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -7044,7 +7044,7 @@ namespace LaunchPlugin
                     if (brake01 <= 0.02)
                     {
                         _brakeReleaseTicks++;
-                        if (_brakeReleaseTicks >= 2)
+                        if (_brakeReleaseTicks >= 3)
                         {
                             _brakeLatchedWaitingForRelease = false;
                             _brakeReleaseTicks = 0;
@@ -7063,7 +7063,8 @@ namespace LaunchPlugin
                 if (canStartEvent)
                 {
                     _brakeEventActive = true;
-                    _brakeEventPeak = Math.Max(0.0, Math.Min(1.0, brake01));
+                    _brakeEventPeak = brake01;
+                    _brakeReleaseTicks = 0;
                 }
 
                 if (_brakeEventActive)


### PR DESCRIPTION
### Motivation
- Prevent event fragmentation and immediate re-triggers during trail braking and long corners by making the brake peak detector less sensitive to brief oscillations and throttle contamination.
- Keep the external contract for `Brake.PreviousPeakPct` unchanged (value latched only on event end, inputs remain normalized `0..1`).

### Description
- Replaced the simple active flag with an explicit state machine using `bool _brakeEventActive`, `double _brakeEventPeak`, `bool _brakeLatchedWaitingForRelease`, and `int _brakeReleaseTicks` in `LalaLaunch.cs` and ensured `ResetBrakeCaptureState()` clears all of these values.
- Applied hysteresis thresholds so START requires `brake > 0.05 && throttle < 0.20` while END uses `brake <= 0.02 || throttle >= 0.20`, ensuring different start/end cutoffs.
- On event end the detector latches and publishes `Brake.PreviousPeakPct = _brakeEventPeak`, sets `_brakeLatchedWaitingForRelease = true`, and only re-arms after observing at least two consecutive ticks with `brake <= 0.02` (via `_brakeReleaseTicks`).
- Updated internal docs to match the behavior change: `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`; no exports or external names were changed.

### Testing
- Attempted automated build: ran `dotnet build -v minimal` in the environment but it failed because `dotnet` is not installed, so compilation could not be verified here.
- Performed local code and grep inspection to confirm the new variables, state transitions, reset wiring, and doc edits are present and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db61ba195c832fad080dca977200f6)