### PR TITLE
Pit Fuel Control: selection feedback, direct-selects, zero action, and max-toggle export

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,11 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### PR #575 follow-up: preserve pit-command failure feedback on source changes
+- Classification: **both** (driver-visible pit command feedback correctness + internal contract alignment).
+- Updated `PitFuelControlEngine` source-change paths (`SourceCycle` and direct `SetPush/SetNorm/SetSave`) so selection feedback is only published when no send was attempted (`Mode=OFF`).
+- In `Mode=MAN/AUTO`, source-change actions now preserve transport failure feedback (`Pit Cmd Fail`) from the pit-command send path instead of overwriting it with `FUEL SRC ...`.
+
 ### Pit Fuel Control action/feedback follow-up (source/mode feedback + direct-select + zero + max-toggle state)
 - Updated `PitFuelControlEngine` so source/mode actions now publish through the existing pit-command feedback seam even when no fuel send occurs:
   - `SourceCycle` now always surfaces `FUEL SRC <PUSH|NORM|SAVE|PLAN|STBY>` feedback when selection-only,

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,22 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### Pit Fuel Control action/feedback follow-up (source/mode feedback + direct-select + zero + max-toggle state)
+- Updated `PitFuelControlEngine` so source/mode actions now publish through the existing pit-command feedback seam even when no fuel send occurs:
+  - `SourceCycle` now always surfaces `FUEL SRC <PUSH|NORM|SAVE|PLAN|STBY>` feedback when selection-only,
+  - `ModeCycle` now always surfaces `FUEL MODE <OFF|MAN|AUTO>`,
+  - both paths now stamp `Pit.Command.LastAction` with the actual action id (`Pit.FuelControl.SourceCycle` / `Pit.FuelControl.ModeCycle`) on selection-only presses.
+- Added direct source-select actions:
+  - `Pit.FuelControl.SetPush`
+  - `Pit.FuelControl.SetNorm`
+  - `Pit.FuelControl.SetSave`
+  - In `MAN/AUTO`, these send immediately using the normal raw pit-command path while preserving action identity in `Pit.Command.LastAction`; in `OFF`, they update selection-only feedback.
+- Added new plugin-owned pit action `Pit.FuelSetZero` mapped through the existing built-in pit-command transport/feedback seam with short feedback text `FUEL ZERO`.
+- Added plugin-owned max-fuel toggle concept state in `PitCommandEngine`:
+  - pressing `Pit.FuelSetMax` now flips persistent state `Pit.Command.FuelSetMaxToggleState`,
+  - transport/feedback still routes through the normal pit-command seam.
+- Classification: **both** (new driver-visible pit action/feedback behavior and internal pit-command/pit-fuel control seam extension).
+
 ### PR follow-up: apply Pit Fuel Control contingency before clamp
 - Corrected live Pit Fuel Control target composition in `LalaLaunch.BuildPitFuelControlSnapshot` so `NORM/PUSH/SAVE` now apply contingency before the non-negative clamp:
   - `target = max(0, requirement + contingency - currentFuel)` (equivalently `max(0, shortfall + contingency)`),

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -3,8 +3,8 @@
 **CANONICAL OBSERVABILITY MAP**
 
 Validated against: HEAD
-Last reviewed: 2026-04-18
-Last updated: 2026-04-18
+Last reviewed: 2026-04-19
+Last updated: 2026-04-19
 Branch: work
 
 Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub.Logging.Current.Warn(...)`. Use the tag prefixes to filter in SimHub’s log view. Placeholder logs are noted; no deprecated messages are currently removed in code. Legacy/alternate copies of this list do not exist.
@@ -42,7 +42,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Launch] State change: <old> -> <new>.`** — Launch state machine transition (e.g., primed → logging).【F:LalaLaunch.cs†L2470-L2494】
 - **`[LalaPlugin:Launch Trace] <reason> – cancelling to Idle.`** — Launch trace aborted to idle with the provided reason (debounced).【F:LalaLaunch.cs†L3048-L3074】
 - **`[LalaPlugin:Launch] ManualPrimed timeout fired ...`** — Manual prime exceeded 30 s; launch cancelled and user-disabled latched.【F:LalaLaunch.cs†L4993-L5004】
