### PR TITLE
Hotfix: Skip launch summary CSV header during trace housekeeping

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -191,3 +191,9 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Removed legacy ExtraProperties signal accessors in MSGV1 `SignalProvider`; affected signals now intentionally remain unavailable with one-time-per-signal warnings.
 - Removed legacy ExtraProperties traffic fast-path in `MessagingSystem`; native/session context path remains.
 - Removed `IRacingExtraProperties.` prefix bypass from `ProfilesManagerViewModel` property helper to eliminate compatibility alias treatment.
+
+## 2026-04-12 — Launch trace mixed-file parser summary-header hotfix
+- Classification: **internal-only** (housekeeping parser correctness + log-noise reduction; no user workflow or format changes).
+- Fixed launch trace housekeeping analysis to explicitly skip the summary CSV header row that follows `[LaunchSummaryHeader]`.
+- Prevented valid mixed trace files from routing `TimestampUtc,...` through telemetry row parsing, eliminating the false telemetry DateTime parse error during Launch Analysis file scans.
+- Kept launch trace naming/CSV format/summary schema unchanged; empty/header-only cleanup and completed trace retention rules remain intact.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-11
+Last updated: 2026-04-12
 Branch: work
 
 ## Current repo/link status
@@ -9,9 +9,9 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Replaced `Brake.PreviousPeakPct` capture from a fixed 40-sample Dahl-style window to an event-based braking detector.
-- New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.05` or `throttle >= 0.20`; latch peak on event end.
-- Brake/throttle processing remains normalized `0..1` inside plugin runtime with no in-plugin ×100 scaling, and no speed guard was added so stationary testing remains valid.
+- Launch trace housekeeping mixed-file parser now skips the summary CSV header row after `[LaunchSummaryHeader]`, preventing false telemetry parse errors on valid trace files.
+- Launch trace naming, telemetry CSV schema, and launch summary section format remain unchanged.
+- Empty/header-only trace cleanup rules and completed-trace retention behavior remain unchanged.
 
 ## Reviewed documentation set
 ### Changed in this sweep
@@ -32,16 +32,22 @@ Branch: work
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
+### Changed in launch trace summary-header hotfix
+- `LalaLaunch.cs`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
 ### Reviewed and left unchanged
 - `Docs/Internal/Architecture_Guardrails.md`
 - `Docs/Internal/CODEX_TASK_TEMPLATE.txt`
 - `Docs/Subsystems/Launch_Mode.md`
 - `Docs/Subsystems/Dash_Integration.md`
+- `Docs/Internal/SimHubLogMessages.md`
 
 ## Delivery status highlights
-- Removed previous `_brakeTrigger` / `_brakeSampleCount` 40-sample latch path and replaced it with minimal event-state variables (`_brakeEventActive`, `_brakeEventPeak`, `_brakePreviousPeakPct`).
-- `Brake.PreviousPeakPct` now updates only when a braking event ends (brake release or throttle application), avoiding corner-exit throttle contamination and enabling deterministic stationary validation.
-- Manual/session recovery still clears active brake state and resets `Brake.PreviousPeakPct` to `0.0`.
+- `TryAnalyzeTraceFile(...)` now tracks `[LaunchSummaryHeader]` and skips the following summary CSV header row explicitly.
+- Launch Analysis housekeeping/list discovery no longer misroutes `TimestampUtc,...` metadata rows through telemetry parsing.
+- `ReadLaunchTraceFile(...)` behavior remains unchanged and continues to parse telemetry rows plus `[LaunchSummary]` payload lines as before.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Brake.PreviousPeakPct event-based detector replacement`).
+- Validation recorded against `HEAD` (`Launch trace mixed-file parser summary-header hotfix`).

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -15375,6 +15375,7 @@ namespace LaunchPlugin
             {
                 var lines = File.ReadAllLines(filePath);
                 bool expectSummaryLine = false;
+                bool skipSummaryHeaderCsvLine = false;
                 foreach (var raw in lines)
                 {
                     string line = raw?.Trim() ?? string.Empty;
@@ -15390,6 +15391,13 @@ namespace LaunchPlugin
 
                     if (string.Equals(line, "[LaunchSummaryHeader]", StringComparison.Ordinal))
                     {
+                        skipSummaryHeaderCsvLine = true;
+                        continue;
+                    }
+
+                    if (skipSummaryHeaderCsvLine)
+                    {
+                        skipSummaryHeaderCsvLine = false;
                         continue;
                     }
 


### PR DESCRIPTION
### Motivation
- Prevent a false telemetry parse error emitted during launch-trace housekeeping when the summary CSV header line (`TimestampUtc,...`) is encountered after the `[LaunchSummaryHeader]` marker.

### Description
- Narrow fix in `TryAnalyzeTraceFile(...)` (in `LalaLaunch.cs`) that tracks `[LaunchSummaryHeader]` and explicitly skips the immediately following summary CSV header row so it is not passed to `ParseTelemetryDataRow(...)`.
- Preserved normal trace-reading behavior: `ReadLaunchTraceFile(...)` was left unchanged and still ignores `Timestamp*` header lines and parses telemetry + `[LaunchSummary]` payloads as before.
- Documentation updated to record the fix in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`.
- Files changed: `LalaLaunch.cs`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.
- Verification result: static inspection and code-path review confirm the summary-header line will no longer fall through to telemetry parsing, while empty/header-only cleanup and completed-trace retention rules remain unchanged; remaining edge cases include new/unknown metadata markers which would still require explicit handling in future changes.

### Testing
- Attempted automated build with `dotnet build LaunchPlugin.sln`, which failed in this environment because `dotnet` is not installed, so no compile/test artifacts were produced.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6b0c44f8832fb7bef3c8e0df65dc)