### PR TITLE
Fix wet lap-time and PB persistence routing

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,13 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-22 — PR follow-up: PB readback wet/dry fallback on unvalidated best-lap events
+- Classification: **both** (driver-visible PB condition routing correction + internal gate hardening).
+- In `LalaLaunch.cs` 500ms PB refresh path:
+  - condition-only PB readback now uses current `_isWetMode` whenever the best-lap event does not validate against the current accepted lap handoff (`lapValidForPb == false`),
+  - validated best-lap events continue using accepted-lap wet latch for write/read consistency.
+- Prevents stale-latch dry/wet routing from publishing PB seconds from the wrong surface condition around tight timing gates and restore windows.
+
 ### 2026-04-22 — Wet lap-time / wet PB persistence write-path audit follow-up
 - Classification: **both** (driver-visible wet persistence correction + internal routing gate hardening).
 - Hardened accepted-lap wet/dry routing consistency in `LalaLaunch.cs`:

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,16 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-22 — Wet lap-time / wet PB persistence write-path audit follow-up
+- Classification: **both** (driver-visible wet persistence correction + internal routing gate hardening).
+- Hardened accepted-lap wet/dry routing consistency in `LalaLaunch.cs`:
+  - latched accepted-lap wet mode and reused it for downstream PB write-path gating (`TryUpdatePBByCondition(...)`) and condition-only PB readback.
+  - broadened wet tyre detection to treat positive `PlayerTireCompound` values as wet (`>0`) so wet-mode routing does not silently stay dry when telemetry uses non-zero wet compound variants.
+- Fixed pace persistence coupling:
+  - moved profile avg-lap (`AvgLapTimeDry/Wet`) persistence to the pace-accepted path instead of the fuel-accepted path, restoring wet lap-time persistence/feed when fuel delta validation rejects a lap.
+- Fixed wet PB relearn-after-clear acceptance:
+  - `TryUpdatePBByCondition(...)` now treats cleared/non-positive baseline PB values as unavailable so first valid wet PB candidate can persist after a clear.
+
 ### 2026-04-22 — PreRace follow-up: explicit one-stop pit-refill feasibility helper
 - Classification: **internal-only** (code-path clarity/refactor; one-stop status behavior unchanged).
 - Added `IsOneStopFeasibleForPreRace(...)` in `LalaLaunch.cs` so one-stop feasibility is explicitly evaluated against pit-stop refill capacity (effective tank at stop) and second-stint fuel demand (`total needed - start fuel`).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,9 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- PR follow-up fixed PB condition-only readback fallback in 500ms best-lap refresh path:
+  - when a best-lap event cannot be validated against the current accepted-lap handoff, condition-only PB readback now uses live `_isWetMode` instead of stale `_lastValidLapWasWet`;
+  - validated events continue to use accepted-lap wet latch, preserving write/read consistency on accepted laps.
 - Wet lap-time / wet PB persistence write-path audit follow-up:
   - accepted-lap wet/dry routing is now latched through downstream PB write/readback gating, preventing condition drift between lap validation and PB persistence;
   - wet tyre routing now treats positive native `PlayerTireCompound` values as wet (`>0`) to avoid false-dry routing on non-zero wet compound variants;
@@ -530,6 +533,12 @@ Branch: work
 - `LalaLaunch.cs`
 - `Docs/Subsystems/LapRef.md`
 - `Docs/Internal/SimHubParameterInventory.md`
+- `Docs/Internal/Development_Changelog.md`
+- `Docs/RepoStatus.md`
+
+### Changed in PR follow-up: PB readback wet/dry fallback on unvalidated best-lap events
+- `LalaLaunch.cs`
+- `Docs/Subsystems/Profiles_And_PB.md`
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,11 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- Wet lap-time / wet PB persistence write-path audit follow-up:
+  - accepted-lap wet/dry routing is now latched through downstream PB write/readback gating, preventing condition drift between lap validation and PB persistence;
+  - wet tyre routing now treats positive native `PlayerTireCompound` values as wet (`>0`) to avoid false-dry routing on non-zero wet compound variants;
+  - profile avg-lap persistence (`AvgLapTimeDry/Wet`) now follows pace-accepted laps directly (no longer blocked by fuel-accepted gate), restoring wet lap-time feed for Strategy/Profile consumers;
+  - PB write gating now treats cleared non-positive baseline values as unavailable, allowing first valid wet PB relearn lap to persist after clear.
 - PreRace follow-up clarified one-stop feasibility ownership in code:
   - introduced explicit helper `IsOneStopFeasibleForPreRace(...)` for one-stop gate evaluation,
   - helper evaluates one-stop against pit-stop refill capacity plus second-stint fuel demand (`total needed - start fuel`),

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -1,7 +1,7 @@
 # Fuel Model
 
 Validated against commit: HEAD