-- **`[LalaPlugin:Init] Actions registered: MsgCx, TogglePitScreen, Pit.ClearAll, Pit.ClearTires, Pit.ToggleFuel, Pit.FuelAdd1, Pit.FuelRemove1, Pit.FuelAdd10, Pit.FuelRemove10, Pit.FuelSetMax, Pit.ToggleTiresAll, Pit.ToggleFastRepair, Pit.ToggleAutoFuel, Pit.Windshield, Pit.FuelControl.SourceCycle, Pit.FuelControl.ModeCycle, CustomMessage01..CustomMessage10 (+ aliases Pit.FuelAdd/Pit.FuelRemove), PrimaryDashMode, DeclutterMode, ToggleDarkMode, SecondaryDashMode (legacy), EventMarker, LaunchMode, TrackMarkersLock, TrackMarkersUnlock`** — Init-time action registration summary for SimHub bindings.
+- **`[LalaPlugin:Init] Actions registered: MsgCx, TogglePitScreen, Pit.ClearAll, Pit.ClearTires, Pit.ToggleFuel, Pit.FuelSetZero, Pit.FuelAdd1, Pit.FuelRemove1, Pit.FuelAdd10, Pit.FuelRemove10, Pit.FuelSetMax, Pit.ToggleTiresAll, Pit.ToggleFastRepair, Pit.ToggleAutoFuel, Pit.Windshield, Pit.FuelControl.SourceCycle, Pit.FuelControl.ModeCycle, Pit.FuelControl.SetPush, Pit.FuelControl.SetNorm, Pit.FuelControl.SetSave, CustomMessage01..CustomMessage10 (+ aliases Pit.FuelAdd/Pit.FuelRemove), PrimaryDashMode, DeclutterMode, ToggleDarkMode, SecondaryDashMode (legacy), EventMarker, LaunchMode, TrackMarkersLock, TrackMarkersUnlock`** — Init-time action registration summary for SimHub bindings.
 - **`[LalaPlugin:DarkMode] ToggleDarkMode action fired -> Mode=<old>(<label>)-><new>(<label>).`** — Dark mode cycle action fired from Controls & Events.
 - **`[LalaPlugin:DarkMode] Lovely availability changed -> available=<true|false>.`** — Runtime Lovely detection status changed (logged once per transition).
 - **`[LalaPlugin:DarkMode] Auto Active transition -> active=..., Alt=..., Precip=..., S=..., W=..., F=..., on<2.0, off>4.0.`** — Auto hysteresis transition with brightness-factor inputs and thresholds.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -3,8 +3,8 @@
 **CANONICAL CONTRACT**
 
 Validated against: HEAD
-Last reviewed: 2026-04-18
-Last updated: 2026-04-18
+Last reviewed: 2026-04-19
+Last updated: 2026-04-19
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -326,7 +326,8 @@ Shift Assist runtime/settings notes:
 | Pit.Command.Active | bool | `true` while `Pit.Command.DisplayText` is active; otherwise `false`. | Per tick. | `PitCommandEngine.cs` message timer + `LalaLaunch.cs` `AttachCore`. |
 | Pit.Command.LastAction | string | Last fired pit command action id for troubleshooting. | On action fire; surfaced each tick. | `PitCommandEngine.cs` action audit state + `LalaLaunch.cs` `AttachCore`. |
 | Pit.Command.LastRaw | string | Last raw command/message text submitted by the caller before final transport normalization (for example `#fuel +500$` on raw pit-command path, `#...$` on built-in actions, or custom plain text). | On action fire; surfaced each tick. | `PitCommandEngine.cs` command mapping/normalization + `LalaLaunch.cs` `AttachCore`. |
-| Pit.FuelControl.Source | int | Plugin-owned pit fuel source selector (`0` PUSH, `1` NORM, `2` SAVE, `3` PLAN, `4` STBY). `STBY` is recovery-only and exits to `PUSH` on next source-cycle action. | Per tick. | `PitFuelControlEngine.cs` state machine + `LalaLaunch.cs` `AttachCore`. |
+| Pit.Command.FuelSetMaxToggleState | bool | Plugin-owned max-fuel toggle concept state. Flips on every `Pit.FuelSetMax` press so dashes can label what the next press means. Transport and feedback still use the normal pit-command seam. | On `Pit.FuelSetMax` action fire; surfaced each tick. | `PitCommandEngine.cs` toggle state + `LalaLaunch.cs` `AttachCore`. |
+| Pit.FuelControl.Source | int | Plugin-owned pit fuel source selector (`0` PUSH, `1` NORM, `2` SAVE, `3` PLAN, `4` STBY). `STBY` is recovery-only and exits to `PUSH` on next source-cycle action. `SourceCycle` + direct source-select actions (`SetPush/SetNorm/SetSave`) always publish short pit-command feedback (`FUEL SRC ...`) when no send occurs (for example mode `OFF`). | Per tick. | `PitFuelControlEngine.cs` state machine + `LalaLaunch.cs` `AttachCore`. |
 | Pit.FuelControl.SourceText | string | Short source label (`PUSH`/`NORM`/`SAVE`/`PLAN`/`STBY`). | Per tick. | `PitFuelControlEngine.cs` source text mapping + `LalaLaunch.cs` `AttachCore`. |
 | Pit.FuelControl.Mode | int | Plugin-owned fuel-control mode (`0` OFF, `1` MAN, `2` AUTO). `AUTO` is skipped while source is `PLAN`. | Per tick. | `PitFuelControlEngine.cs` mode state + `LalaLaunch.cs` `AttachCore`. |
 | Pit.FuelControl.ModeText | string | Short mode label (`OFF`/`MAN`/`AUTO`). | Per tick. | `PitFuelControlEngine.cs` mode text mapping + `LalaLaunch.cs` `AttachCore`. |
