### PR TITLE
Extend Pit.Box pre-entry visibility and add pit-limit-aware Pit.Box.BrakeNow

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,13 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### Pit box pre-entry countdown visibility + pit-limit-aware brake-now helper
+- Extended `Pit.Box.DistanceM` / `Pit.Box.TimeS` publication in `LalaLaunch.cs` so the pit-box countdown can appear slightly before pit-lane entry when pit-owned visibility authority is active: in pit lane, `PitPhase.EnteringPits`, or fallback player track-percent band `[0.80..1.00] ∪ [0.00..0.20]`.
+- Kept fail-safe behavior: both exports still publish `0` when authority inputs are missing/invalid or when outside the visibility gate; `Pit.Box.TimeS` remains conservative (`0` when speed is too low/invalid).
+- Added plugin-owned `Pit.Box.BrakeNow` export for BoxEntry dash visibility so dashboards no longer need fixed-distance arithmetic.
+- `Pit.Box.BrakeNow` is calibrated from the existing 80 kph/25 m behavior and scales by pit limit (`triggerDistanceM = 25.0 * (pitLimitKph / 80.0)`), then gates on valid pit-box authority, valid pit-limit authority, speed `>2` kph, positive distance, and the same in-lane/pre-entry visibility gate.
+- Pit-limit authority chain remains plugin-owned and consistent with existing seams: `DataCorePlugin.GameData.PitLimiterSpeed` primary, parsed `DataCorePlugin.GameRawData.SessionData.WeekendInfo.TrackPitSpeedLimit` fallback.
+
 ### Pit-loss baseline standardization (drive-through) + fixed pit-exit transition allowance
 - Standardized pit-loss semantics and guidance so learned/stored pit-lane loss is explicitly a **drive-through baseline** (clean limiter-speed lane travel, no box stop).
 - Added fixed `PitExitTransitionAllowanceSec = 2.75` in `LalaLaunch.cs` at the shared boxed-stop prediction seam (`CalculateTotalStopLossSeconds`), yielding:

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -3,8 +3,8 @@
 **CANONICAL CONTRACT**
 
 Validated against: HEAD
-Last reviewed: 2026-04-13
-Last updated: 2026-04-13
+Last reviewed: 2026-04-15
+Last updated: 2026-04-15
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -196,8 +196,9 @@ Branch: work
 | Pit.EntryLineTimeLoss_s | double | Time loss in seconds versus pit limit from the first compliant point to the pit entry line (0 if not computed). | Latched on pit entry line. | `PitEngine.UpdatePitEntryAssist` + `AttachCore`【F:PitEngine.cs†L452-L510】【F:LalaLaunch.cs†L3045-L3049】 |
 | PitExit.DistanceM | int | Forward distance in metres to the stored pit exit marker (wraps at S/F). Returns 0 if data missing. | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L4216-L4248】【F:LalaLaunch.cs†L3068-L3069】 |
 | PitExit.TimeS | int | Estimated time in seconds to pit exit using current speed (0 if speed too small or data missing). | Per tick. | `LalaLaunch.cs` — `UpdatePitExitDisplayValues` + `AttachCore`【F:LalaLaunch.cs†L4216-L4248】【F:LalaLaunch.cs†L3068-L3069】 |
