### PR TITLE
LapRef: reuse H2H player seams for player lap/time/sector display and simplify LapReferenceEngine

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,20 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### LapRef refactor: remove local player display lifecycle and reuse H2H/core player seams
+- Refactored `LapReferenceEngine` player-side behavior to reuse the same trusted player seams already proven in H2H/core instead of maintaining a competing LapRef-local player display lifecycle.
+- `LapRef.Player.LapTimeSec` now publishes from the same trusted player last-lap seam used by H2H/core (CarIdx last-lap authority path passed through `LalaLaunch`), removing prior dependency on LapRef-validated snapshot latching for player-row lap-time display.
+- Player sector row publication now consumes live CarSA fixed-sector cache directly each tick (H2H-style cache consumption) rather than a bespoke LapRef-local display/rollover snapshot model.
+- Removed redundant LapRef-local player-display machinery:
+  - removed the dedicated live player display snapshot state,
+  - removed redundant validated-player snapshot usage from player-row publication.
+- Kept only minimal LapRef-owned current-lap comparable state for truthful compare/cumulative outputs, with rollover/lap-advance re-arm preserved.
+- Kept LapRef ownership boundaries intact:
+  - SessionBest/ProfileBest remain static LapRef-owned reference rows,
+  - compare/cumulative outputs remain current-lap truthful,
+  - PB persistence seam ownership remains unchanged.
+- Classification: **both** (player-row behavior parity correction + internal architecture/docs alignment).
+
 ### PR #577 review follow-up: clear AUTO baseline on AUTO -> OFF
 - Updated `PitFuelControlEngine.ModeCycle` AUTO disable branch to clear stale AUTO baseline state:
   - `AUTO -> OFF` now sets `LastSentFuelLitres=-1` and `Source=STBY` in addition to `Mode=OFF` and `AutoArmed=false`.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -3,8 +3,8 @@
 **CANONICAL CONTRACT**
 
 Validated against: HEAD
-Last reviewed: 2026-04-19
-Last updated: 2026-04-19
+Last reviewed: 2026-04-20
+Last updated: 2026-04-20
 Branch: work
 
 - All exports are attached in `LalaLaunch.cs` during `Init()` via `AttachCore`/`AttachVerbose`. Core values are refreshed in `DataUpdate` (500 ms poll for fuel/pace/pit via `_poll500ms`; per-tick for launch/dash/messaging). Verbose rows require `SimhubPublish.VERBOSE`.【F:LalaLaunch.cs†L2644-L3120】【F:LalaLaunch.cs†L3411-L3775】
@@ -118,7 +118,7 @@ Branch: work
 | LapRef.PlayerCarIdx / LapRef.ActiveSegment | int/int | Player `CarIdx` and current active segment context (1..6; 0 when unknown). | Per tick. | `LalaLaunch.cs` + `LapReferenceEngine.cs` + `AttachCore`. |
 | LapRef.DeltaToSessionBestSec / LapRef.DeltaToProfileBestSec | double/double | Cumulative player delta (seconds) to session-best/profile-best across completed **current-lap comparable sectors only**. Eligibility is re-armed on normal lap rollover, so prior-lap carried display boxes do not contribute; values publish `0` until at least one current-lap valid player/reference sector pair contributes. | Per tick. | `LapReferenceEngine.cs` + `LalaLaunch.cs` + `AttachCore`. |
 | LapRef.DeltaToSessionBestValid / LapRef.DeltaToProfileBestValid | bool/bool | True only when at least one current-lap valid sector pair contributed to the corresponding cumulative delta; false at lap start/rollover until new-lap comparable sectors exist. | Per tick. | `LapReferenceEngine.cs` + `LalaLaunch.cs` + `AttachCore`. |
