### PR TITLE
Docs: v1.1 release sweep and new Pit Commands subsystem doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ For internal between-release development history, see `Docs/Internal/Development
 ## v1.1 (Unreleased)
 
 ### Added
-- Added a new **Overview** top-level plugin tab as a landing/front-door page with quick links, lightweight status, release-check awareness, and dashboard preview placeholders.
+- **Overview tab** as the plugin front door for quick links, release-check visibility, and at-a-glance status.
+- **Plugin-owned pit/custom command workflow** with built-in pit actions, custom-message slots, and in-plugin transport selection.
+- **Pit Fuel Control + Tyre Control** command surfaces for dashboard/hardware bindings (`LalaLaunch.Pit.FuelControl.*`, `LalaLaunch.Pit.TyreControl.*`).
+- **ClassBest export family** for class session-best holder visibility on dashboards.
 
 ### Changed
-- _No public release notes staged yet._
+- **Strategy/PreRace status logic** refreshed with scenario-first outcomes and clearer status colors/text for no-stop, one-stop, and multi-stop contexts.
+- **Pit command transport behavior** now defaults to direct window-message delivery with bounded legacy fallback options.
+- **Pit Fuel Control behavior** refined so AUTO ownership/cancel behavior is clearer and non-AUTO OFF/MAN follows iRacing MFD fuel-enable truth.
+- **Dashboard/navigation documentation** and Overview-first workflow guidance were aligned across user docs.
 
 ### Fixed
-- _No public release notes staged yet._
+- Corrected one-stop feasibility checks to use pit-stop refill capacity rather than start-of-race free tank space.
+- Fixed wet/dry PB and pace persistence routing edge cases around lap-validation timing and wet-compound detection.
+- Hardened pit/custom command observability and confirmation wording so attempted transport is not shown as guaranteed in-sim effect.
 
 ## v1.0 – Initial Public Release
 

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,18 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-22 — v1.1 documentation sweep (release-prep, no code changes)
+- Classification: **both** (public release-note/doc refresh + internal canonical-doc map alignment).
+- Refreshed root `CHANGELOG.md` unreleased `v1.1` section so staged release notes are complete, concise, and quickly scannable for users.
+- Reviewed and updated core user docs:
+  - `Docs/User_Guide.md` pit/custom command section now points explicitly to the user-facing and subsystem-owning pit command docs.
+  - `Docs/Quick_Start.md` pit setup section now includes direct links for full usage + technical ownership references.
+- Added canonical subsystem documentation for the combined pit command stack:
+  - new `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md` covering built-in pit actions, custom messages, transport semantics, Pit Fuel Control ownership, and Tyre Control ownership.
+- Updated index/status alignment:
+  - added the new subsystem doc to `Docs/Project_Index.md`,
+  - recorded the sweep in `Docs/RepoStatus.md`.
+
 ### 2026-04-22 — Pit Fuel Control v2 redesign (AUTO-owned + MFD-derived OFF/MAN + edge-trigger external cancel)
 - Classification: **both** (driver-visible pit-fuel workflow contract change + internal ownership/cancel seam redesign).
 - Reworked `PitFuelControlEngine` mode ownership contract:

--- a/Docs/Pit_Assist.md
+++ b/Docs/Pit_Assist.md
@@ -41,6 +41,8 @@ Trust pit popups most when your pit data is good. That usually means:
 
 Pit command buttons should now be bound to plugin-owned Controls & Events actions:
 
+Technical contract note: this page is driver-facing usage guidance. The canonical subsystem ownership/exports/log contract for pit/custom commands + fuel/tyre control lives in [Docs/Subsystems/Pit_Commands_And_Fuel_Control.md](Subsystems/Pit_Commands_And_Fuel_Control.md).
+
 - `LalaLaunch.Pit.ClearAll`
 - `LalaLaunch.Pit.ClearTires`
 - `LalaLaunch.Pit.ToggleFuel`

--- a/Docs/Project_Index.md
+++ b/Docs/Project_Index.md
@@ -1,7 +1,7 @@
 # Project Index
 
 Validated against commit: HEAD
-Last updated: 2026-04-09
+Last updated: 2026-04-22
 Branch: work
 
 ## What this repo is
@@ -44,6 +44,7 @@ These pages are the technical/canonical subsystem layer. They explain internal o
 - [Subsystems/Launch_Mode.md](Subsystems/Launch_Mode.md)
 - [Subsystems/Shift_Assist.md](Subsystems/Shift_Assist.md)
 - [Subsystems/Pit_Timing_And_PitLoss.md](Subsystems/Pit_Timing_And_PitLoss.md)
+- [Subsystems/Pit_Commands_And_Fuel_Control.md](Subsystems/Pit_Commands_And_Fuel_Control.md)
 - [Subsystems/Pit_Entry_Assist.md](Subsystems/Pit_Entry_Assist.md)
 - [Subsystems/Rejoin_Assist.md](Subsystems/Rejoin_Assist.md)
 - [Subsystems/Opponents.md](Subsystems/Opponents.md)

--- a/Docs/Quick_Start.md
+++ b/Docs/Quick_Start.md
@@ -112,6 +112,7 @@ For a new car/track combination:
 - Transport mode is configurable in **Settings → Pit Commands** (`Auto` direct-message then fallback, `Legacy foreground SendInput only`, `Direct message only`).
 - Auto-focus is not implemented yet (preview setting only).
 - Transport truth: stateful built-in toggles use telemetry before/after confirmation; custom/raw/stateless sends are logged as attempted with unverified delivery (no duplicate-send retry after queued direct-message success).
+- For complete pit/custom command usage guidance, see [Pit Assist](Pit_Assist.md). For technical export/action ownership, see [Subsystems/Pit_Commands_And_Fuel_Control.md](Subsystems/Pit_Commands_And_Fuel_Control.md).
 
 ### Dash navigation quick setup
 

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,11 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-22 docs sweep for v1.1 release prep completed:
+  - refreshed root `CHANGELOG.md` unreleased `v1.1` notes to be concise and user-facing,
+  - reviewed and refreshed `Docs/User_Guide.md` and `Docs/Quick_Start.md` pit/custom command guidance links,
+  - added canonical subsystem contract doc `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md` to capture combined pit command + fuel/tyre control ownership,
+  - updated `Docs/Project_Index.md` subsystem map to include the new pit command subsystem doc.
 - Pit Fuel Control v2 redesign landed (AUTO plugin-owned, OFF/MAN MFD-derived truth):
   - effective `Pit.FuelControl.Mode` now derives from iRacing MFD fuel-enable truth (`dpFuelFill`) whenever plugin AUTO is not active (`OFF` when unchecked, `MAN` when checked);
   - AUTO cancel no longer uses mismatch/baseline comparison and is now edge-triggered on external changes to either requested fuel (`PitSvFuel`) or fuel-enable (`dpFuelFill`);

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -1,0 +1,103 @@
+# Pit Commands and Fuel/Tyre Control
+
+Validated against commit: HEAD
+Last updated: 2026-04-22
+Branch: work
+
+## Purpose
+This subsystem owns plugin-driven pit-lane command dispatch and command-state surfaces used by dashboards and hardware bindings.
+
+It combines:
+- built-in pit command actions (`LalaLaunch.Pit.*`),
+- custom message actions (`LalaLaunch.CustomMessage01..10`),
+- Pit Fuel Control (`LalaLaunch.Pit.FuelControl.*` + `Pit.FuelControl.*` exports),
+- Tyre Control (`LalaLaunch.Pit.TyreControl.*` + `Pit.TyreControl.*` exports),
+- short-lived command feedback exports (`Pit.Command.*`).
+
+This is the canonical technical document for the pit/custom command stack and replaces ad-hoc split references across unrelated subsystem pages.
+
+## Inputs (source + cadence)
+- Driver actions from SimHub Controls & Events / dash touch bindings.
+- Live telemetry/state confirmation inputs used by stateful pit toggles (fuel/tyres/repair/auto-fuel).
+- iRacing process/window availability for transport selection.
+- Pit telemetry seams used by fuel-control ownership/cancel logic:
+  - requested pit fuel (`PitSvFuel`),
+  - MFD fuel-enable truth (`dpFuelFill`),
+  - iRacing AutoFuel state,
+  - `Telemetry.IsOnTrackCar` lifecycle edges.
+- Declared wetness + tyre-related telemetry for Tyre Control AUTO mode.
+
+## Internal state
+### Command transport state
+- Selected transport mode (`Auto`, `Legacy foreground SendInput only`, `Direct message only`).
+- Direct-path sequencing state used to avoid unsafe duplicate-open/double-send fallback behavior.
+- Last action/raw command strings for bounded diagnostics (`Pit.Command.LastAction`, `Pit.Command.LastRaw`).
+
+### Feedback state
+- Short-lived command feedback text/active latch (`Pit.Command.DisplayText`, `Pit.Command.Active`).
+- Stateful-toggle before/after verification status (effect-confirmed vs attempted-only).
+
+### Pit Fuel Control state
+- Source state (`STBY`/runtime modes) and AUTO arming semantics.
+- Mode state where AUTO is plugin-owned; non-AUTO mode mirrors MFD truth (`OFF`/`MAN` from `dpFuelFill`).
+- Target litres and override-active semantics for command generation.
+
+### Tyre Control state
+- Mode state machine: `OFF -> DRY -> WET -> AUTO -> OFF`.
+- Retry/cooldown bookkeeping for compound sends.
+- Service-state enforcement seam aligned to all-four tyre selection truth.
+
+## Calculation blocks (high level)
+1. Receive an action from plugin-owned binding surface.
+2. Resolve built-in pit/custom/fuel-control/tyre-control command intent.
+3. Dispatch via selected transport mode:
+   - Auto: direct-message first, bounded fallback where safe.
+   - Legacy: foreground-only SendInput.
+   - Direct-only: no fallback.
+4. Publish feedback + diagnostics:
+   - stateful built-ins use effect confirmation when available,
+   - custom/raw/stateless built-ins are transport-attempt only.
+5. Maintain Pit Fuel Control ownership rules:
+   - AUTO can cancel on external requested-fuel or MFD-enable edges,
+   - lifecycle resets (`IsOnTrackCar` edges, iRacing AutoFuel ownership, offline suppression) force inert/disarmed safety state.
+6. Maintain Tyre Control enforcement:
+   - OFF forces service off,
+   - DRY/WET/AUTO keep service on and drive compound request semantics,
+   - AUTO follows declared wetness.
+
+## Outputs (exports + logs)
+Canonical export names live in `Docs/Internal/SimHubParameterInventory.md`; key families:
+- `Pit.Command.*` (display text, active, last action/raw, max-toggle state),
+- `Pit.FuelControl.*` (source, mode, target, override),
+- `Pit.TyreControl.*` (mode text/state).
+
+Canonical log wording and meaning live in `Docs/Internal/SimHubLogMessages.md`; key themes:
+- transport mode/attempt path (`postmessage` vs `sendinput`),
+- fallback reason context and suppression cases,
+- effect-confirmed vs unverified delivery semantics,
+- tyre compound attempt/retry diagnostics.
+
+## Dependencies / ordering assumptions
+- This subsystem owns transport + command dispatch and must remain the only authority for pit/custom command sends.
+- Dashboards are consumers only; they should bind plugin actions and read exports, not reimplement command logic.
+- Fuel planner/runtime fuel math remains outside this subsystem; pit command/fuel-control uses those outputs but does not redefine fuel model behavior.
+
+## Reset rules
+- `Telemetry.IsOnTrackCar` edge transitions reset Pit Fuel Control ownership state and Tyre Control mode to safe defaults.
+- Session/lifecycle reset seams clear short-lived command feedback and stale command state.
+- External ownership events (for example iRacing AutoFuel) force Pit Fuel Control to inert/disarmed state.
+
+## Failure modes / edge cases
+- No usable iRacing process/window: command send attempt fails and feedback/log surfaces should make this visible.
+- Direct transport partial-state uncertainty: Auto mode suppresses unsafe fallback on that press to avoid duplicate corruption.
+- Transport success for custom/raw/stateless commands is attempt-only; in-sim effect is unverified by design.
+- Tyre compound send failure paths are bounded by retry/cooldown budget to avoid per-tick resend spam.
+- External pit-menu edits can cancel AUTO once and force safety recovery state in fuel control.
+
+## Test checklist
+- Bind and press representative built-in pit actions from SimHub Controls & Events.
+- Validate transport mode behavior in each mode (`Auto`, `Legacy`, `Direct only`) with logs.
+- Confirm stateful toggle actions show effect-confirmed semantics and custom/raw actions stay unverified semantics.
+- Confirm Pit Fuel Control AUTO cancel triggers on external fuel request and MFD enable changes.
+- Confirm Tyre Control mode cycle order and AUTO wet/dry switching follow declared-wet authority.
+- Confirm `IsOnTrackCar` edges reset fuel/tyre control states to safe defaults.

--- a/Docs/User_Guide.md
+++ b/Docs/User_Guide.md
@@ -163,6 +163,7 @@ Lala Race Assist Plugin includes separate driver-facing pages for recovery/rejoi
   - `Direct message only` disables fallback.
 - Auto-focus is not implemented yet (preview setting only).
 - Confirmation semantics: stateful built-in pit toggles are effect-confirmed via before/after telemetry; custom messages, raw commands, and stateless built-ins are transport-attempt only (delivery unverified).
+- For the full driver workflow, use [Pit Assist](Pit_Assist.md). For canonical technical ownership/exports, use [Subsystems/Pit_Commands_And_Fuel_Control.md](Subsystems/Pit_Commands_And_Fuel_Control.md).
 
 ### H2H
 


### PR DESCRIPTION
### Motivation
- Prepare a concise, user-facing `v1.1` release note and align core documentation for the upcoming release. 
- Consolidate and document the plugin-owned pit/custom-command, fuel-control, and tyre-control behaviour into a single canonical subsystem doc for clarity and maintenance. 
- Ensure user-facing guides and the project index point to the authoritative technical contract so dashboards and bindings use the documented actions/exports. 

### Description
- Updated the root `CHANGELOG.md` `v1.1 (Unreleased)` section with concise Added / Changed / Fixed bullets that reflect recent pit, PreRace, and dashboard improvements. 
- Added `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md` as the canonical subsystem document covering built-in pit actions, custom messages, transport modes, Pit Fuel Control ownership, Tyre Control semantics, exports, resets, failure modes, and a test checklist. 
- Updated `Docs/Project_Index.md` to include the new subsystem doc and refreshed the index metadata date. 
- Linked the new subsystem doc from driver-facing pages by updating `Docs/User_Guide.md`, `Docs/Quick_Start.md`, and `Docs/Pit_Assist.md`, and recorded the sweep in `Docs/RepoStatus.md` and `Docs/Internal/Development_Changelog.md`. 

### Testing
- Repository consistency checks (whitespace/conflict check) were run and passed. 
- Cross-document reference validation via repository search for the new `Pit_Commands_And_Fuel_Control` links was performed and found the updated docs referencing the new subsystem. 
- Local repository validations completed successfully and a PR metadata entry was produced to stage these documentation changes for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e924019588832fbb4ff02629702ed4)