-| Pit.Box.DistanceM | int | Forward wrapped distance in metres to the player pit box using native player track percent + native `DriverPitTrkPct` + session track length authority. Returns 0 when not in pit lane or when any authority is invalid/missing. | Per tick while in pit lane (0 outside pit lane). | `PitEngine.cs` (`PlayerPitBoxTrackPct`) + `LalaLaunch.cs` (`UpdatePitBoxDisplayValues`) + `AttachCore`. |
-| Pit.Box.TimeS | int | Estimated seconds to the player pit box using current speed and `Pit.Box.DistanceM`. Returns 0 when speed is too low/invalid or authority is invalid/missing. | Per tick while in pit lane (0 outside pit lane). | `LalaLaunch.cs` — `UpdatePitBoxDisplayValues` + `AttachCore`. |
+| Pit.Box.DistanceM | int | Forward wrapped distance in metres to the player pit box using native player track percent + native `DriverPitTrkPct` + session track length authority. Publishes while in pit lane and also in a pit-owned pre-entry window (`PitPhase.EnteringPits` or fallback player track-percent band `[0.80..1.00] ∪ [0.00..0.20]`). Returns 0 outside that gate or when authority is invalid/missing. | Per tick while pit box visibility gate is active (otherwise `0`). | `PitEngine.cs` (`PlayerPitBoxTrackPct`, `CurrentPitPhase`, `PlayerTrackPercentNormalized`) + `LalaLaunch.cs` (`UpdatePitBoxDisplayValues`) + `AttachCore`. |
+| Pit.Box.TimeS | int | Estimated seconds to the player pit box using current speed and `Pit.Box.DistanceM`. Uses conservative timing (`0` when speed is too low/invalid) and follows the same pit-owned pre-entry visibility gate as `Pit.Box.DistanceM`; returns `0` when authority is invalid/missing. | Per tick while pit box visibility gate is active (otherwise `0`). | `LalaLaunch.cs` — `UpdatePitBoxDisplayValues` + `AttachCore`. |
+| Pit.Box.BrakeNow | bool | Plugin-owned BoxEntry “BRAKE NOW” visibility helper for dashboards. `true` only when pit-box authority is valid, speed is sane (`>2` kph), distance is positive and within dynamic trigger distance `25.0 * (pitLimitKph / 80.0)`, pit-limit authority is valid, and pit box visibility gate is active (in lane or allowed pre-entry window). Pit-limit authority chain: `DataCorePlugin.GameData.PitLimiterSpeed` then parsed `DataCorePlugin.GameRawData.SessionData.WeekendInfo.TrackPitSpeedLimit`. | Per tick (false when authority/gate conditions are not met). | `LalaLaunch.cs` — `TryResolvePitLimiterSpeedKph`, `UpdatePitBoxDisplayValues`, `AttachCore`. |
 
 ## Launch
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-13
+Last updated: 2026-04-15
 Branch: work
 
 ## Current repo/link status
@@ -9,20 +9,17 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
-- Standardized pit-loss learning contract to drive-through baseline semantics in user/canonical docs.
-- Added fixed `PitExitTransitionAllowanceSec = 2.75` at the shared total-stop-loss seam (`CalculateTotalStopLossSeconds`) so boxed-stop prediction now uses:
-  - `learned drive-through pit-lane baseline + boxed service model + 2.75s transition allowance`.
-- Kept pure lane-travel outputs unchanged (`Fuel.LastPitLaneTravelTime`, `PitExit.TimeS`).
-- Kept ownership boundaries intact: Opponents still consumes the shared pit-loss seam for race-scoped pit-exit countdown prediction; dashboard layer remains presentation-only.
-- Updated subsystem/user/internal docs and development changelog to match final runtime semantics.
+- Extended `Pit.Box.DistanceM` and `Pit.Box.TimeS` publication window so pit-box countdown can appear slightly before pit-lane entry when pit-owned authority is valid.
+- New visibility gate: in pit lane OR pit-owned pre-entry context (`PitPhase.EnteringPits`) OR fallback player track-percent band `[0.80..1.00] ∪ [0.00..0.20]`; outside gate or invalid authority still publishes `0`.
+- Added plugin-owned dash helper export `Pit.Box.BrakeNow` with pit-limit-aware threshold scaling (`25.0 * pitLimitKph / 80.0`) using existing limiter authority chain (`GameData.PitLimiterSpeed` then parsed `WeekendInfo.TrackPitSpeedLimit`).
+- Kept ownership boundaries intact: pit-owned logic remains in plugin runtime (`LalaLaunch.cs` + `PitEngine` authority seams), dashboards stay presentation-only.
+- Updated subsystem/internal docs and development changelog to match final runtime/export contract.
 
 ## Reviewed documentation set
-### Changed in pit-loss baseline + pit-exit transition allowance task
+### Changed in pit-box pre-entry visibility + pit-limit-aware brake-now helper task
 - `LalaLaunch.cs`
 - `Docs/Subsystems/Pit_Timing_And_PitLoss.md`
 - `Docs/Internal/SimHubParameterInventory.md`
-- `Docs/Quick_Start.md`
-- `Docs/User_Guide.md`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
@@ -33,12 +30,13 @@ Branch: work
 - `Docs/Internal/SimHubLogMessages.md`
 - `README.md`
 - `CHANGELOG.md`
-- `Docs/Subsystems/Fuel_Model.md`
+- `Docs/Quick_Start.md`
+- `Docs/User_Guide.md`
 
 ## Delivery status highlights