-Last updated: 2026-04-21
+Last updated: 2026-04-22
 Branch: work
 
 ## Purpose
@@ -97,6 +97,7 @@ Common reject cases include:
 - deltas that fall too far outside the saved profile baseline when a baseline exists.
 
 Wet/dry mode does **not** change the validity rules; it only decides which condition window receives an accepted sample.
+For persistence routing, lap condition is latched at accepted-lap time so downstream profile/PB writes use the same wet/dry value even if live tyre signal changes later in the tick.
 
 ### 2) Rolling window maintenance
 Accepted samples are inserted into the active condition window.
@@ -105,6 +106,7 @@ The subsystem then:
 - updates min/max guidance values,
 - refreshes session max-burn state inside guarded bounds,
 - protects newly seeded values until enough fresh live data exists.
+- pace/avg-lap persistence is driven by **pace-accepted laps** (not gated behind fuel-sample acceptance), so valid wet pace can continue feeding Strategy/Profile lap-time data even when a lap's fuel delta is rejected.
 
 ### 3) Stable burn selection
 The runtime chooses a stable burn candidate from:

--- a/Docs/Subsystems/Profiles_And_PB.md
+++ b/Docs/Subsystems/Profiles_And_PB.md
@@ -68,6 +68,7 @@ PB laps are captured when:
 
 PB metadata (source + timestamp) is stored separately for dry and wet laps. The **active condition** (dry vs wet) is driven by live wet-mode detection (tyre compound), so PB capture always aligns to the current surface mode.
 PB write gating treats `0`/non-positive cleared PB values as unavailable (same as `null`) so first valid relearn lap after a clear can persist.
+When periodic best-lap polling cannot validate the event against the current accepted lap, condition-only PB readback falls back to current live wet mode (instead of stale accepted-lap wet latch) so downstream PB seconds stay aligned with actual active surface mode.
 When a PB update includes real sector values, condition-specific PB sector fields are persisted alongside the lap time. Missing sectors remain null and are never synthesized.
 
 ---

--- a/Docs/Subsystems/Profiles_And_PB.md
+++ b/Docs/Subsystems/Profiles_And_PB.md
@@ -1,7 +1,7 @@
 # Profiles and Personal Bests
 
 Validated against commit: HEAD
-Last updated: 2026-04-21
+Last updated: 2026-04-22
 Branch: work
 
 ## Purpose
@@ -67,6 +67,7 @@ PB laps are captured when:
 - PB values are telemetry-owned in Profiles; the PB display is read-only in the Profiles workflow (no manual PB editing path).
 
 PB metadata (source + timestamp) is stored separately for dry and wet laps. The **active condition** (dry vs wet) is driven by live wet-mode detection (tyre compound), so PB capture always aligns to the current surface mode.
+PB write gating treats `0`/non-positive cleared PB values as unavailable (same as `null`) so first valid relearn lap after a clear can persist.
 When a PB update includes real sector values, condition-specific PB sector fields are persisted alongside the lap time. Missing sectors remain null and are never synthesized.
 
 ---

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -7629,7 +7629,8 @@ namespace LaunchPlugin
 
                     var activeTrackStats = ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackKey)
                         ?? ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackName);
-                    int? selectedPbMs = activeTrackStats?.GetConditionOnlyBestLapMs(lapWasWetForPb);
+                    bool pbReadWetMode = lapValidForPb ? lapWasWetForPb : _isWetMode;
+                    int? selectedPbMs = activeTrackStats?.GetConditionOnlyBestLapMs(pbReadWetMode);
                     double selectedPbSeconds = selectedPbMs.HasValue ? selectedPbMs.Value / 1000.0 : 0.0;
                     FuelCalculator?.SetPersonalBestSeconds(selectedPbSeconds);
                 }

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -648,6 +648,7 @@ namespace LaunchPlugin
         private bool _msgV1InfoLogged = false;
         private int _lastValidLapMs = 0;
         private int _lastValidLapNumber = -1;
+        private bool _lastValidLapWasWet = false;
         private int?[] _lastValidatedLapRefSectorMs;
         private bool? _lastIsWetTyres = null;
 