-| LapRef.Player.* | mixed | Player live-comparison side outputs: `Valid`, `LapTimeSec`, `ActiveSegment`, and `S1..S6State` / `S1..S6Sec`. Player row sector boxes are display-persistent across lap rollover (H2H-like continuity): prior completed sectors remain visible at new-lap start and are progressively overwritten by new completed sectors from the live CarSA fixed-sector cache snapshot. `LapTimeSec` is latched from the validated-lap capture seam using player `CarIdxLastLapTime` authority (guarded fallback to gate candidate when unavailable). | Per tick. | `LapReferenceEngine.cs` + `LalaLaunch.cs` + `AttachCore`. |
+| LapRef.Player.* | mixed | Player live-comparison side outputs: `Valid`, `LapTimeSec`, `ActiveSegment`, and `S1..S6State` / `S1..S6Sec`. Player row sectors are published directly from live CarSA fixed-sector cache presence each tick (same H2H-style cache-consumption behavior; no LapRef-local display rollover model). `LapTimeSec` is published from the same trusted player last-lap seam used by H2H/core (CarIdx last-lap authority path via `playerLastLapTimeSec`). | Per tick. | `LapReferenceEngine.cs` + `LalaLaunch.cs` + `AttachCore`. |
 | LapRef.SessionBest.* | mixed | In-memory session-best validated static reference snapshot (`Valid`, `LapTimeSec`, `S1..S6State`, `S1..S6Sec`). Lower validated lap time wins; capture lap-time authority is the same player `CarIdxLastLapTime` seam used by H2H/core player lap timing (with guarded fallback only when unavailable). Lap time can remain valid even with missing sectors. | Per tick after capture. | `LapReferenceEngine.cs` + `LalaLaunch.cs` + `AttachCore`. |
 | LapRef.ProfileBest.* | mixed | Profile all-time static reference side (`Valid`, `LapTimeSec`, `S1..S6State`, `S1..S6Sec`) rematerialized from active profile/track/condition each tick using `BestLapMsDry/Wet` and optional `BestLapSector1..6Dry/WetMs`. | Per tick. | `CarProfiles.cs` + `LapReferenceEngine.cs` + `LalaLaunch.cs` + `AttachCore`. |
 | LapRef.Compare.SessionBest.* | mixed | Per-sector comparison versus session best: `S1..S6State`, `S1..S6DeltaSec`. Comparison uses current-lap comparable eligibility (not carried display state), so prior-lap sectors are not treated as new-lap compare input after rollover. Delta publishes only when both sectors are real; otherwise state is non-valid and delta is `0`. | Per tick. | `LapReferenceEngine.cs` + `AttachCore`. |

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-19
+Last updated: 2026-04-20
 Branch: work
 
 ## Current repo/link status
@@ -58,6 +58,11 @@ Branch: work
   - `PUSH/NORM/SAVE` now include profile contingency (`ContingencyValue` + `IsContingencyInLaps`)
   - explicit contingency zero remains zero (no hidden reserve)
 - Hardened LapRef rollover seam for transient zero-segment boundary samples:
+- LapRef player-side refactor now reuses H2H/core trusted seams directly:
+  - `LapRef.Player.LapTimeSec` now publishes from the same trusted player last-lap seam used by H2H/core.
+  - player sector row display now consumes live CarSA fixed-sector cache directly each tick (H2H-style) instead of a LapRef-local display/rollover snapshot lifecycle.
+  - removed redundant LapRef-local player display state while retaining only minimal current-lap comparable state for truthful compare/cumulative outputs.
+  - SessionBest/ProfileBest static reference ownership and PB persistence invariants remain unchanged.
   - current-lap compare/cumulative eligibility now re-arms on normal wrap (`current > 0 && previous > 0 && current < previous`) and on boundary transition into segment `0` from late-lap state (`previous > 1 && current == 0`)
   - closes the `6 -> 0 -> 1` mapping path so stale prior-lap compare/cumulative validity does not leak into new-lap start
   - kept player-row sector-box persistence behavior unchanged
@@ -282,6 +287,14 @@ Branch: work
 
 ### Changed in PR #577 review follow-up (AUTO->OFF baseline clear)
 - `PitFuelControlEngine.cs`
+- `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
+### Changed in LapRef player-side seam reuse refactor
+- `LapReferenceEngine.cs`
+- `LalaLaunch.cs`
+- `Docs/Subsystems/LapRef.md`
 - `Docs/Internal/SimHubParameterInventory.md`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`

--- a/Docs/Subsystems/LapRef.md
+++ b/Docs/Subsystems/LapRef.md
@@ -1,7 +1,7 @@
 # LapRef (Offline Reference Lap Comparison)
 
 Validated against commit: HEAD
-Last updated: 2026-04-19
+Last updated: 2026-04-20
 Branch: work
 
 ## Purpose
