### PR TITLE
Fix wet-condition PB fallback and guard LapRef session-best sync

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,17 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-21 — Wet-condition PB/session-best audit follow-up (condition-only PB reads + LapRef session-best cross-condition guard)
+- Classification: **both** (driver-visible wet PB/session-best correctness + bounded LapRef authority seam hardening).
+- Fixed remaining wet PB fallback leakage in planner/profile-facing PB reads:
+  - strategy/profile PB display paths now use condition-only PB lookup (`wet -> wet only`, `dry -> dry only`) and no longer borrow dry PB when wet PB is absent.
+- Kept wet PB persistence path condition-scoped and unchanged in ownership:
+  - validated-lap PB updates continue to route `_isWetMode` into `TryUpdatePBByCondition(...)`,
+  - wet PB updates persist only wet fields (`BestLapMsWet`, `BestLapSector1..6WetMs`), dry path remains separate.
+- Hardened LapRef SessionBest authority sync against cross-condition repopulation:
+  - trusted player best-lap seam remains enabled only after current-context capture arming,
+  - tick-sync now applies only when authoritative value is near-equal to captured current-context session-best baseline (tight tolerance), preventing a dry global-best seam value from overwriting wet-mode SessionBest after wet reset/capture.
+
 ### 2026-04-21 — Final docs sweep: plugin-owned pit commands + custom messages + pit fuel control
 - Classification: **both** (user-facing guidance alignment + subsystem/internal contract sync).
 - Updated user-facing docs (`README`, `Quick Start`, `User Guide`, `Pit Assist`) to align around final plugin-owned pit/custom workflow:

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- Wet-condition PB/session-best audit follow-up (bounded to profile/PB/planner/LapRef wet-dry behavior):
+  - planner/profile PB reads now use condition-only lookup, so wet mode no longer borrows dry PB when wet PB is absent;
+  - validated wet PB persistence remains condition-scoped on existing telemetry gate path (`_isWetMode` -> `TryUpdatePBByCondition(...)` -> wet PB fields only);
+  - LapRef session-best authority sync remains trusted-seam based but now only applies when near-equal to the captured current-context baseline, preventing dry global-best seam values from repopulating wet SessionBest after wet reset.
 - Final documentation sweep aligned user-facing + dash-facing + internal docs with the implemented combined pit command stack:
   - plugin-owned pit command actions and plugin-owned custom-message actions are now the documented default workflow;
   - built-in pit command configuration location is documented as `Settings -> Pit Commands`;

--- a/Docs/Subsystems/LapRef.md
+++ b/Docs/Subsystems/LapRef.md
@@ -21,7 +21,7 @@ LapRef mirrors H2H's fixed 6-sector presentation concept but is fully separate f
 - **LapRef does not own** lap validation rules. It captures only from the existing validated-lap gate in `UpdateLiveFuelCalcs`.
 - **LapRef lap-time authority** is split by responsibility:
   - player-row last-lap capture uses the same trusted H2H/core seam (`CarIdxLastLapTime` with validated-gate freshness guard),
-  - session-best `LapTimeSec` is synchronized each tick to the trusted H2H/core best-lap seam (native player best-lap authority path in `LalaLaunch`) only after LapRef has captured a current-context session-best baseline; LapRef still owns the session-best sector snapshot contract.
+  - session-best `LapTimeSec` is synchronized each tick to the trusted H2H/core best-lap seam (native player best-lap authority path in `LalaLaunch`) only after LapRef has captured a current-context session-best baseline; sync is constrained to near-equal values (tight tolerance) so non-condition-scoped seam values do not overwrite the active condition baseline. LapRef still owns the session-best sector snapshot contract.
 - **LapRef does not modify** H2H behavior, Opponents behavior, or CarSA derivation rules.
 
 ## Snapshot model
@@ -146,6 +146,7 @@ Session-best lap-time authority arming behavior:
 - on context reset, authoritative session-best lap-time sync is disarmed
 - disarmed state prevents stale prior-session best-lap values from being copied into `LapRef.SessionBest.LapTimeSec`
 - sync is re-armed by the first valid current-context `CaptureValidatedLap(...)` session-best capture, after which trusted authority resumes driving `LapRef.SessionBest.LapTimeSec`