@@ -2219,6 +2220,7 @@ namespace LaunchPlugin
             _minWetFuelPerLap = 0.0;
             _lastValidLapMs = 0;
             _lastValidLapNumber = -1;
+            _lastValidLapWasWet = false;
             _wetFuelPersistLogged = false;
             _dryFuelPersistLogged = false;
             _msgV1InfoLogged = false;
@@ -2949,6 +2951,8 @@ namespace LaunchPlugin
                         paceDeltaForLog = lastLapSec - paceBaselineForLog;
                     }
 
+                    bool lapConditionWet = _isWetMode;
+
                     double fuelUsed = (_lapStartFuel > 0 && currentFuel >= 0)
                         ? (_lapStartFuel - currentFuel)
                         : 0.0;
@@ -3055,7 +3059,7 @@ namespace LaunchPlugin
                         if (!fuelRejected)
                         {
                             var (baselineDry, baselineWet) = GetProfileFuelBaselines();
-                            double baseline = _isWetMode ? baselineWet : baselineDry;
+                            double baseline = lapConditionWet ? baselineWet : baselineDry;
 
                             if (baseline > 0.0)
                             {
@@ -3074,7 +3078,7 @@ namespace LaunchPlugin
                             : (string.IsNullOrEmpty(fuelRejectReason) ? "rejected" : fuelRejectReason);
                     }
 
-                    bool recordWetFuel = fuelAccepted && _isWetMode;
+                    bool recordWetFuel = fuelAccepted && lapConditionWet;
                     bool recordPaceForStats = paceAccepted;
                     bool recordFuelForStats = fuelAccepted;
 
@@ -3085,6 +3089,7 @@ namespace LaunchPlugin
                         double pbGateLapSec = IsValidCarSaLapTimeSec(lapRefAuthoritativeLapSec) ? lapRefAuthoritativeLapSec : lastLapSec;
                         _lastValidLapMs = (int)Math.Round(pbGateLapSec * 1000.0);
                         _lastValidLapNumber = completedLapsNow;
+                        _lastValidLapWasWet = lapConditionWet;
                     }
 
                     if (recordPaceForStats)
@@ -3235,7 +3240,7 @@ namespace LaunchPlugin
                                 ?? ActiveProfile.ResolveTrackByNameOrKey(CurrentTrackName);
                             if (trackRecord != null)
                             {
-                                if (_isWetMode)
+                                if (lapConditionWet)
                                 {
                                     trackRecord.WetFuelSampleCount = _validWetLaps;
 
@@ -3276,60 +3281,69 @@ namespace LaunchPlugin
                                     }
                                 }
 
-                                int paceSamples = _recentLapTimes.Count;
-                                if (_isWetMode)
-                                {
-                                    trackRecord.WetLapTimeSampleCount = paceSamples;
-                                }
-                                else
-                                {
-                                    trackRecord.DryLapTimeSampleCount = paceSamples;
-                                }
+                            }
+                        }
+                    }
 