-- Kept ownership boundaries intact: Pit timing remains pit-loss owner and Opponents remains race-scoped pit-exit prediction owner.
-- Added a fixed transition allowance only at the shared stop-loss seam, avoiding blanket/double application.
+- Kept ownership boundaries intact: pit-box distance/time + brake-now helper remain plugin-owned pit logic; no dashboard JSON edits were required.
+- Preserved existing export names (`Pit.Box.DistanceM`, `Pit.Box.TimeS`) while extending visibility gating only.
 - No new log lines were added; `Docs/Internal/SimHubLogMessages.md` remained unchanged.
 
 ## Validation note
-- Validation recorded against `HEAD` (`Pit-loss baseline standardized to drive-through + fixed 2.75s pit-exit transition allowance`).
+- Validation recorded against `HEAD` (`Pit.Box pre-entry visibility extension + new pit-limit-aware Pit.Box.BrakeNow helper export`).

--- a/Docs/Subsystems/Pit_Timing_And_PitLoss.md
+++ b/Docs/Subsystems/Pit_Timing_And_PitLoss.md
@@ -1,7 +1,7 @@
 # Pit Timing and Pit Loss
 
-Validated against commit: 298accf
-Last updated: 2026-04-13
+Validated against commit: HEAD
+Last updated: 2026-04-15
 Branch: work
 
 ## Purpose
@@ -207,7 +207,8 @@ Typical outputs include:
 - `Fuel.Live.TireChangeTime_S`
 - `PitExit.DistanceM` / `PitExit.TimeS` (pit-exit waypoint distance/time using stored exit marker + live speed). These remain zero outside the pit lane and refresh on the 250 ms poll cadence, matching pit-lane state to avoid noisy updates when circulating on track.
 - `PitExit.TimeToExitSec` (plugin-owned blended pit-exit time-to-exit for dash timing): early/low-speed phase follows `PitExit.RemainingCountdownSec`, then blends toward `PitExit.TimeS` as player speed approaches pit-limiter speed. Blend uses limiter authority chain `DataCorePlugin.GameData.PitLimiterSpeed` then parsed `DataCorePlugin.GameRawData.SessionData.WeekendInfo.TrackPitSpeedLimit`; publishes `0` outside pit lane and guards invalid values.
-- `Pit.Box.DistanceM` / `Pit.Box.TimeS` (player pit-box waypoint distance/time using native `DriverPitTrkPct`, player track percent, session track length, and live speed). These remain zero outside the pit lane, and also fail-safe to zero when authority inputs are missing/invalid.
+- `Pit.Box.DistanceM` / `Pit.Box.TimeS` (player pit-box waypoint distance/time using native `DriverPitTrkPct`, player track percent, session track length, and live speed). These publish in pit lane, and may also publish in a short pit-owned pre-entry window when authority is valid (`PitPhase.EnteringPits` or fallback player track-percent band near start/finish: `[0.80..1.00] ∪ [0.00..0.20]`). Outside that gate—or when authority inputs are missing/invalid—they publish `0`.
+- `Pit.Box.BrakeNow` (plugin-owned BoxEntry “BRAKE NOW” visibility helper). Publishes `true` only when pit-box authority + pit-limit authority are valid, speed is sane (`>2 kph`), distance is positive, pit box is within dynamic threshold `25.0 * (pitLimitKph / 80.0)`, and the same in-lane/pre-entry visibility gate is active. Limiter authority chain: `DataCorePlugin.GameData.PitLimiterSpeed` primary, parsed `DataCorePlugin.GameRawData.SessionData.WeekendInfo.TrackPitSpeedLimit` fallback; publishes `false` when unavailable/invalid.
 - `Pit.Box.Active` / `Pit.Box.ElapsedSec` / `Pit.Box.RemainingSec` / `Pit.Box.TargetSec` / `Pit.Box.LastDeltaSec` (driver-facing in-box service countdown contract). `Active` is true only while the player is in a valid in-box service state (`in pit lane && in pit stall && PitPhase.InBox`). `ElapsedSec` reuses the existing pit stop elapsed timer from `PitEngine` (no second timer). During the short settle period (1.0s elapsed), the live effective target is `max(modeledTargetSec, repairRemainingSec)` where `modeledTargetSec = (max(fuelTime, tireTime) + 1.0s boxed-service overhead)` and `repairRemainingSec` is boxed native repair-left authority (`PitRepairLeft`, plus `PitOptRepairLeft` when optional repairs are enabled). The `+1.0s` overhead is stationary box-service allowance only (boxing/settle/pickup-release slop), not lane travel. At settle threshold, that effective target is latched/frozen for the stop and exported as `Pit.Box.TargetSec`, so late stop telemetry drift no longer moves the countdown target. `RemainingSec` stays repair-aware and is computed each tick as `max(max(0, TargetSec - ElapsedSec), repairRemainingSec)`. `Pit.Box.LastDeltaSec` is computed on stop end as `(latched TargetSec - final ElapsedSec)` where positive means quicker than target and negative means slower than target; it is non-zero only for 5 seconds after stop end and then automatically returns to `0`. All exports publish `0`/`false` when inactive or unavailable (including drive-throughs and missed-box states).
 
 These values feed directly into:

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4077,6 +4077,7 @@ namespace LaunchPlugin
         private double _carPlayerTrackPct = 0.0;
         private int _pitBoxDistanceM = 0;
         private int _pitBoxTimeS = 0;
