### PR TITLE
Fix custom-message settings load to preserve saved rows on restart

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,14 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-21 — PR #584 follow-up: custom-message load normalization preserves saved rows
+- Classification: **internal-only** (settings JSON load/normalization correction; no action binding or runtime dispatch contract change).
+- Removed eager default slot prepopulation from `LaunchPluginSettings.CustomMessages` so Json.NET deserialization no longer appends loaded rows after an already-populated default set.
+- Kept `NormalizePitCommandSettings(...)` as the single default-slot authority:
+  - if `CustomMessages` is missing/null/undersized, it now creates/fills exactly `CustomPitMessageSlotCount` slots,
+  - if loaded slots exist, they remain in-place and are normalized (slot numbering/default field fill) without being displaced by preexisting defaults.
+- Fix outcome: saved custom-message label/text rows survive restart, while fresh installs and missing settings still receive the expected 10 default slots.
+
 ### Pit Fuel Control follow-up: zero transport, AUTO ownership cancel redesign, OFF/STBY reset semantics, offline suppression
 - Updated `PitCommandEngine` zero-fuel transport payloads to `#fuel 0.01$` for both:
   - dedicated `Pit.FuelSetZero`,

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- PR #584 follow-up fixed custom-message restart persistence at settings load:
+  - removed eager default prepopulation of `LaunchPluginSettings.CustomMessages` before JSON deserialize;
+  - `NormalizePitCommandSettings(...)` remains the default-slot authority and now supplies default rows only when collection data is missing/null/undersized;
+  - saved custom-message rows now load intact across restart, while new/missing settings still normalize to the expected 10 slots.
 - Pit Fuel Control follow-up (bounded to pit fuel-control + pit-command seam):
   - `Pit.FuelSetZero` and `Pit.FuelSetMax` ZERO phase now transport `#fuel 0.01$` (MAX phase unchanged).
   - AUTO cancel now uses live requested-fuel movement ownership detection outside plugin send suppression (no stale baseline mismatch dependence); cancellation is one-shot to `OFF + STBY` with `AUTO CANCELLED`.
@@ -321,6 +325,11 @@ Branch: work
 - `LalaLaunch.cs`
 - `Docs/Subsystems/LapRef.md`
 - `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
+### Changed in PR #584 follow-up (custom-message load normalization persistence fix)
+- `LalaLaunch.cs`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -16393,7 +16393,7 @@ namespace LaunchPlugin
             { CarSAStyleResolver.BorderModeDefault, "#F5F5F5" }
         };
         public ObservableCollection<LaunchPluginFriendEntry> Friends { get; set; } = new ObservableCollection<LaunchPluginFriendEntry>();
-        public ObservableCollection<CustomMessageSlot> CustomMessages { get; set; } = CreateDefaultCustomMessages();
+        public ObservableCollection<CustomMessageSlot> CustomMessages { get; set; }
 
         // --- LalaDash Toggles (Default ON) ---
         public bool LalaDashShowLaunchScreen { get; set; } = true;
@@ -16425,16 +16425,6 @@ namespace LaunchPlugin
         public bool OverlayDashShowRadioMessages { get; set; } = true;
         public bool OverlayDashShowTraffic { get; set; } = true;
 
-        private static ObservableCollection<CustomMessageSlot> CreateDefaultCustomMessages()
-        {
-            var list = new ObservableCollection<CustomMessageSlot>();
-            for (int i = 1; i <= LalaLaunch.CustomPitMessageSlotCount; i++)
-            {
-                list.Add(new CustomMessageSlot(i));
-            }
-
-            return list;
-        }
     }
     /// <summary>
     /// Helper class for continuous telemetry data logging, now specifically focused on per-launch traces.


### PR DESCRIPTION
### Motivation
- Saved custom-message edits were lost after SimHub restart because `LaunchPluginSettings.CustomMessages` was pre-populated with defaults before JSON deserialization, and Json.NET populated loaded entries into that already-filled collection causing later normalization to throw away saved rows. 
- The change ensures deserialization does not keep a pre-populated default collection so persisted user rows survive restarts while still providing defaults for fresh installs.

### Description
- Removed the eager initializer from `LaunchPluginSettings.CustomMessages` so the property is `null` prior to settings deserialization. (`LalaLaunch.cs`)
- Left `NormalizePitCommandSettings(...)` as the single default-slot authority and relied on it to create/trim/populate `CustomMessages` only when the collection is `null` or undersized, preserving any loaded rows. (`LalaLaunch.cs`, `NormalizePitCommandSettings` behavior unchanged)
- Updated internal documentation to record the fix and rationale in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`.
- No runtime action bindings, message transport, or user-visible command behavior was modified.

### Testing
- Verified code changes by inspecting `LalaLaunch.cs` to ensure the initializer was removed and `NormalizePitCommandSettings(...)` still creates/fills the collection when needed. (static code inspection)
- Confirmed docs were updated: `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` were modified to describe the fix. (git diff / commit)
- Attempted to run a build with `dotnet build LaunchPlugin.csproj -c Release`, but the environment does not have `dotnet` installed so the build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cde31598832fb96e472156a0f22f)