@@ -339,6 +340,8 @@ Shift Assist runtime/settings notes:
 Dark Mode binding warning: When `Use Lovely True Dark` is enabled and Lovely is available, Lovely controls `DarkMode.Active` even if Mode is `Off`, and `BrightnessPct` stays on the user slider value (no auto scaling while Lovely drives). `OpacityPct` remains the final dim value published to dashes. `ModeText` remains tied to `Mode` only (`Off`/`Manual`/`Auto`). `LalaLaunch.ToggleDarkMode` is ignored to prevent conflicting toggles. Do not bind both Lovely and LalaLaunch dark-mode toggles to the same physical input.
 
 Settings persistence note (not runtime SimHub exports): `PitCommandsAutoFocusPreview` and `CustomMessages[1..10].Name/MessageText` are persisted UI/settings fields in `LaunchPluginSettings` used by Settings-tab editors and custom-message action dispatch, and are intentionally not attached via `AttachCore/AttachVerbose`.
+
+Pit action surface note (Controls & Events): plugin-owned pit actions now include `Pit.FuelSetZero`, `Pit.FuelControl.SetPush`, `Pit.FuelControl.SetNorm`, and `Pit.FuelControl.SetSave` in addition to the existing cycle/actions set.
 
 ## Friends
 | Exported name | Type | Units / meaning | Update cadence | Defined in |

--- a/Docs/Pit_Assist.md
+++ b/Docs/Pit_Assist.md
@@ -44,6 +44,7 @@ Pit command buttons should now be bound to plugin-owned Controls & Events action
 - `LalaLaunch.Pit.ClearAll`
 - `LalaLaunch.Pit.ClearTires`
 - `LalaLaunch.Pit.ToggleFuel`
+- `LalaLaunch.Pit.FuelSetZero`
 - `LalaLaunch.Pit.FuelAdd1`
 - `LalaLaunch.Pit.FuelRemove1`
 - `LalaLaunch.Pit.FuelAdd10`
@@ -55,6 +56,9 @@ Pit command buttons should now be bound to plugin-owned Controls & Events action
 - `LalaLaunch.Pit.Windshield`
 - `LalaLaunch.Pit.FuelControl.SourceCycle`
 - `LalaLaunch.Pit.FuelControl.ModeCycle`
+- `LalaLaunch.Pit.FuelControl.SetPush`
+- `LalaLaunch.Pit.FuelControl.SetNorm`
+- `LalaLaunch.Pit.FuelControl.SetSave`
 
 These actions replace any old dashboard bindings that directly called `IRacingExtraProperties` pit-command actions.
 

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,9 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- PR #575 follow-up fixed Pit Fuel Control source-change failure feedback masking:
+  - `SourceCycle` and direct source-select actions now publish `FUEL SRC ...` selection feedback only when no send is attempted (`Mode=OFF`).
+  - In `Mode=MAN/AUTO`, failed send attempts now keep existing pit-command failure feedback (`Pit Cmd Fail`) visible instead of being overwritten by selection text.
 - PR follow-up corrected Pit Fuel Control live-target contingency ordering:
   - `NORM/PUSH/SAVE` now apply contingency before clamp (`max(0, shortfall + contingency)`)
   - avoids contingency-only overfuel commands when current fuel is already above the base live requirement

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-18
+Last updated: 2026-04-19
 Branch: work
 
 ## Current repo/link status
@@ -78,6 +78,11 @@ Branch: work
 - PR 572 follow-up tightened PLAN validity further: car + track/layout key + race basis + race length now all must match between planner and live session before PLAN is considered valid.
 - PR 572 follow-up moved pit fuel-control sends to a dedicated raw pit-command path that intentionally reuses built-in pit-command normalization before chat injection (trailing `$` consistency fix).
 - PR 572 follow-up made MAX override command explicit with a named clamp-safe overshoot constant rather than implicit magic literals.