+        private bool _pitBoxBrakeNow = false;
         private bool _pitBoxCountdownActive = false;
         private double _pitBoxElapsedSec = 0.0;
         private double _pitBoxRemainingSec = 0.0;
@@ -5067,6 +5068,7 @@ namespace LaunchPlugin
             AttachCore("PitExit.TimeToExitSec", () => _pitExitTimeToExitSec);
             AttachCore("Pit.Box.DistanceM", () => _pitBoxDistanceM);
             AttachCore("Pit.Box.TimeS", () => _pitBoxTimeS);
+            AttachCore("Pit.Box.BrakeNow", () => _pitBoxBrakeNow);
             AttachCore("Pit.Box.Active", () => _pitBoxCountdownActive);
             AttachCore("Pit.Box.ElapsedSec", () => _pitBoxElapsedSec);
             AttachCore("Pit.Box.RemainingSec", () => _pitBoxRemainingSec);
@@ -6416,13 +6418,13 @@ namespace LaunchPlugin
             if (inLane)
             {
                 UpdatePitExitDisplayValues(data, true);
-                UpdatePitBoxDisplayValues(data, true);
+                UpdatePitBoxDisplayValues(data, pluginManager, true);
             }
             else
             {
                 // Clear once when not in pit lane
                 UpdatePitExitDisplayValues(data, false);
-                UpdatePitBoxDisplayValues(data, false);
+                UpdatePitBoxDisplayValues(data, pluginManager, false);
             }
             double currentFuelNow = data.NewData?.Fuel ?? 0.0;
             UpdatePitBoxCountdownValues(inLane, isInPitStall);
@@ -12326,12 +12328,35 @@ namespace LaunchPlugin
             return true;
         }
 