+- authoritative sync only applies when the trusted seam value is near-equal to the captured active-context session-best baseline, preventing wet-mode/dry-mode cross-condition overwrite from a non-condition-scoped trusted seam
 
 Lap rollover handling is intentionally separate from reset:
 - normal lap boundary progression does **not** clear visible completed sector boxes

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -4268,7 +4268,7 @@ namespace LaunchPlugin
             ts = SelectedTrackStats ?? ResolveSelectedTrackStats();
         }
 
-        int? ms = ts?.GetBestLapMsForCondition(IsWet);
+        int? ms = ts?.GetConditionOnlyBestLapMs(IsWet);
         if (ms.HasValue && ms.Value > 0)
         {
             _loadedBestLapTimeSeconds = ms.Value / 1000.0;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -7235,7 +7235,7 @@ namespace LaunchPlugin
 
                     var activeTrackStats = ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackKey)
                         ?? ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackName);
-                    int? selectedPbMs = activeTrackStats?.GetBestLapMsForCondition(_isWetMode);
+                    int? selectedPbMs = activeTrackStats?.GetConditionOnlyBestLapMs(_isWetMode);
                     double selectedPbSeconds = selectedPbMs.HasValue ? selectedPbMs.Value / 1000.0 : 0.0;
                     FuelCalculator?.SetPersonalBestSeconds(selectedPbSeconds);
                 }

--- a/LapReferenceEngine.cs
+++ b/LapReferenceEngine.cs
@@ -8,6 +8,7 @@ namespace LaunchPlugin
         public const int SegmentStateEmpty = 0;
         public const int SegmentStatePending = 1;
         public const int SegmentStateValid = 2;
+        private const double SessionBestAuthoritySyncToleranceSec = 0.05;
 
         private readonly LapReferenceSnapshot _livePlayerCurrentLapSnapshot = new LapReferenceSnapshot();
         private readonly LapReferenceSnapshot _sessionBestSnapshot = new LapReferenceSnapshot();
@@ -294,6 +295,11 @@ namespace LaunchPlugin
             }
 
             if (!IsValidLapTime(playerBestLapTimeSec))
+            {
+                return;
+            }
+
+            if (Math.Abs(playerBestLapTimeSec - _sessionBestSnapshot.LapTimeSec) > SessionBestAuthoritySyncToleranceSec)
             {
                 return;
             }


### PR DESCRIPTION
### Motivation
- Certain planner/profile and LapRef paths were still using fallback-style PB lookup that allowed wet mode to borrow dry PB when no wet PB existed, causing incorrect wet PB display in planner and profile pages.  
- LapRef SessionBest could be repopulated from the non-condition-scoped trusted player-best seam after a wet-mode reset, which violated the intended condition-scoped session-best reset behavior.  
- The fix must be bounded: persist/writes remain condition-scoped and only read/display paths and a narrow LapRef guard should be changed.

### Description
- Switched planner/profile PB reads to strict condition-only lookup by replacing `GetBestLapMsForCondition(...)` with `GetConditionOnlyBestLapMs(...)` in `FuelCalcs.UpdateProfileBestLapForCondition(...)` and the PB handoff in `LalaLaunch` so wet mode no longer borrows dry PB.  
- Hardened `LapReferenceEngine` authoritative session-best tick sync by adding a small tolerance guard (`SessionBestAuthoritySyncToleranceSec`) and refusing sync when the trusted seam value diverges beyond that tolerance from the captured current-context baseline.  
- Updated subsystem docs and internal changelog to record the bounded changes to LapRef behavior and PB/profile read semantics (`Docs/Subsystems/LapRef.md`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`).  
- Files changed: `FuelCalcs.cs`, `LalaLaunch.cs`, `LapReferenceEngine.cs`, `Docs/Subsystems/LapRef.md`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`.

### Testing
- Attempted automated build: `dotnet build LaunchPlugin.sln` could not be executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- No other automated tests were run in this environment; changes are minimal and localized to PB read paths and a narrow LapRef guard to minimize regression risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e791f120a4832f8ee5da42940e886c)