@@ -15,11 +15,11 @@ It compares:
 LapRef mirrors H2H's fixed 6-sector presentation concept but is fully separate from `H2HRace.*` / `H2HTrack.*` contracts.
 
 ## Ownership and boundaries
-- **LapRef owns** validated-lap snapshot state, session-best state, profile-best materialization, and `LapRef.*` exports.
+- **LapRef owns** session-best static reference state, profile-best static reference materialization, compare/cumulative outputs, and `LapRef.*` exports.
 - **LapRef does not own** sector derivation. It consumes CarSA fixed-sector cache read-only via `TryGetFixedSectorCacheSnapshot`.
 - **LapRef does not own** wet/dry detection. It uses runtime `_isWetMode` routing.
 - **LapRef does not own** lap validation rules. It captures only from the existing validated-lap gate in `UpdateLiveFuelCalcs`.
-- **LapRef lap-time authority** is aligned to the same player telemetry seam used by H2H/core (`CarIdxLastLapTime` for player row/session-best capture path), but uses a freshness guard against the validated-gate candidate to avoid one-tick stale rollover samples before accepting the CarIdx seam.
+- **LapRef lap-time authority** is aligned to the same player telemetry seam used by H2H/core (`CarIdxLastLapTime` for player row/session-best capture path), with a bounded freshness guard against the validated-gate candidate at capture time.
 - **LapRef does not modify** H2H behavior, Opponents behavior, or CarSA derivation rules.
 
 ## Snapshot model
@@ -33,13 +33,17 @@ A captured validated lap snapshot carries:
 
 Missing sectors remain empty. Lap time can still be valid without sector data.
 
-LapRef also maintains a separate **live current-lap comparison view** for the player side:
+LapRef maintains a minimal **current-lap comparable snapshot** for compare/cumulative truth:
 - active segment comes from live player lap pct mapping
-- completed sectors for the current lap are read from CarSA fixed-sector cache
-- only completed sectors behind the current segment are treated as comparable
+- sectors are sourced from live CarSA fixed-sector cache
+- only completed current-lap sectors behind the current segment are treated as comparable
 - no partial current-sector elapsed values are synthesized
-- completed sector boxes persist across lap rollover and are overwritten progressively as new-lap sectors complete (H2H-like presentation continuity)
-- compare/cumulative truth uses current-lap re-armed sector eligibility so prior-lap carried visual boxes do not contribute after rollover
+- compare/cumulative truth uses current-lap re-armed sector eligibility
+
+Player-row sector display continuity is H2H-style:
+- LapRef reads CarSA cache presence directly each tick for `LapRef.Player.S1..S6*`
+- LapRef does not run a bespoke player display/rollover state machine
+- rollover/start-finish continuity therefore follows the same CarSA-cache-driven behavior pattern already proven in H2H player/target sector display
 
 ## Capture and update flow
 1. Existing validated-lap gate accepts a lap in `UpdateLiveFuelCalcs`.
@@ -47,10 +51,10 @@ LapRef also maintains a separate **live current-lap comparison view** for the pl
 3. Snapshot becomes player reference row and competes for in-memory session best.
 4. Existing profile PB seam persists lap-time PB; sector fields are persisted condition-wise when available.
 5. Each tick, LapRef rematerializes profile-best from active profile + track + wet/dry condition.
-6. Each tick, LapRef also materializes the player **live current-lap comparison sectors** from the current CarSA cache snapshot + current active segment and publishes `LapRef.*`.
-   - Player-row sector display continuity follows H2H-like cache behavior: any valid CarSA sector value can refresh the corresponding displayed player box immediately, while unchanged boxes naturally persist until replaced.
-   - This live row is not hard-cleared every tick; it preserves prior completed sectors at lap start and replaces each slot only when the corresponding new-lap sector is actually completed.
-   - Live compare/cumulative evaluation uses a separate current-lap comparable snapshot that clears on lap rollover while player row display continuity remains intact.
+6. Each tick, LapRef:
+   - publishes player sector boxes directly from the current CarSA fixed-sector cache snapshot (H2H-style read-only consumption),
+   - updates only the minimal current-lap comparable snapshot needed for truthful compare/cumulative outputs,
+   - re-arms current-lap comparable eligibility on rollover/lap advance while keeping static references unchanged.
 
 PB safety note:
 - Profile PB remains telemetry-owned (validated-lap seam); Profiles UI no longer permits manual PB entry.
