### PR TITLE
Add plugin-owned Pit.Box.DistanceM / Pit.Box.TimeS exports

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### Plugin-owned pit-box distance/time exports for dash use
+- Added plugin-owned `Pit.Box.DistanceM` and `Pit.Box.TimeS` exports in `LalaLaunch.cs` for in-lane pit-box guidance, with fail-safe zero publication outside pit lane or when authority inputs are invalid.
+- Added `PitEngine.PlayerPitBoxTrackPct` as the native/session authority seam for player pit-box track percent (`DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverPitTrkPct`) and reused it in pit-phase logic paths.
+- Kept pit-box time estimation conservative by deriving it from current speed only when speed is sane; otherwise `Pit.Box.TimeS` publishes `0`.
+
 ### Brake previous-peak detector hysteresis + re-arm lock refinement
 - Refined `Brake.PreviousPeakPct` event detection in `LalaLaunch.cs` to use start/end hysteresis thresholds: start at `brake > 0.05 && throttle < 0.20`, end at `brake <= 0.02 || throttle >= 0.20`.
 - Added explicit latch/re-arm behavior after publish so a completed event cannot immediately retrigger; re-arm now requires three consecutive release ticks where either `brake <= 0.02` or `throttle >= 0.20`.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -186,6 +186,8 @@ Branch: work
 | Pit.EntryLineTimeLoss_s | double | Time loss in seconds versus pit limit from the first compliant point to the pit entry line (0 if not computed). | Latched on pit entry line. | `PitEngine.UpdatePitEntryAssist` + `AttachCore`【F:PitEngine.cs†L452-L510】【F:LalaLaunch.cs†L3045-L3049】 |
 | PitExit.DistanceM | int | Forward distance in metres to the stored pit exit marker (wraps at S/F). Returns 0 if data missing. | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L4216-L4248】【F:LalaLaunch.cs†L3068-L3069】 |
 | PitExit.TimeS | int | Estimated time in seconds to pit exit using current speed (0 if speed too small or data missing). | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L4216-L4248】【F:LalaLaunch.cs†L3068-L3069】 |
+| Pit.Box.DistanceM | int | Forward wrapped distance in metres to the player pit box using native player track percent + native `DriverPitTrkPct` + session track length authority. Returns 0 when not in pit lane or when any authority is invalid/missing. | Per tick while in pit lane (0 outside pit lane). | `PitEngine.cs` (`PlayerPitBoxTrackPct`) + `LalaLaunch.cs` (`UpdatePitBoxDisplayValues`) + `AttachCore`. |
+| Pit.Box.TimeS | int | Estimated seconds to the player pit box using current speed and `Pit.Box.DistanceM`. Returns 0 when speed is too low/invalid or authority is invalid/missing. | Per tick while in pit lane (0 outside pit lane). | `LalaLaunch.cs` — `UpdatePitBoxDisplayValues` + `AttachCore`. |
 
 ## Launch
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,33 +9,16 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Replaced `Brake.PreviousPeakPct` capture from a fixed 40-sample Dahl-style window to an event-based braking detector.
-- New braking event contract: start when `brake > 0.05` and `throttle < 0.20`; track running peak while active; end when `brake <= 0.02` or `throttle >= 0.20`; latch peak on event end.
-- Added post-publish latch/re-arm lock for `Brake.PreviousPeakPct`: after event end, detector must observe at least three consecutive ticks where either `brake <= 0.02` or `throttle >= 0.20` before a new event can begin.
-- Brake/throttle processing remains normalized `0..1` inside plugin runtime with no in-plugin ×100 scaling, and no speed guard was added so stationary testing remains valid.
+- Added plugin-owned pit-box exports for dash use: `Pit.Box.DistanceM` and `Pit.Box.TimeS`.
+- Pit-box authority now comes from native session/player sources only (`DriverPitTrkPct`, player track percent, and session track length via existing PitEngine seams).
+- `Pit.Box.*` fail-safe behavior is strict: publish `0` outside pit lane, and publish `0` when authority/speed inputs are invalid (no fallback to `IRacingExtraProperties`).
 
 ## Reviewed documentation set