-        private void UpdatePitBoxDisplayValues(GameData data, bool inPitLane)
+        private bool IsPitBoxVisibilityGateActive(bool inPitLane)
         {
-            if (!inPitLane)
+            if (inPitLane)
+            {
+                return true;
+            }
+
+            if (_pit != null && _pit.CurrentPitPhase == PitPhase.EnteringPits)
+            {
+                return true;
+            }
+
+            double carPct = _pit != null ? _pit.PlayerTrackPercentNormalized : double.NaN;
+            if (double.IsNaN(carPct) || double.IsInfinity(carPct) || carPct < 0.0 || carPct > 1.0)
+            {
+                return false;
+            }
+
+            return carPct >= 0.80 || carPct <= 0.20;
+        }
+
+        private void UpdatePitBoxDisplayValues(GameData data, PluginManager pluginManager, bool inPitLane)
+        {
+            bool visibilityGateActive = IsPitBoxVisibilityGateActive(inPitLane);
+            if (!visibilityGateActive)
             {
                 _pitBoxDistanceM = 0;
                 _pitBoxTimeS = 0;
+                _pitBoxBrakeNow = false;
                 return;
             }
 
@@ -12339,6 +12364,7 @@ namespace LaunchPlugin
             {
                 _pitBoxDistanceM = 0;
                 _pitBoxTimeS = 0;
+                _pitBoxBrakeNow = false;
                 return;
             }
 
@@ -12347,6 +12373,7 @@ namespace LaunchPlugin
             {
                 _pitBoxDistanceM = 0;
                 _pitBoxTimeS = 0;
+                _pitBoxBrakeNow = false;
                 return;
             }
 
@@ -12356,6 +12383,7 @@ namespace LaunchPlugin
             {
                 _pitBoxDistanceM = 0;
                 _pitBoxTimeS = 0;
+                _pitBoxBrakeNow = false;
                 return;
             }
 
@@ -12367,10 +12395,17 @@ namespace LaunchPlugin
             {
                 _pitBoxDistanceM = 0;
                 _pitBoxTimeS = 0;
+                _pitBoxBrakeNow = false;
                 return;
             }
 
-            double speedMps = data.NewData.SpeedKmh / 3.6;
+            double speedKph = data.NewData.SpeedKmh;
+            if (double.IsNaN(speedKph) || double.IsInfinity(speedKph) || speedKph < 0.0)
+            {
+                speedKph = 0.0;
+            }
+
+            double speedMps = speedKph / 3.6;
             double timeS = (speedMps > PitExitSpeedEpsilonMps && !double.IsNaN(speedMps) && !double.IsInfinity(speedMps))
                 ? (distanceM / speedMps)
                 : 0.0;
@@ -12382,6 +12417,26 @@ namespace LaunchPlugin
 
             _pitBoxDistanceM = Math.Max(0, (int)Math.Round(distanceM, MidpointRounding.AwayFromZero));
             _pitBoxTimeS = Math.Max(0, (int)Math.Round(timeS, MidpointRounding.AwayFromZero));
+
+            _pitBoxBrakeNow = false;
+            if (distanceM <= 0.0 || speedKph <= 2.0)
+            {
+                return;
+            }
+
+            double pitLimitKph;
+            if (!TryResolvePitLimiterSpeedKph(pluginManager, out pitLimitKph) || pitLimitKph <= 0.0)
+            {
+                return;
+            }
+
+            double triggerDistanceM = 25.0 * (pitLimitKph / 80.0);
+            if (double.IsNaN(triggerDistanceM) || double.IsInfinity(triggerDistanceM) || triggerDistanceM <= 0.0)
+            {
+                return;
+            }
+
+            _pitBoxBrakeNow = distanceM <= triggerDistanceM;
         }
 
         private void RefreshClassMetadata(PluginManager pluginManager)


### PR DESCRIPTION
### Motivation
- Allow dashboards to show the pit-box countdown slightly before pit-lane entry when plugin-owned authority is available, covering tracks where the box is reached before the lane flag and edge cases near start/finish. 
- Remove dashboard-side hardcoded 25 m fixed-distance logic by providing a plugin-owned helper that scales the BoxEntry “BRAKE NOW” threshold with the pit speed limit authority so the cue remains calibrated across different pit limits.

### Description
- Extended the `Pit.Box.DistanceM` / `Pit.Box.TimeS` publication gate in `LalaLaunch.cs` so values publish when in-lane OR when `_pit.CurrentPitPhase == PitPhase.EnteringPits` OR when player track percent is in the fallback band `>=0.80 || <=0.20` (pre-entry visibility gate), otherwise they remain `0` and invalid authority still fails safe. 
- Added a new plugin-owned boolean export `Pit.Box.BrakeNow` (attached via `AttachCore`) computed in `UpdatePitBoxDisplayValues(...)` that triggers when distance>0, speed>2 kph, pit-limit authority is available, and `distanceM <= triggerDistanceM` where `triggerDistanceM = 25.0 * (pitLimitKph / 80.0)` (pit-limit scaling); pit-limit resolution reuses the existing `TryResolvePitLimiterSpeedKph(...)` seam (`DataCorePlugin.GameData.PitLimiterSpeed` primary, parsed `WeekendInfo.TrackPitSpeedLimit` fallback). 
- Preserved existing export names and semantics for `Pit.Box.DistanceM` and `Pit.Box.TimeS` (no renames), kept `Pit.Box.TimeS` conservative (returns `0` when speed is too low/invalid), and ensured all new logic remains plugin-owned (dash remains presentation-only). 
- Updated documentation to reflect the change: `Docs/Subsystems/Pit_Timing_And_PitLoss.md`, `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` were updated to document the pre-entry gate and the new `Pit.Box.BrakeNow` export.

### Testing
- Attempted an automated build with `dotnet build LaunchPlugin.sln` but the environment lacks the SDK (`/bin/bash: dotnet: command not found`), so no successful compile was produced in this runner. 
- Code and documentation changes were exercised locally in the repository and committed; runtime/integration validation (build + run) remains to be executed in a development environment with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc84145a0832fbf25194f7d1a3771)