@@ -71,9 +75,9 @@ For comparison rows (`LapRef.Compare.*`):
 - `pending` when exactly one side has real sector
 - `empty` when neither side has real sector
 
-At new-lap start, comparison validity is re-armed from empty current-lap eligibility:
-- prior-lap carried display sectors do not count for compare validity
+At new-lap start/lap advance, comparison validity is re-armed from empty current-lap eligibility:
 - compare rows reactivate only as current-lap sectors complete
+- player-row display remains CarSA-cache-driven and does not introduce extra LapRef-local rollover latches
 
 ## Export family
 Family-level:

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -6889,7 +6889,7 @@ namespace LaunchPlugin
                         trackBehindSelector);
                 }
 
-                UpdateLapReferenceContext(playerCarIdx, carIdxLapDistPct, sessionTypeName);
+                UpdateLapReferenceContext(playerCarIdx, carIdxLapDistPct, carIdxLap, sessionTypeName, playerLastLapTimeSec);
                 if (_friendsDirty)
                 {
                     RefreshFriendUserIds();
@@ -12835,7 +12835,7 @@ namespace LaunchPlugin
                 && Math.Abs(candidateBestLapSec - currentClassBestSec) <= CarSaLapTimeEpsilonSec;
         }
 
-        private void UpdateLapReferenceContext(int playerCarIdx, float[] carIdxLapDistPct, string sessionTypeName)
+        private void UpdateLapReferenceContext(int playerCarIdx, float[] carIdxLapDistPct, int[] carIdxLap, string sessionTypeName, double playerLastLapTimeSec)
         {
             if (_lapReferenceEngine == null)
             {
@@ -12846,9 +12846,14 @@ namespace LaunchPlugin
             string trackKey = !string.IsNullOrWhiteSpace(CurrentTrackKey) ? CurrentTrackKey : (CurrentTrackName ?? string.Empty);
             bool isWetMode = _isWetMode;
             int activeSegment = 0;
+            int playerLapRef = 0;
             if (playerCarIdx >= 0 && carIdxLapDistPct != null && playerCarIdx < carIdxLapDistPct.Length)
             {
                 activeSegment = ComputeLapRefActiveSegment(carIdxLapDistPct[playerCarIdx]);
+            }
+            if (playerCarIdx >= 0 && carIdxLap != null && playerCarIdx < carIdxLap.Length)
+            {
+                playerLapRef = carIdxLap[playerCarIdx];
             }
             CarSAEngine.FixedSectorCacheSnapshot liveFixedSectorSnapshot = default(CarSAEngine.FixedSectorCacheSnapshot);
             bool hasLiveFixedSectorSnapshot =
@@ -12884,6 +12889,8 @@ namespace LaunchPlugin
                 trackKey,
                 isWetMode,
                 playerCarIdx,
+                playerLastLapTimeSec,
+                playerLapRef,
                 activeSegment,
                 profileBestLapSec,
                 profileBestSectors,

--- a/LapReferenceEngine.cs
+++ b/LapReferenceEngine.cs
@@ -9,8 +9,6 @@ namespace LaunchPlugin
         public const int SegmentStatePending = 1;
         public const int SegmentStateValid = 2;
 
-        private readonly LapReferenceSnapshot _playerSnapshot = new LapReferenceSnapshot();
-        private readonly LapReferenceSnapshot _livePlayerComparisonSnapshot = new LapReferenceSnapshot();
         private readonly LapReferenceSnapshot _livePlayerCurrentLapSnapshot = new LapReferenceSnapshot();
         private readonly LapReferenceSnapshot _sessionBestSnapshot = new LapReferenceSnapshot();
         private readonly LapReferenceSnapshot _profileBestSnapshot = new LapReferenceSnapshot();
@@ -21,6 +19,7 @@ namespace LaunchPlugin
         private string _trackKey = string.Empty;
         private bool _isWet;
         private int _lastLivePlayerActiveSegment;
+        private int _lastLivePlayerLapRef;
 
         public LapReferenceEngine()
         {
@@ -37,12 +36,11 @@ namespace LaunchPlugin
             _trackKey = string.Empty;
             _isWet = false;
 
-            _playerSnapshot.Clear();
-            _livePlayerComparisonSnapshot.Clear();
             _livePlayerCurrentLapSnapshot.Clear();
             _sessionBestSnapshot.Clear();
             _profileBestSnapshot.Clear();
             _lastLivePlayerActiveSegment = 0;
+            _lastLivePlayerLapRef = 0;
             Outputs.Reset();
         }
 
@@ -53,6 +51,8 @@ namespace LaunchPlugin
             string trackKey,
             bool isWet,
             int playerCarIdx,
+            double playerLastLapTimeSec,
+            int playerLapRef,
             int playerActiveSegment,
             double profileBestLapSec,
             int?[] profileBestSectorMs,
@@ -79,11 +79,10 @@ namespace LaunchPlugin
                 _trackKey = nextTrackKey;
                 _isWet = isWet;
 
-                _playerSnapshot.Clear();
-                _livePlayerComparisonSnapshot.Clear();
                 _livePlayerCurrentLapSnapshot.Clear();
                 _sessionBestSnapshot.Clear();
                 _lastLivePlayerActiveSegment = 0;
+                _lastLivePlayerLapRef = 0;
             }
 
             MaterializeProfileBest(profileBestLapSec, profileBestSectorMs, isWet);
@@ -92,8 +91,8 @@ namespace LaunchPlugin
             Outputs.Mode = isWet ? "Wet" : "Dry";
             Outputs.PlayerCarIdx = playerCarIdx;
             Outputs.ActiveSegment = SanitizeSegment(playerActiveSegment);
-            BuildLivePlayerComparisonSnapshot(Outputs.ActiveSegment, hasLiveFixedSectorSnapshot, liveFixedSectorSnapshot);
-            BuildLivePlayerOutput(Outputs.Player, _livePlayerComparisonSnapshot, Outputs.ActiveSegment, Outputs.Valid, _playerSnapshot);
+            BuildLivePlayerCurrentLapSnapshot(Outputs.ActiveSegment, playerLapRef, hasLiveFixedSectorSnapshot, liveFixedSectorSnapshot);
+            BuildLivePlayerOutput(Outputs.Player, Outputs.ActiveSegment, Outputs.Valid, playerLastLapTimeSec, hasLiveFixedSectorSnapshot, liveFixedSectorSnapshot);
 
             Outputs.SessionBest.AssignFromSnapshot(_sessionBestSnapshot);
             Outputs.ProfileBest.AssignFromSnapshot(_profileBestSnapshot);
@@ -152,8 +151,6 @@ namespace LaunchPlugin
                     }
                 }
             }