+- Pit Fuel Control follow-up expanded action/feedback coverage:
+  - `SourceCycle` and `ModeCycle` now update `Pit.Command.DisplayText` + `Pit.Command.LastAction` even on selection-only presses (no fuel send).
+  - Added direct source-select actions: `Pit.FuelControl.SetPush`, `Pit.FuelControl.SetNorm`, `Pit.FuelControl.SetSave`.
+  - Added plugin-owned zero-fuel action `Pit.FuelSetZero` on the normal pit-command transport/feedback seam.
+  - `Pit.FuelSetMax` now flips a plugin-owned toggle concept state exported as `Pit.Command.FuelSetMaxToggleState` for dash label logic.
 
 ## Reviewed documentation set
 ### Changed in LapRef rollover seam transient-zero follow-up
@@ -144,6 +149,17 @@ Branch: work
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 
+### Changed in Pit Fuel Control action/feedback follow-up
+- `PitFuelControlEngine.cs`
+- `PitCommandEngine.cs`
+- `LalaLaunch.cs`
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/SimHubLogMessages.md`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/Subsystems/Dash_Integration.md`
+- `Docs/Pit_Assist.md`
+- `Docs/RepoStatus.md`
+
 ### Changed in fuel projection phase seam + Pit Fuel Control authority alignment task
 - `LalaLaunch.cs`
 - `Docs/Internal/SimHubParameterInventory.md`
@@ -197,6 +213,7 @@ Branch: work
 - Preserved focused helper ownership (`PitCommandEngine`) for transport/mapping/feedback/failure logic instead of widening central runtime loops.
 - Added bounded observability and short-lived user feedback exports so command success/failure is visible on dash and in SimHub logs.
 - Extended focused-helper ownership with `PitFuelControlEngine` for pit fuel source/mode state and decision logic while keeping `LalaLaunch` as action/export wiring.
+- Kept scope bounded to pit action surface/feedback seam extensions (no dashboard JSON/UI expansion): direct source-select + zero-fuel actions, selection-only source/mode feedback publication, and max-fuel toggle-state export.
 
 ## Validation note
 - Validation recorded against `HEAD` (`Pit Fuel Control live targets now apply contingency before clamp for NORM/PUSH/SAVE, preventing contingency-only overfuel sends when already above base requirement`).

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -1,7 +1,7 @@
 # Dash Integration
 
 Validated against commit: HEAD
-Last updated: 2026-04-18
+Last updated: 2026-04-19
 Branch: work
 
 ## Purpose
@@ -32,7 +32,7 @@ This document is the canonical dash-facing contract layer. It does **not** redef
 ### Rejoin / pit / messages
 - Rejoin widgets should respect the explicit rejoin exports rather than infer active state from message text alone.
 - Pit-screen / pit-entry widgets should combine pit visibility toggles with pit-specific active flags.
-- Pit command buttons in strategy/pit widgets must bind to plugin-owned actions (`LalaLaunch.Pit.ClearAll`, `LalaLaunch.Pit.ClearTires`, `LalaLaunch.Pit.ToggleFuel`, `LalaLaunch.Pit.FuelAdd1`, `LalaLaunch.Pit.FuelRemove1`, `LalaLaunch.Pit.FuelAdd10`, `LalaLaunch.Pit.FuelRemove10`, `LalaLaunch.Pit.FuelSetMax`, `LalaLaunch.Pit.ToggleTiresAll`, `LalaLaunch.Pit.ToggleFastRepair`, `LalaLaunch.Pit.ToggleAutoFuel`, `LalaLaunch.Pit.Windshield`, `LalaLaunch.Pit.FuelControl.SourceCycle`, `LalaLaunch.Pit.FuelControl.ModeCycle`) rather than `IRacingExtraProperties` action ids.
+- Pit command buttons in strategy/pit widgets must bind to plugin-owned actions (`LalaLaunch.Pit.ClearAll`, `LalaLaunch.Pit.ClearTires`, `LalaLaunch.Pit.ToggleFuel`, `LalaLaunch.Pit.FuelSetZero`, `LalaLaunch.Pit.FuelAdd1`, `LalaLaunch.Pit.FuelRemove1`, `LalaLaunch.Pit.FuelAdd10`, `LalaLaunch.Pit.FuelRemove10`, `LalaLaunch.Pit.FuelSetMax`, `LalaLaunch.Pit.ToggleTiresAll`, `LalaLaunch.Pit.ToggleFastRepair`, `LalaLaunch.Pit.ToggleAutoFuel`, `LalaLaunch.Pit.Windshield`, `LalaLaunch.Pit.FuelControl.SourceCycle`, `LalaLaunch.Pit.FuelControl.ModeCycle`, `LalaLaunch.Pit.FuelControl.SetPush`, `LalaLaunch.Pit.FuelControl.SetNorm`, `LalaLaunch.Pit.FuelControl.SetSave`) rather than `IRacingExtraProperties` action ids.
 - Custom chat buttons should bind to plugin-owned actions `LalaLaunch.CustomMessage01..LalaLaunch.CustomMessage10` (configured in Settings → Custom Messages) rather than embedding transport/raw chat syntax in dash logic.
 - Message-dash widgets should consume the message engine outputs directly rather than rebuilding message priority logic in SimHub expressions.
 