-### Changed in this sweep
+### Changed in pit-box export sweep
+- `PitEngine.cs`
 - `LalaLaunch.cs`
 - `Docs/Internal/SimHubParameterInventory.md`
-- `Docs/Internal/Development_Changelog.md`
-- `Docs/RepoStatus.md`
-
-### Changed in follow-up hotfix
-- `LalaLaunch.cs`
-- `Messaging/SignalProvider.cs`
-- `Docs/Internal/SimHubLogMessages.md`
-- `Docs/Internal/Development_Changelog.md`
-- `Docs/RepoStatus.md`
-
-### Changed in stale-fallback reset follow-up
-- `LalaLaunch.cs`
-- `Docs/Internal/Development_Changelog.md`
-- `Docs/RepoStatus.md`
-
-### Changed in brake detector hysteresis/re-arm refinement
-- `LalaLaunch.cs`
-- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
@@ -46,9 +29,9 @@ Branch: work
 - `Docs/Subsystems/Dash_Integration.md`
 
 ## Delivery status highlights
-- Removed previous `_brakeTrigger` / `_brakeSampleCount` 40-sample latch path and replaced it with minimal event-state variables (`_brakeEventActive`, `_brakeEventPeak`, `_brakePreviousPeakPct`).
-- `Brake.PreviousPeakPct` still updates only when a braking event ends (brake release or throttle application), while start/end hysteresis plus re-arm lock reduce trail-brake fragmentation and immediate long-corner re-triggers.
-- Manual/session recovery clears active/latch/counter brake state and resets `Brake.PreviousPeakPct` to `0.0`.
+- Added a plugin-owned pit-box percent seam in `PitEngine` (`PlayerPitBoxTrackPct`) fed from native `DriverPitTrkPct` with normalized percent handling.
+- Added plugin-owned dash exports `Pit.Box.DistanceM` and `Pit.Box.TimeS` in `LalaLaunch` using wrapped pct delta and session track length, mirroring existing pit-exit display math style.
+- Kept strict safe defaults: all pit-box outputs return `0` outside pit lane or on invalid authority, and time returns `0` when speed is too low/invalid.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Brake.PreviousPeakPct hysteresis + re-arm lock refinement`).
+- Validation recorded against `HEAD` (`plugin-owned pit-box distance/time exports`).

--- a/Docs/Subsystems/Pit_Timing_And_PitLoss.md
+++ b/Docs/Subsystems/Pit_Timing_And_PitLoss.md
@@ -1,7 +1,7 @@
 # Pit Timing and Pit Loss
 
 Validated against commit: 298accf
-Last updated: 2026-03-24
+Last updated: 2026-04-12
 Branch: work
 
 ## Purpose
@@ -183,6 +183,7 @@ Typical outputs include:
 - `Fuel.Live.RefuelRate_Lps`
 - `Fuel.Live.TireChangeTime_S`
 - `PitExit.DistanceM` / `PitExit.TimeS` (pit-exit waypoint distance/time using stored exit marker + live speed). These remain zero outside the pit lane and refresh on the 250 ms poll cadence, matching pit-lane state to avoid noisy updates when circulating on track.
+- `Pit.Box.DistanceM` / `Pit.Box.TimeS` (player pit-box waypoint distance/time using native `DriverPitTrkPct`, player track percent, session track length, and live speed). These remain zero outside the pit lane, and also fail-safe to zero when authority inputs are missing/invalid.
 
 These values feed directly into:
 - Fuel Model pit projections.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -12180,8 +12180,7 @@ namespace LaunchPlugin
                 return;
             }
 
-            double carPct = data.NewData.TrackPositionPercent;
-            if (carPct > 1.5) carPct *= 0.01;
+            double carPct = _pit.PlayerTrackPercentNormalized;
             if (carPct < 0.0 || carPct > 1.0 || double.IsNaN(carPct) || double.IsInfinity(carPct))
             {
                 _pitBoxDistanceM = 0;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4069,6 +4069,8 @@ namespace LaunchPlugin
         private readonly TrackMarkerPulse<TrackMarkerLockedMismatchMessage> _trackMarkerLockedMismatchPulse = new TrackMarkerPulse<TrackMarkerLockedMismatchMessage>();
         private int _pitExitDistanceM = 0;
         private int _pitExitTimeS = 0;
+        private int _pitBoxDistanceM = 0;
+        private int _pitBoxTimeS = 0;
         private const double PitExitSpeedEpsilonMps = 0.1;
 
         // ==== Refuel learning state (hardened) ====
@@ -5035,6 +5037,8 @@ namespace LaunchPlugin
             AttachCore("TrackMarkers.Session.NeedsExitRefresh", () => _pit?.TrackMarkersSessionNeedsExitRefresh ?? false);
             AttachCore("PitExit.DistanceM", () => _pitExitDistanceM);
             AttachCore("PitExit.TimeS", () => _pitExitTimeS);
+            AttachCore("Pit.Box.DistanceM", () => _pitBoxDistanceM);
+            AttachCore("Pit.Box.TimeS", () => _pitBoxTimeS);
             AttachCore("TrackMarkers.Trigger.FirstCapture", () => IsTrackMarkerPulseActive(_trackMarkerFirstCapturePulseUtc));
             AttachCore("TrackMarkers.Trigger.TrackLengthChanged", () => IsTrackMarkerPulseActive(_trackMarkerTrackLengthChangedPulseUtc));
             AttachCore("TrackMarkers.Trigger.LinesRefreshed", () => IsTrackMarkerPulseActive(_trackMarkerLinesRefreshedPulseUtc));
@@ -6378,11 +6382,13 @@ namespace LaunchPlugin
             if (inLane)
             {
                 UpdatePitExitDisplayValues(data, true);
+                UpdatePitBoxDisplayValues(data, true);
             }
             else
             {
                 // Clear once when not in pit lane
                 UpdatePitExitDisplayValues(data, false);
+                UpdatePitBoxDisplayValues(data, false);
             }
 
             // --- Rejoin assist update & lap incident tracking ---
@@ -12156,6 +12162,65 @@ namespace LaunchPlugin
 
             _pitExitDistanceM = Math.Max(0, (int)Math.Round(distanceM, MidpointRounding.AwayFromZero));
             _pitExitTimeS = Math.Max(0, (int)Math.Round(timeS, MidpointRounding.AwayFromZero));
+        }
+
+        private void UpdatePitBoxDisplayValues(GameData data, bool inPitLane)
+        {
+            if (!inPitLane)
+            {
+                _pitBoxDistanceM = 0;
+                _pitBoxTimeS = 0;
+                return;
+            }
+
+            if (data?.NewData == null || _pit == null)
+            {
+                _pitBoxDistanceM = 0;
+                _pitBoxTimeS = 0;
+                return;
+            }
+
+            double carPct = data.NewData.TrackPositionPercent;
+            if (carPct > 1.5) carPct *= 0.01;
+            if (carPct < 0.0 || carPct > 1.0 || double.IsNaN(carPct) || double.IsInfinity(carPct))
+            {
+                _pitBoxDistanceM = 0;
+                _pitBoxTimeS = 0;
+                return;
+            }
+
+            double boxPct = _pit.PlayerPitBoxTrackPct;
+            double trackLenM = _pit.TrackMarkersSessionTrackLengthM;
+            if (double.IsNaN(boxPct) || double.IsNaN(trackLenM) || trackLenM <= 0.0)
+            {
+                _pitBoxDistanceM = 0;
+                _pitBoxTimeS = 0;
+                return;
+            }
+
+            double deltaPct = boxPct - carPct;
+            if (deltaPct < 0.0) deltaPct += 1.0;
+
+            double distanceM = deltaPct * trackLenM;
+            if (double.IsNaN(distanceM) || double.IsInfinity(distanceM) || distanceM < 0.0)
+            {
+                _pitBoxDistanceM = 0;
+                _pitBoxTimeS = 0;
+                return;
+            }
+
+            double speedMps = data.NewData.SpeedKmh / 3.6;
+            double timeS = (speedMps > PitExitSpeedEpsilonMps && !double.IsNaN(speedMps) && !double.IsInfinity(speedMps))
+                ? (distanceM / speedMps)
+                : 0.0;
+
+            if (double.IsNaN(timeS) || double.IsInfinity(timeS) || timeS < 0.0)
+            {
+                timeS = 0.0;
+            }
+
+            _pitBoxDistanceM = Math.Max(0, (int)Math.Round(distanceM, MidpointRounding.AwayFromZero));
+            _pitBoxTimeS = Math.Max(0, (int)Math.Round(timeS, MidpointRounding.AwayFromZero));
         }
 
         private void RefreshClassMetadata(PluginManager pluginManager)

--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -62,6 +62,7 @@ namespace LaunchPlugin
         public string PitEntryLineDebrief { get; private set; } = "normal";
         public string PitEntryLineDebriefText { get; private set; } = string.Empty;
         public double PitEntryLineTimeLoss_s { get; private set; } = 0.0;
+        public double PlayerTrackPercentNormalized { get; private set; } = double.NaN;
         public double PlayerPitBoxTrackPct { get; private set; } = double.NaN;
         private bool _pitEntryAssistWasActive;
         private bool _pitEntryFirstCompliantCaptured;
@@ -127,6 +128,7 @@ namespace LaunchPlugin
             PitEntryLineDebrief = "normal";
             PitEntryLineDebriefText = string.Empty;
             PitEntryLineTimeLoss_s = 0.0;
+            PlayerTrackPercentNormalized = double.NaN;
             PlayerPitBoxTrackPct = double.NaN;
         }
 
@@ -154,6 +156,7 @@ namespace LaunchPlugin
             _trackMarkersLastKey = trackKey;
             var sessionState = GetSessionState(trackKey, create: true);
             double carPct = NormalizeTrackPercent(data?.NewData?.TrackPositionPercent ?? double.NaN);
+            PlayerTrackPercentNormalized = carPct;
             PlayerPitBoxTrackPct = ReadPlayerPitBoxTrackPct(pluginManager);
 
             if (double.IsNaN(sessionState.SessionStartTrackLengthM))
@@ -1354,7 +1357,7 @@ namespace LaunchPlugin
                 }
                 else
                 {
-                    double carPct = NormalizeTrackPercent(data.NewData.TrackPositionPercent);
+                    double carPct = PlayerTrackPercentNormalized;
                     double boxPct = PlayerPitBoxTrackPct;
 
                     if (!double.IsNaN(boxPct) && !double.IsNaN(carPct))
@@ -1436,7 +1439,7 @@ namespace LaunchPlugin
                 }
                 else
                 {
-                    double carPct = NormalizeTrackPercent(data.NewData.TrackPositionPercent);
+                    double carPct = PlayerTrackPercentNormalized;
                     double boxPct = PlayerPitBoxTrackPct;
 
                     if (!double.IsNaN(boxPct) && !double.IsNaN(carPct))

--- a/PitEngine.cs
+++ b/PitEngine.cs
@@ -62,6 +62,7 @@ namespace LaunchPlugin
         public string PitEntryLineDebrief { get; private set; } = "normal";
         public string PitEntryLineDebriefText { get; private set; } = string.Empty;
         public double PitEntryLineTimeLoss_s { get; private set; } = 0.0;
+        public double PlayerPitBoxTrackPct { get; private set; } = double.NaN;
         private bool _pitEntryAssistWasActive;
         private bool _pitEntryFirstCompliantCaptured;
         private double _pitEntryFirstCompliantDToLine_m;
@@ -126,6 +127,7 @@ namespace LaunchPlugin
             PitEntryLineDebrief = "normal";
             PitEntryLineDebriefText = string.Empty;
             PitEntryLineTimeLoss_s = 0.0;
+            PlayerPitBoxTrackPct = double.NaN;
         }
 
         public string PitEntryCueText
@@ -152,6 +154,7 @@ namespace LaunchPlugin
             _trackMarkersLastKey = trackKey;
             var sessionState = GetSessionState(trackKey, create: true);
             double carPct = NormalizeTrackPercent(data?.NewData?.TrackPositionPercent ?? double.NaN);
+            PlayerPitBoxTrackPct = ReadPlayerPitBoxTrackPct(pluginManager);
 
             if (double.IsNaN(sessionState.SessionStartTrackLengthM))
             {
@@ -1024,6 +1027,23 @@ namespace LaunchPlugin
             return !double.IsNaN(pct) && pct > 0.0 && pct <= 1.0;
         }
 
+        private double ReadPlayerPitBoxTrackPct(PluginManager pluginManager)
+        {
+            if (pluginManager == null) return double.NaN;
+
+            try
+            {
+                object pitBoxTrackPctRaw = pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverPitTrkPct");
+                if (pitBoxTrackPctRaw == null) return double.NaN;
+
+                return NormalizeTrackPercent(Convert.ToDouble(pitBoxTrackPctRaw));
+            }
+            catch
+            {
+                return double.NaN;
+            }
+        }
+
         private string GetTrackMarkersFolderPath()
         {
             return PluginStorage.GetPluginFolder();
@@ -1334,11 +1354,10 @@ namespace LaunchPlugin
                 }
                 else
                 {
-                    double carPct = data.NewData.TrackPositionPercent;
-                    var boxObj = pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverPitTrkPct");
-                    double boxPct = (boxObj != null) ? Convert.ToDouble(boxObj) : -1.0;
+                    double carPct = NormalizeTrackPercent(data.NewData.TrackPositionPercent);
+                    double boxPct = PlayerPitBoxTrackPct;
 
-                    if (boxPct >= 0.0)
+                    if (!double.IsNaN(boxPct) && !double.IsNaN(carPct))
                     {
                         double delta = (boxPct - carPct + 1.0) % 1.0;
                         _afterBoxThisLane = (delta >= 0.5); // box is behind → already passed it
@@ -1417,11 +1436,10 @@ namespace LaunchPlugin
                 }
                 else
                 {
-                    double carPct = data.NewData.TrackPositionPercent;
-                    var boxObj = pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverPitTrkPct");
-                    double boxPct = (boxObj != null) ? Convert.ToDouble(boxObj) : -1.0;
+                    double carPct = NormalizeTrackPercent(data.NewData.TrackPositionPercent);
+                    double boxPct = PlayerPitBoxTrackPct;
 
-                    if (boxPct >= 0.0)
+                    if (!double.IsNaN(boxPct) && !double.IsNaN(carPct))
                     {
                         double delta = (boxPct - carPct + 1.0) % 1.0;
                         CurrentPitPhase = (delta < 0.5)


### PR DESCRIPTION
### Motivation
- Provide a plugin-owned replacement for legacy dashboard reliance on `IRacingExtraProperties` for pit-box distance/time using existing native/session authority only. 
- Reuse Pit subsystem seams (track-percent, session track length, PitEngine) so dashboards can bind to a stable plugin export without changing dashboard JSON. 
- Keep behaviour fail-safe and bounded: publish `0` when authority/speed is invalid or when off pit lane.

### Description
- Added a native/session seam `PlayerPitBoxTrackPct` to `PitEngine` populated from `DataCorePlugin.GameRawData.SessionData.DriverInfo.DriverPitTrkPct` with normalization and safe read (`PlayerPitBoxTrackPct`/`ReadPlayerPitBoxTrackPct`).
- Reworked pit-phase logic to reuse `PlayerPitBoxTrackPct` for approaching/leaving-box decisions instead of ad-hoc reads. 
- Added core exports `Pit.Box.DistanceM` and `Pit.Box.TimeS` in `LalaLaunch.cs` and attached them via the existing `AttachCore` path. 
- Implemented `UpdatePitBoxDisplayValues` in `LalaLaunch.cs` to compute wrapped delta percent (`deltaPct = boxPct - carPct; if (deltaPct < 0) deltaPct += 1.0`), multiply by session track length, and estimate time conservatively from current speed only when sane; all outputs default to `0` when authority or speed is invalid. 
- Updated documentation: `Docs/Internal/SimHubParameterInventory.md`, `Docs/Subsystems/Pit_Timing_And_PitLoss.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` to declare the new exports and internal changelog entry.

### Testing
- Searched and validated symbol wiring with repository queries confirming new symbols (`Pit.Box.DistanceM`, `Pit.Box.TimeS`, `PlayerPitBoxTrackPct`, `UpdatePitBoxDisplayValues`). — succeeded.
- Attempted to build with `dotnet build LaunchPlugin.sln` to validate compile, but the environment lacks the `dotnet` CLI (`/bin/bash: dotnet: command not found`), so compile was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db729d09e0832fb32d951c633d11bb)