-
-            _playerSnapshot.CopyFrom(snapshot);
 
             bool sessionBestImproved = !_sessionBestSnapshot.HasLapTime || lapTimeSec < _sessionBestSnapshot.LapTimeSec;
             if (sessionBestImproved)
@@ -255,33 +252,27 @@ namespace LaunchPlugin
             }
         }
 
-        private void BuildLivePlayerComparisonSnapshot(
+        private void BuildLivePlayerCurrentLapSnapshot(
             int activeSegment,
+            int playerLapRef,
             bool hasLiveFixedSectorSnapshot,
             CarSAEngine.FixedSectorCacheSnapshot liveFixedSectorSnapshot)
         {
             int previousActiveSegment = _lastLivePlayerActiveSegment;
             _lastLivePlayerActiveSegment = activeSegment;
 
-            if (IsLapRollover(previousActiveSegment, activeSegment))
+            bool hasLapRef = playerLapRef > 0;
+            bool lapRefAdvanced = hasLapRef && _lastLivePlayerLapRef > 0 && playerLapRef != _lastLivePlayerLapRef;
+            _lastLivePlayerLapRef = hasLapRef ? playerLapRef : _lastLivePlayerLapRef;
+
+            if (lapRefAdvanced || IsLapRollover(previousActiveSegment, activeSegment))
             {
                 _livePlayerCurrentLapSnapshot.Clear();
             }
 
-            _livePlayerComparisonSnapshot.ActiveSegment = activeSegment;
-
             if (!hasLiveFixedSectorSnapshot)
             {
                 return;
-            }
-
-            for (int i = 0; i < SegmentCount; i++)
-            {
-                var sector = liveFixedSectorSnapshot.GetSector(i);
-                if (sector.HasValue && IsValidLapTime(sector.DurationSec))
-                {
-                    _livePlayerComparisonSnapshot.SetSector(i, true, sector.DurationSec);
-                }
             }
 
             int completedSectorCount = GetCompletedSectorCount(activeSegment);
@@ -296,7 +287,6 @@ namespace LaunchPlugin
                 if (sector.HasValue && IsValidLapTime(sector.DurationSec))
                 {
                     _livePlayerCurrentLapSnapshot.SetSector(i, true, sector.DurationSec);
-                    _livePlayerComparisonSnapshot.SetSector(i, true, sector.DurationSec);
                 }
             }
         }