-                                bool persistedAvgLap = false;
-                                int persistedMs = 0;
-                                if (paceSamples >= FuelPersistMinLaps && Pace_StintAvgLapTimeSec > 0)
+                    if (recordPaceForStats && ActiveProfile != null)
+                    {
+                        var trackRecord = ActiveProfile.FindTrack(CurrentTrackKey)
+                            ?? ActiveProfile.ResolveTrackByNameOrKey(CurrentTrackName);
+                        if (trackRecord != null)
+                        {
+                            int paceSamples = _recentLapTimes.Count;
+                            if (lapConditionWet)
+                            {
+                                trackRecord.WetLapTimeSampleCount = paceSamples;
+                            }
+                            else
+                            {
+                                trackRecord.DryLapTimeSampleCount = paceSamples;
+                            }
+
+                            bool persistedAvgLap = false;
+                            int persistedMs = 0;
+                            if (paceSamples >= FuelPersistMinLaps && Pace_StintAvgLapTimeSec > 0)
+                            {
+                                int ms = (int)Math.Round(Pace_StintAvgLapTimeSec * 1000.0);
+                                if (ms > 0)
                                 {
-                                    int ms = (int)Math.Round(Pace_StintAvgLapTimeSec * 1000.0);
-                                    if (ms > 0)
+                                    if (lapConditionWet)
                                     {
-                                        if (_isWetMode)
+                                        if (!trackRecord.WetConditionsLocked)
                                         {
-                                            if (!trackRecord.WetConditionsLocked)
-                                            {
-                                                trackRecord.AvgLapTimeWet = ms;
-                                                trackRecord.MarkAvgLapUpdatedWet("Telemetry");
-                                                persistedAvgLap = true;
-                                                persistedMs = ms;
-                                            }
+                                            trackRecord.AvgLapTimeWet = ms;
+                                            trackRecord.MarkAvgLapUpdatedWet("Telemetry");
+                                            persistedAvgLap = true;
+                                            persistedMs = ms;
                                         }
-                                        else
+                                    }
+                                    else
+                                    {
+                                        if (!trackRecord.DryConditionsLocked)
                                         {
-                                            if (!trackRecord.DryConditionsLocked)
-                                            {
-                                                trackRecord.AvgLapTimeDry = ms;
-                                                trackRecord.MarkAvgLapUpdatedDry("Telemetry");
-                                                persistedAvgLap = true;
-                                                persistedMs = ms;
-                                            }
+                                            trackRecord.AvgLapTimeDry = ms;
+                                            trackRecord.MarkAvgLapUpdatedDry("Telemetry");
+                                            persistedAvgLap = true;
+                                            persistedMs = ms;
                                         }
                                     }
                                 }
+                            }
 
-                                if (persistedAvgLap)
-                                {
-                                    ProfilesViewModel?.SaveProfiles();
-                                    string trackLabel = !string.IsNullOrWhiteSpace(trackRecord.DisplayName)
-                                        ? trackRecord.DisplayName
-                                        : (!string.IsNullOrWhiteSpace(CurrentTrackName) ? CurrentTrackName : trackRecord.Key ?? "(unknown track)");
-                                    string carLabel = ActiveProfile?.ProfileName ?? "(unknown car)";
-                                    string modeLabel = _isWetMode ? "Wet" : "Dry";
-                                    bool locked = _isWetMode ? trackRecord.WetConditionsLocked : trackRecord.DryConditionsLocked;
-                                    string lapText = trackRecord.MillisecondsToLapTimeString(persistedMs);
-                                    SimHub.Logging.Current.Info(
-                                        $"[LalaPlugin:Profile/Pace] Persisted AvgLapTime{modeLabel} for {carLabel} @ {trackLabel}: " +
-                                        $"{lapText} ({persistedMs} ms), samples={paceSamples}, locked={locked}");
-                                }
+                            if (persistedAvgLap)
+                            {
+                                ProfilesViewModel?.SaveProfiles();
+                                string trackLabel = !string.IsNullOrWhiteSpace(trackRecord.DisplayName)
+                                    ? trackRecord.DisplayName
+                                    : (!string.IsNullOrWhiteSpace(CurrentTrackName) ? CurrentTrackName : trackRecord.Key ?? "(unknown track)");
+                                string carLabel = ActiveProfile?.ProfileName ?? "(unknown car)";
+                                string modeLabel = lapConditionWet ? "Wet" : "Dry";
+                                bool locked = lapConditionWet ? trackRecord.WetConditionsLocked : trackRecord.DryConditionsLocked;
+                                string lapText = trackRecord.MillisecondsToLapTimeString(persistedMs);
+                                SimHub.Logging.Current.Info(
+                                    $"[LalaPlugin:Profile/Pace] Persisted AvgLapTime{modeLabel} for {carLabel} @ {trackLabel}: " +
+                                    $"{lapText} ({persistedMs} ms), samples={paceSamples}, locked={locked}");
                             }
                         }
                     }
@@ -3357,7 +3371,7 @@ namespace LaunchPlugin
                         fuelUsed,
                         recordFuelForStats,
                         fuelReason,
-                        _isWetMode,
+                        lapConditionWet,
                         LiveFuelPerLap,
                         _validDryLaps,
                         _validWetLaps,
@@ -6692,6 +6706,7 @@ namespace LaunchPlugin
             _lastAnnouncedMaxFuel = -1;
             _lastValidLapMs = 0;
             _lastValidLapNumber = -1;
+            _lastValidLapWasWet = false;
             _lastValidatedLapRefSectorMs = null;
             _wetFuelPersistLogged = false;
             _dryFuelPersistLogged = false;
@@ -7596,11 +7611,12 @@ namespace LaunchPlugin
                     int lapMs = (int)Math.Round(currentBestLap.TotalMilliseconds);
                     int completedLapsNow = Convert.ToInt32(data.NewData?.CompletedLaps ?? 0);
                     bool lapValidForPb = _lastValidLapNumber == completedLapsNow && Math.Abs(_lastValidLapMs - lapMs) <= 2;