@@ -40,6 +40,7 @@ This document is the canonical dash-facing contract layer. It does **not** redef
 - Dashboards trigger pit actions only; transport ownership is in-plugin.
 - Current runtime transport is direct chat-command injection (`open chat` → `type command` → `send`), with explicit failure logs when chat injection is unavailable.
 - Dashboards can bind short-lived user feedback exports `LalaLaunch.Pit.Command.DisplayText` and `LalaLaunch.Pit.Command.Active` for command confirmations/failures.
+- Dashboards can also bind `LalaLaunch.Pit.Command.LastAction`/`LastRaw` for diagnostics, plus `LalaLaunch.Pit.Command.FuelSetMaxToggleState` for max-fuel toggle-label logic.
 - Dashboards can bind `LalaLaunch.Pit.FuelControl.*` exports (`Source/SourceText`, `Mode/ModeText`, `TargetLitres`, `OverrideActive`) for pit fuel control state display; dashboards do not own source/mode/plan validity logic.
 - The same transport seam also dispatches custom-message actions; dashboards should keep custom-message content authored in plugin Settings rather than hardcoding message text in dash scripts/buttons.
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -133,7 +133,7 @@ namespace LaunchPlugin
             _pitFuelControlEngine = new PitFuelControlEngine(
                 BuildPitFuelControlSnapshot,
                 SendPitFuelControlCommand,
-                message => _pitCommandEngine.PublishFeedback(message));
+                (actionName, message, raw) => _pitCommandEngine.PublishActionFeedback(actionName, message, raw));
         }
 
         // --- Dashboard Manager ---
@@ -259,6 +259,7 @@ namespace LaunchPlugin
         public void PitClearAll() => ExecutePitCommand(PitCommandAction.ClearAll);
         public void PitClearTyres() => ExecutePitCommand(PitCommandAction.ClearTyres);
         public void PitToggleFuel() => ExecutePitCommand(PitCommandAction.ToggleFuel);
+        public void PitFuelSetZero() => ExecutePitCommand(PitCommandAction.FuelSetZero);
         public void PitFuelAdd1() => ExecutePitCommand(PitCommandAction.FuelAdd1);
         public void PitFuelRemove1() => ExecutePitCommand(PitCommandAction.FuelRemove1);
         public void PitFuelAdd10() => ExecutePitCommand(PitCommandAction.FuelAdd10);
@@ -270,6 +271,9 @@ namespace LaunchPlugin
         public void PitWindshield() => ExecutePitCommand(PitCommandAction.Windshield);
         public void PitFuelControlSourceCycle() => _pitFuelControlEngine.SourceCycle();
         public void PitFuelControlModeCycle() => _pitFuelControlEngine.ModeCycle();
