### PR TITLE
Follow-up: fix max-fill feedback detection for fractional tank space

### DIFF
--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -423,8 +423,7 @@ namespace LaunchPlugin
             }
 
             int requestedSafe = Math.Max(0, requestedLitres);
-            int availableSpaceRoundedUp = RoundUpLitres(snapshot.TankSpaceLitres);
-            return requestedSafe > availableSpaceRoundedUp;
+            return requestedSafe > snapshot.TankSpaceLitres;
         }
 
         private void RefreshDerivedState()


### PR DESCRIPTION
### Motivation
- Ensure max-fill feedback (`FUEL MAX`) is shown when a requested litres value exceeds the actual available tank space even if the available space is fractional (e.g., request 25L vs 24.2L available), and keep this change strictly feedback-only.

### Description
- Update `IsMaxStyleFeedbackRequest(...)` in `PitFuelControlEngine.cs` to compare `requestedLitres` against the raw `snapshot.TankSpaceLitres` (double) instead of `RoundUpLitres(snapshot.TankSpaceLitres)`, so fractional-space cases are detected as max-style requests; transport/send behavior is unchanged.

### Testing
- Attempted `dotnet build -v minimal`, but the `dotnet` CLI is not available in this environment (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87b991668832fa1be178747caaa6c)