### PR TITLE
PB clear: immediate UI refresh, orange warning text, and compact button label

### DIFF
--- a/CarProfiles.cs
+++ b/CarProfiles.cs
@@ -1023,16 +1023,18 @@ namespace LaunchPlugin
             if (isWetEffective)
             {
                 BestLapMsWet = 0;
-                BestLapTimeWetText = MillisecondsToLapTimeString(BestLapMsWet);
                 WetBestLapUpdatedSource = null;
                 WetBestLapUpdatedUtc = null;
+                _bestLapMsWetText = string.Empty;
+                OnPropertyChanged(nameof(BestLapTimeWetText));
             }
             else
             {
                 BestLapMsDry = 0;
-                BestLapTimeDryText = MillisecondsToLapTimeString(BestLapMsDry);
                 DryBestLapUpdatedSource = null;
                 DryBestLapUpdatedUtc = null;
+                _bestLapMsDryText = string.Empty;
+                OnPropertyChanged(nameof(BestLapTimeDryText));
             }
 
             ClearBestLapSectorsForCondition(isWetEffective);

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,15 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-21 — Profile-track PB clear polish: immediate PB text refresh + warning colour + compact label
+- Classification: **both** (profile editor UX polish + internal property-refresh correctness in the PB clear path).
+- Updated `ClearBestLapAndSectorsForCondition(...)` to mirror relearn visual refresh behavior:
+  - clears condition PB value + PB updated metadata,
+  - clears the condition PB display-text cache,
+  - raises `BestLapTimeDryText` / `BestLapTimeWetText` property changed immediately.
+- Updated profile-track PB clear buttons to use compact label text: `Clear PB Data` in both dry and wet sections.
+- Updated condition `No sector data` status text colour to an orange warning-style tone for clearer visibility in the editor.
+
 ### Pit Fuel Control follow-up: zero transport, AUTO ownership cancel redesign, OFF/STBY reset semantics, offline suppression
 - Updated `PitCommandEngine` zero-fuel transport payloads to `#fuel 0.01$` for both:
   - dedicated `Pit.FuelSetZero`,

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,11 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- Profile-track PB clear polish follow-up (bounded to profile-track editor clear path + UI text styling):
+  - condition PB clear now immediately clears visible PB text in-place by mirroring relearn refresh semantics (clear PB display cache + raise property changed for condition PB text);
+  - dry/wet clear button labels are now compact and identical: `Clear PB Data`;
+  - condition `No sector data` status text now uses an orange warning-style colour for better visibility;
+  - PB cleared-state semantics remain unchanged (`0`/non-positive still unavailable, no valid zero-time PB reference path).
 - Pit Fuel Control follow-up (bounded to pit fuel-control + pit-command seam):
   - `Pit.FuelSetZero` and `Pit.FuelSetMax` ZERO phase now transport `#fuel 0.01$` (MAX phase unchanged).
   - AUTO cancel now uses live requested-fuel movement ownership detection outside plugin send suppression (no stale baseline mismatch dependence); cancellation is one-shot to `OFF + STBY` with `AUTO CANCELLED`.

--- a/Docs/Subsystems/Profiles_And_PB.md
+++ b/Docs/Subsystems/Profiles_And_PB.md
@@ -1,7 +1,7 @@
 # Profiles and Personal Bests
 
 Validated against commit: HEAD
-Last updated: 2026-04-09
+Last updated: 2026-04-21
 Branch: work
 
 ## Purpose
@@ -82,6 +82,7 @@ When a PB update includes real sector values, condition-specific PB sector field
 Profiles UI exposes buttons to reset and relearn track data:
 - **Relearn Pit Data**: clears pit loss values/metadata and resets track markers for that track before saving.
 - **Relearn Dry/Wet Conditions**: clears PB, avg lap time, and fuel stats for the chosen condition, unlocks the condition, and saves.
+- **Clear PB Data** (per dry/wet block): clears only that condition PB lap + PB sectors (`S1..S6`) and PB updated metadata, then immediately clears the visible PB text in-place in the editor via property-change refresh.
 
 ---
 

--- a/ProfilesManagerView.xaml
+++ b/ProfilesManagerView.xaml
@@ -1145,14 +1145,14 @@
                                                 Margin="10,0,0,0"
                                                 ToolTip="Clear dry data and relearn from new live laps (while unlocked)."/>
                                             <styles:SHButtonPrimary
-                                                Content="Clear Dry PB + Sectors"
+                                                Content="Clear PB Data"
                                                 Command="{Binding DataContext.ClearDryBestLapAndSectorsCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                 Margin="10,0,0,0"
                                                 ToolTip="Clear only dry best lap and dry sector 1..6 data."/>
                                             <TextBlock
                                                 Margin="10,0,0,0"
                                                 VerticalAlignment="Center"
-                                                Foreground="#FF9AA0A6"
+                                                Foreground="#FFFFA726"
                                                 Text="No sector data">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock">
@@ -1322,14 +1322,14 @@
                                                 Margin="10,0,0,0"
                                                 ToolTip="Clear wet data and relearn from new live laps (while unlocked)."/>
                                             <styles:SHButtonPrimary
-                                                Content="Clear Wet PB + Sectors"
+                                                Content="Clear PB Data"
                                                 Command="{Binding DataContext.ClearWetBestLapAndSectorsCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                 Margin="10,0,0,0"
                                                 ToolTip="Clear only wet best lap and wet sector 1..6 data."/>
                                             <TextBlock
                                                 Margin="10,0,0,0"
                                                 VerticalAlignment="Center"
-                                                Foreground="#FF9AA0A6"
+                                                Foreground="#FFFFA726"
                                                 Text="No sector data">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock">


### PR DESCRIPTION
### Motivation
- Fix a UI display-refresh mismatch so pressing the profile-track PB clear button immediately clears the visible PB text in the editor without needing to switch tracks.
- Make the “No sector data” info text stand out more by using an orange warning-style color.
- Shorten the PB-clear button label to a compact, context-adequate `Clear PB Data`.

### Description
- Updated `CarProfiles.ClearBestLapAndSectorsForCondition(bool isWetEffective)` to mirror the `Relearn*` visual-refresh pattern by clearing the cached PB display text (`_bestLapMsDryText` / `_bestLapMsWetText`) and raising `OnPropertyChanged` for `BestLapTimeDryText` / `BestLapTimeWetText` so the editor view refreshes immediately.
- Kept existing cleared-PB semantics unchanged (cleared/non-positive PB remains unavailable and will not be treated as a valid zero-time reference by LapRef).
- Modified `ProfilesManagerView.xaml` to change both condition buttons to `Content="Clear PB Data"` and to set the `No sector data` `TextBlock` Foreground to an orange warning color (`#FFFFA726`) in both dry and wet blocks.
- Updated docs to reflect the UI and behavior change: `Docs/Subsystems/Profiles_And_PB.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` were edited to record the change.

### Testing
- Attempted build with `dotnet build LaunchPlugin.sln`; failed in this environment because `dotnet` is not installed (build not executed here).
- Verified text and code edits with repository search and diff commands (`rg` / `git diff`) to ensure the new display-refresh code and XAML changes are present; these checks succeeded.
- Changes were committed to branch `work` (`Fix PB clear UI refresh and polish profile-track labels`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cf32e07c832f9d8cc1e6e1e855e5)