+        public void PitFuelControlSetPush() => _pitFuelControlEngine.SetPush();
+        public void PitFuelControlSetNorm() => _pitFuelControlEngine.SetNorm();
+        public void PitFuelControlSetSave() => _pitFuelControlEngine.SetSave();
         public void TriggerCustomMessageSlot(int slotNumber)
         {
             string customActionName = $"CustomMessage{slotNumber:00}";
@@ -4625,6 +4629,7 @@ namespace LaunchPlugin
             this.AddAction("Pit.ClearAll", (a, b) => PitClearAll());
             this.AddAction("Pit.ClearTires", (a, b) => PitClearTyres());
             this.AddAction("Pit.ToggleFuel", (a, b) => PitToggleFuel());
+            this.AddAction("Pit.FuelSetZero", (a, b) => PitFuelSetZero());
             this.AddAction("Pit.FuelAdd1", (a, b) => PitFuelAdd1());
             this.AddAction("Pit.FuelRemove1", (a, b) => PitFuelRemove1());
             this.AddAction("Pit.FuelAdd10", (a, b) => PitFuelAdd10());
@@ -4636,6 +4641,9 @@ namespace LaunchPlugin
             this.AddAction("Pit.Windshield", (a, b) => PitWindshield());
             this.AddAction("Pit.FuelControl.SourceCycle", (a, b) => PitFuelControlSourceCycle());
             this.AddAction("Pit.FuelControl.ModeCycle", (a, b) => PitFuelControlModeCycle());
+            this.AddAction("Pit.FuelControl.SetPush", (a, b) => PitFuelControlSetPush());
+            this.AddAction("Pit.FuelControl.SetNorm", (a, b) => PitFuelControlSetNorm());
+            this.AddAction("Pit.FuelControl.SetSave", (a, b) => PitFuelControlSetSave());
             this.AddAction("CustomMessage01", (a, b) => TriggerCustomMessageSlot(1));
             this.AddAction("CustomMessage02", (a, b) => TriggerCustomMessageSlot(2));
             this.AddAction("CustomMessage03", (a, b) => TriggerCustomMessageSlot(3));
@@ -4947,6 +4955,7 @@ namespace LaunchPlugin
             AttachCore("Pit.Command.Active", () => _pitCommandEngine.Active);
             AttachCore("Pit.Command.LastAction", () => _pitCommandEngine.LastAction);
             AttachCore("Pit.Command.LastRaw", () => _pitCommandEngine.LastRaw);
+            AttachCore("Pit.Command.FuelSetMaxToggleState", () => _pitCommandEngine.FuelSetMaxToggleState);
             AttachCore("Pit.FuelControl.Source", () => (int)_pitFuelControlEngine.Source);
             AttachCore("Pit.FuelControl.SourceText", () => _pitFuelControlEngine.SourceText);
             AttachCore("Pit.FuelControl.Mode", () => (int)_pitFuelControlEngine.Mode);

--- a/PitCommandEngine.cs
+++ b/PitCommandEngine.cs
@@ -13,6 +13,7 @@ namespace LaunchPlugin
         ClearAll,
         ClearTyres,
         ToggleFuel,
+        FuelSetZero,
         FuelAdd1,
         FuelRemove1,
         FuelAdd10,
@@ -38,11 +39,16 @@ namespace LaunchPlugin
         public string DisplayText { get; private set; } = string.Empty;
         public string LastAction { get; private set; } = string.Empty;
         public string LastRaw { get; private set; } = string.Empty;
+        public bool FuelSetMaxToggleState { get; private set; }
         public bool Active => !string.IsNullOrWhiteSpace(DisplayText) && DateTime.UtcNow < _messageUntilUtc;
 
         public void Execute(PitCommandAction action, PluginManager pluginManager, double tankSpaceLitres)
         {
             LastAction = action.ToString();
+            if (action == PitCommandAction.FuelSetMax)
+            {
+                FuelSetMaxToggleState = !FuelSetMaxToggleState;
+            }
 
             string raw = GetRawCommand(action);
             LastRaw = raw;
@@ -130,6 +136,13 @@ namespace LaunchPlugin
             PublishMessage(message);
         }
 
+        public void PublishActionFeedback(string actionName, string message, string raw)
+        {
+            LastAction = string.IsNullOrWhiteSpace(actionName) ? "PitActionFeedback" : actionName.Trim();
+            LastRaw = raw ?? string.Empty;
+            PublishMessage(message);
+        }
+
         private bool ConfirmAndPublishFeedback(PitCommandAction action, PluginManager pluginManager, bool? before, double tankSpaceLitres)
         {
             if (!IsStatefulAction(action))
@@ -189,6 +202,7 @@ namespace LaunchPlugin
                 case PitCommandAction.ClearAll: return "#clear$";
                 case PitCommandAction.ClearTyres: return "#cleartires$";
                 case PitCommandAction.ToggleFuel: return "#!fuel$";
+                case PitCommandAction.FuelSetZero: return "#fuel 0$";
                 case PitCommandAction.FuelAdd1: return "#fuel +1$";
                 case PitCommandAction.FuelRemove1: return "#fuel -1$";
                 case PitCommandAction.FuelAdd10: return "#fuel +10$";
@@ -246,6 +260,7 @@ namespace LaunchPlugin
             {
                 case PitCommandAction.ClearAll: return "Pit Clear All";
                 case PitCommandAction.ClearTyres: return "Clear Tyres";
+                case PitCommandAction.FuelSetZero: return "FUEL ZERO";
                 case PitCommandAction.FuelAdd1: return reachedFuelMax ? "Fuel MAX" : "Fuel +1";
                 case PitCommandAction.FuelRemove1: return "Fuel -1";
                 case PitCommandAction.FuelAdd10: return reachedFuelMax ? "Fuel MAX" : "Fuel +10";

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -114,13 +114,14 @@ namespace LaunchPlugin
                 AutoArmed = false;
             }
 
-            bool sent = false;
+            bool sendAttempted = false;
             if (Mode == PitFuelControlMode.Man || Mode == PitFuelControlMode.Auto)
             {
-                sent = SendCurrentTarget(isAutoUpdate: false, actionNameOverride: "Pit.FuelControl.SourceCycle");
+                sendAttempted = true;
+                SendCurrentTarget(isAutoUpdate: false, actionNameOverride: "Pit.FuelControl.SourceCycle");
             }
 
-            if (!sent)
+            if (!sendAttempted)
             {
                 PublishSelectionFeedback("Pit.FuelControl.SourceCycle", string.Format("FUEL SRC {0}", SourceToText(Source)));
             }
@@ -239,13 +240,14 @@ namespace LaunchPlugin
             Source = requestedSource;
             RefreshDerivedState();
 
-            bool sent = false;
+            bool sendAttempted = false;
             if (Mode == PitFuelControlMode.Man || Mode == PitFuelControlMode.Auto)
             {
-                sent = SendCurrentTarget(isAutoUpdate: false, actionNameOverride: actionName);
+                sendAttempted = true;
+                SendCurrentTarget(isAutoUpdate: false, actionNameOverride: actionName);
             }
 
-            if (!sent)
+            if (!sendAttempted)
             {
                 PublishSelectionFeedback(actionName, string.Format("FUEL SRC {0}", SourceToText(Source)));
             }

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -56,7 +56,7 @@ namespace LaunchPlugin
 
         private readonly Func<PitFuelControlSnapshot> _snapshotProvider;
         private readonly Func<string, string, string, bool> _chatCommandSender;
-        private readonly Action<string> _feedbackPublisher;
+        private readonly Action<string, string, string> _feedbackPublisher;
 
         private DateTime _suppressManualOverrideUntilUtc = DateTime.MinValue;
         private bool _maxOverrideArmed;
@@ -73,7 +73,7 @@ namespace LaunchPlugin
         public PitFuelControlEngine(
             Func<PitFuelControlSnapshot> snapshotProvider,
             Func<string, string, string, bool> chatCommandSender,
-            Action<string> feedbackPublisher)
+            Action<string, string, string> feedbackPublisher)
         {
             _snapshotProvider = snapshotProvider;
             _chatCommandSender = chatCommandSender;
@@ -114,9 +114,15 @@ namespace LaunchPlugin
                 AutoArmed = false;
             }
 
+            bool sent = false;
             if (Mode == PitFuelControlMode.Man || Mode == PitFuelControlMode.Auto)
             {
-                SendCurrentTarget(isAutoUpdate: false);
+                sent = SendCurrentTarget(isAutoUpdate: false, actionNameOverride: "Pit.FuelControl.SourceCycle");
+            }
+
+            if (!sent)
+            {
+                PublishSelectionFeedback("Pit.FuelControl.SourceCycle", string.Format("FUEL SRC {0}", SourceToText(Source)));
             }
         }
 