@@ -322,10 +312,11 @@ namespace LaunchPlugin
 
         private static void BuildLivePlayerOutput(
             LapReferenceSideOutput output,
-            LapReferenceSnapshot liveSnapshot,
             int activeSegment,
             bool isContextValid,
-            LapReferenceSnapshot lastValidatedSnapshot)
+            double playerLastLapTimeSec,
+            bool hasLiveFixedSectorSnapshot,
+            CarSAEngine.FixedSectorCacheSnapshot liveFixedSectorSnapshot)
         {
             if (output == null)
             {
@@ -335,14 +326,19 @@ namespace LaunchPlugin
             output.Reset();
             output.Valid = isContextValid;
             output.ActiveSegment = activeSegment;
-            output.LapTimeSec = (lastValidatedSnapshot != null && lastValidatedSnapshot.HasLapTime)
-                ? lastValidatedSnapshot.LapTimeSec
-                : 0.0;
+            output.LapTimeSec = IsValidLapTime(playerLastLapTimeSec) ? playerLastLapTimeSec : 0.0;
 
             for (int i = 0; i < SegmentCount; i++)
             {
-                bool hasSector = liveSnapshot != null && liveSnapshot.GetSectorHasValue(i);
-                output.SetSector(i, hasSector ? SegmentStateValid : SegmentStateEmpty, hasSector ? liveSnapshot.GetSectorSec(i) : 0.0);
+                if (!hasLiveFixedSectorSnapshot)
+                {
+                    output.SetSector(i, SegmentStateEmpty, 0.0);
+                    continue;
+                }
+
+                var sector = liveFixedSectorSnapshot.GetSector(i);
+                bool hasSector = sector.HasValue && IsValidLapTime(sector.DurationSec);
+                output.SetSector(i, hasSector ? SegmentStateValid : SegmentStateEmpty, hasSector ? sector.DurationSec : 0.0);
             }
         }
 


### PR DESCRIPTION
### Motivation
- Remove LapRef-local player-display lifecycle and duplicate timing seams and instead publish player lap time and sectors from the same trusted H2H/core seams to avoid stale/laggy displays and simplify internal state.
- Keep LapRef ownership for validated session/profile reference snapshots and compare/cumulative truth while aligning player-row presentation to CarSA/H2H cache consumption semantics.

### Description
- Changed `LalaLaunch.UpdateLapReferenceContext` to pass `playerLastLapTimeSec` and `playerLapRef` into `LapReferenceEngine.UpdateContext` and supply live CarSA fixed-sector snapshot context.
- Refactored `LapReferenceEngine` by removing the redundant LapRef-local live player snapshot and comparison snapshot, introducing `_livePlayerCurrentLapSnapshot` and `_lastLivePlayerLapRef`, and wiring `UpdateContext`/`BuildLivePlayerCurrentLapSnapshot` to clear current-lap comparable state on lap rollover or lap-ref advance.
- `BuildLivePlayerOutput` now publishes `LapRef.Player.LapTimeSec` from the player last-lap telemetry seam and reads player sector boxes directly from the CarSA fixed-sector snapshot each tick (H2H-style), preserving compare/cumulative truth as current-lap only.
- Updated documentation to reflect the seam reuse and behavior changes in `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, and `Docs/Subsystems/LapRef.md` (including updated last-reviewed dates).

### Testing
- Performed a full solution build which completed successfully (`dotnet build` / Visual Studio build).
- Executed the automated unit test suite (`dotnet test`) with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dcf3689c832fa371c927d7975987)