+                    bool lapWasWetForPb = _lastValidLapWasWet;
 
                     bool accepted = false;
                     if (lapValidForPb)
                     {
-                        accepted = ProfilesViewModel.TryUpdatePBByCondition(CurrentCarModel, CurrentTrackKey, lapMs, _isWetMode, _lastValidatedLapRefSectorMs);
+                        accepted = ProfilesViewModel.TryUpdatePBByCondition(CurrentCarModel, CurrentTrackKey, lapMs, lapWasWetForPb, _lastValidatedLapRefSectorMs);
                         string pbLog = $"[LalaPlugin:Pace] candidate={lapMs}ms car='{CurrentCarModel}' trackKey='{CurrentTrackKey}' -> {(accepted ? "accepted" : "rejected")}";
                         if (accepted)
                             SimHub.Logging.Current.Info(pbLog);
@@ -7613,7 +7629,7 @@ namespace LaunchPlugin
 
                     var activeTrackStats = ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackKey)
                         ?? ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackName);
-                    int? selectedPbMs = activeTrackStats?.GetConditionOnlyBestLapMs(_isWetMode);
+                    int? selectedPbMs = activeTrackStats?.GetConditionOnlyBestLapMs(lapWasWetForPb);
                     double selectedPbSeconds = selectedPbMs.HasValue ? selectedPbMs.Value / 1000.0 : 0.0;
                     FuelCalculator?.SetPersonalBestSeconds(selectedPbSeconds);
                 }
@@ -15811,7 +15827,7 @@ namespace LaunchPlugin
             {
                 playerTireCompoundRaw = playerCompound.Value;
                 source = "PlayerTireCompound";
-                return playerCompound.Value == 1;
+                return playerCompound.Value > 0;
             }
 
             // No fallback path; legacy iRacingExtraProperties tyre-compound source is removed.

--- a/ProfilesManagerViewModel.cs
+++ b/ProfilesManagerViewModel.cs
@@ -124,6 +124,10 @@ namespace LaunchPlugin
             int? baselineMs = isWetEffective
                 ? ts.BestLapMsWet
                 : ts.BestLapMsDry;
+            if (baselineMs.HasValue && baselineMs.Value <= 0)
+            {
+                baselineMs = null;
+            }
 
             bool improved = !baselineMs.HasValue || lapMs <= baselineMs.Value - PB_IMPROVE_MS;
             if (!improved)


### PR DESCRIPTION
### Motivation
- Wet lap-times and wet PBs were not persisting or feeding Strategy/LapRef correctly because live tyre-mode and persistence gating could drift between lap acceptance and downstream writes.
- Clearing PBs then running wet laps did not persist a new wet PB because cleared/non-positive PB baselines were treated as valid, blocking the first relearn.
- Avg-lap persistence was coupled to fuel-acceptance, so pace-valid wet laps could fail to surface to Profile/Strategy when the fuel delta gate rejected the same lap.

### Description
- Latched accepted-lap condition: at lap acceptance the wet/dry condition is latched and reused for all downstream persistence and PB readback paths so condition routing is consistent end-to-end (changes primarily in `LalaLaunch.cs`).
- Pace vs fuel decoupling: moved avg-lap persistence (`AvgLapTimeDry/Wet`) onto the pace-accepted path so valid pace can update profile/strategy even when fuel validation rejects the lap (`LalaLaunch.cs`).
- Hardened wet detection: `TryReadIsWetTyres(...)` now treats any positive native `PlayerTireCompound` value as wet (`>0`) to avoid false-dry routing on non-standard non-zero variants (`LalaLaunch.cs`).
- PB write gating: `TryUpdatePBByCondition(...)` now treats cleared/non-positive baseline PB values as unavailable so a first valid relearn after clear is allowed (`ProfilesManagerViewModel.cs`).
- Documentation and changelog: updated subsystem docs and internal changelog to reflect the behavior change and rationale (`Docs/Subsystems/Fuel_Model.md`, `Docs/Subsystems/Profiles_And_PB.md`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`).

### Testing
- Attempted automated build: `dotnet build LaunchPlugin.sln` was run in the environment and could not be executed because `dotnet` is not installed here, so a compile verification could not be completed (environment limitation).
- No further automated tests were available in this environment; recommend running `dotnet build LaunchPlugin.sln` and a live replay/live session smoke check to verify: wet lap feed to Strategy/Live Snapshot, wet avg persistence after FuelPersistMinLaps, and wet PB write-after-clear behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e816d78d40832fb1c6a2dd8678b012)