@@ -128,26 +134,32 @@ namespace LaunchPlugin
             {
                 Mode = PitFuelControlMode.Man;
                 AutoArmed = false;
-                return;
             }
-
-            if (Mode == PitFuelControlMode.Man)
+            else if (Mode == PitFuelControlMode.Man)
             {
                 if (Source == PitFuelControlSource.Plan)
                 {
                     Mode = PitFuelControlMode.Off;
                     AutoArmed = false;
-                    return;
                 }
-
-                Mode = PitFuelControlMode.Auto;
-                AutoArmed = true;
-                return;
+                else
+                {
+                    Mode = PitFuelControlMode.Auto;
+                    AutoArmed = true;
+                }
+            }
+            else
+            {
+                Mode = PitFuelControlMode.Off;
+                AutoArmed = false;
             }
 
-            Mode = PitFuelControlMode.Off;
-            AutoArmed = false;
+            PublishSelectionFeedback("Pit.FuelControl.ModeCycle", string.Format("FUEL MODE {0}", ModeToText(Mode)));
         }
+
+        public void SetPush() => SetSource(PitFuelControlSource.Push, "Pit.FuelControl.SetPush");
+        public void SetNorm() => SetSource(PitFuelControlSource.Norm, "Pit.FuelControl.SetNorm");
+        public void SetSave() => SetSource(PitFuelControlSource.Save, "Pit.FuelControl.SetSave");
 
         public void OnLapCross()
         {
@@ -214,26 +226,44 @@ namespace LaunchPlugin
                 AutoArmed = false;
                 OverrideActive = false;
                 _maxOverrideArmed = false;
-                _feedbackPublisher?.Invoke("AUTO CANCELLED");
+                PublishSelectionFeedback("Pit.FuelControl.AutoCancelled", "AUTO CANCELLED");
             }
         }
 
         public string SourceText => SourceToText(Source);
         public string ModeText => ModeToText(Mode);
 
-        private void SendCurrentTarget(bool isAutoUpdate)
+        private void SetSource(PitFuelControlSource requestedSource, string actionName)
+        {
+            RefreshDerivedState();
+            Source = requestedSource;
+            RefreshDerivedState();
+
+            bool sent = false;
+            if (Mode == PitFuelControlMode.Man || Mode == PitFuelControlMode.Auto)
+            {
+                sent = SendCurrentTarget(isAutoUpdate: false, actionNameOverride: actionName);
+            }
+
+            if (!sent)
+            {
+                PublishSelectionFeedback(actionName, string.Format("FUEL SRC {0}", SourceToText(Source)));
+            }
+        }
+
+        private bool SendCurrentTarget(bool isAutoUpdate, string actionNameOverride = null)
         {
             RefreshDerivedState();
 
             if (Source == PitFuelControlSource.Stby)
             {
-                return;
+                return false;
             }
 
             int roundedTarget = ComputeRoundedTargetLitres();
             if (roundedTarget < 0)
             {
-                return;
+                return false;
             }
 
             bool useMax = OverrideActive;
@@ -241,7 +271,9 @@ namespace LaunchPlugin
                 ? string.Format("#fuel +{0}$", MaxFuelOvershootLitres)
                 : string.Format("#fuel {0}$", roundedTarget);
             string feedback = BuildFeedbackText(isAutoUpdate, useMax, roundedTarget);
-            string actionName = isAutoUpdate ? "Pit.FuelControl.AutoUpdate" : "Pit.FuelControl.SourceSet";
+            string actionName = !string.IsNullOrWhiteSpace(actionNameOverride)
+                ? actionNameOverride.Trim()
+                : (isAutoUpdate ? "Pit.FuelControl.AutoUpdate" : "Pit.FuelControl.SourceSet");
 
             bool sent = _chatCommandSender != null && _chatCommandSender(actionName, commandText, feedback);
             if (sent)
@@ -253,6 +285,13 @@ namespace LaunchPlugin
                     AutoArmed = true;
                 }
             }
+
+            return sent;
+        }
+
+        private void PublishSelectionFeedback(string actionName, string message)
+        {
+            _feedbackPublisher?.Invoke(actionName, message, string.Empty);
         }
 
         private int ComputeRoundedTargetLitres()


### PR DESCRIPTION
### Motivation
- Dashboards need immediate visible feedback when pit-fuel source/mode is changed even if no fuel-chat send occurs, and some widgets require direct-select actions (PUSH/NORM/SAVE) rather than only cycles. 
- Drivers need a simple zero-fuel action and a predictable max-fuel toggle state so dash labels can reflect the next press meaning.
- Keep all feedback and sends on the existing pit-command transport/feedback seam so dashboards remain pure presentation consumers.

### Description
- Added selection-only feedback plumbing so source and mode changes update the existing pit-command feedback seam: `Pit.Command.DisplayText` and `Pit.Command.LastAction` now reflect selection-only presses with concise text like `FUEL SRC PUSH` / `FUEL MODE AUTO` when no send occurs. (`PitFuelControlEngine.cs` + `PitCommandEngine.cs` publishing helper). 
- Added direct source-select actions implemented in `PitFuelControlEngine`: `Pit.FuelControl.SetPush`, `Pit.FuelControl.SetNorm`, and `Pit.FuelControl.SetSave`, wired to SimHub actions in `LalaLaunch.cs`; these respect `OFF` (selection-only) vs `MAN/AUTO` (immediate send) semantics. 
- Added a zero-fuel action `Pit.FuelSetZero` that uses the existing built-in raw pit command mapping (`#fuel 0$`) and normal feedback text `FUEL ZERO`. (`PitCommandEngine.cs` + action in `LalaLaunch.cs`). 
- Introduced a plugin-owned max-fuel toggle concept: pressing `Pit.FuelSetMax` flips `Pit.Command.FuelSetMaxToggleState` (exported via `AttachCore`) while preserving transport and feedback semantics. (`PitCommandEngine.cs`, exported in `LalaLaunch.cs`). 
- Extended the pit-command feedback API so `PitFuelControlEngine` can publish action-labelled selection feedback (so `Pit.Command.LastAction`/`LastRaw` show the originating action id even when no chat send occurs). 
- Updated canonical docs and inventory entries to reflect new actions/exports and feedback text changes: `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/SimHubLogMessages.md`, `Docs/Subsystems/Dash_Integration.md`, `Docs/Pit_Assist.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.

### Testing
- Attempted a full build with `dotnet build -v minimal` in this environment; it failed because `dotnet` is not available here (environment limitation). 
- Verified wiring and surface-level consistency via source inspection and diffs: ensured new actions are registered with `AddAction(...)`, new exports are attached with `AttachCore(...)`, and the pit-command raw mapping/feedback strings are present. 
- Ran targeted searches/inspections of changed files to confirm expected behavior hooks and messages were added and that existing transport/feedback seams were reused; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42a87c904832fb0169d1abf331229)