### PR TITLE
Fix pit control regressions: remove blocking fuel toggle re-poll and restore tyre manual confirmation

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -39,8 +39,9 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
   - `Pit.ToggleFuel` already runs through `PitCommandEngine` stateful before/after confirmation for `dpFuelFill`.
   - The extra poll loop could falsely fail against stale snapshot cadence and made `ModeCycle` appear frozen on `OFF -> MAN`.
 - New behavior is now non-blocking at this seam:
-  - if `Pit.ToggleFuel` confirms success, fuel-mode transition accepts it immediately and preserves existing suppression/observed-state update behavior;
-  - if `Pit.ToggleFuel` fails confirmation, existing `Pit Cmd Fail` behavior remains unchanged.
+  - `TryToggleFuelFillEnabled(...)` now does one immediate post-send snapshot read with no wait loop and only returns success when telemetry `dpFuelFill` matches the expected toggle target;
+  - snapshot unavailable or post-send mismatch now returns failure so ModeCycle does not proceed on transport-attempt-only success;
+  - existing `Pit Cmd Fail` feedback semantics remain unchanged.
 
 ### 2026-04-23 — Tyre Control regression follow-up: restore manual confirmation window on mode changes
 - Classification: **both** (driver-visible tyre command-send restoration + internal manual-truth ordering fix).

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,22 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-23 — Pit Fuel Control regression follow-up: remove blocking OFF->MAN toggle re-poll loop
+- Classification: **both** (driver-visible ModeCycle responsiveness fix + internal control-loop safety hardening).
+- Updated `PitFuelControlEngine.TryToggleFuelFillEnabled(...)` to stop running a second blocking telemetry poll loop after `Pit.ToggleFuel`.
+  - `Pit.ToggleFuel` already runs through `PitCommandEngine` stateful before/after confirmation for `dpFuelFill`.
+  - The extra poll loop could falsely fail against stale snapshot cadence and made `ModeCycle` appear frozen on `OFF -> MAN`.
+- New behavior is now non-blocking at this seam:
+  - if `Pit.ToggleFuel` confirms success, fuel-mode transition accepts it immediately and preserves existing suppression/observed-state update behavior;
+  - if `Pit.ToggleFuel` fails confirmation, existing `Pit Cmd Fail` behavior remains unchanged.
+
+### 2026-04-23 — Tyre Control regression follow-up: restore manual confirmation window on mode changes
+- Classification: **both** (driver-visible tyre command-send restoration + internal manual-truth ordering fix).
+- Restored missing `BeginOrClearManualConfirmation(mode)` call in `PitTyreControlEngine.SetMode(...)`.
+  - Without this arming call, manual truth reconciliation could run immediately on the next telemetry tick and remap fresh manual mode selections (`DRY`/`WET`) back to stale current MFD truth before enforcement sends ran.
+  - Result was apparent control-engine no-op behavior: mode looked selected briefly but no tyre-service/compound send attempts landed.
+- With confirmation-window arming restored, mode-change sends now get their intended bounded confirmation window before external-truth fallback/remap logic is allowed to reclaim ownership.
+
 ### 2026-04-23 — Tyre Control PR review follow-up: complete AUTO intent match + unknown service-enforcement hold
 - Classification: **both** (driver-visible AUTO ownership correctness + internal enforcement gating hardening).
 - Hardened `PitTyreControlEngine.IsObservedTruthConvergingToPluginIntent(...)` so plugin-owned convergence requires a complete match across the full relevant pending intent set:

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,10 +9,14 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-23 PR review follow-up restored non-blocking post-toggle verification in `TryToggleFuelFillEnabled(...)`:
+  - `_fuelToggleSender()` transport-attempt success is no longer treated as confirmed toggle by itself;
+  - after successful send attempt, the engine now performs one immediate snapshot read and requires `dpFuelFill` to match expected ON/OFF before returning success;
+  - no wait/re-poll loops were reintroduced; snapshot unavailable/mismatch returns failure so `ModeCycle` does not advance on unconfirmed toggle.
 - Pit Fuel Control regression follow-up landed (`OFF -> MAN` ModeCycle freeze fix):
   - removed redundant blocking telemetry re-poll loop from `PitFuelControlEngine.TryToggleFuelFillEnabled(...)` after `Pit.ToggleFuel`;
   - `Pit.ToggleFuel` remains the authoritative state-confirmed toggle seam (before/after `dpFuelFill` check in `PitCommandEngine`);
-  - preserves existing suppression/baseline update behavior while preventing false `Pit Cmd Fail` caused by stale snapshot timing during `OFF -> MAN`.
+  - preserves existing non-blocking behavior while keeping toggle-result reporting aligned to immediate telemetry truth during `OFF -> MAN`.
 - Tyre Control regression follow-up landed (manual mode-change confirmation window restore):
   - restored `BeginOrClearManualConfirmation(mode)` arming in `PitTyreControlEngine.SetMode(...)`;
   - prevents immediate manual-truth reconciliation from remapping fresh manual mode selections to stale MFD truth before first enforcement send attempts;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,14 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- Pit Fuel Control regression follow-up landed (`OFF -> MAN` ModeCycle freeze fix):
+  - removed redundant blocking telemetry re-poll loop from `PitFuelControlEngine.TryToggleFuelFillEnabled(...)` after `Pit.ToggleFuel`;
+  - `Pit.ToggleFuel` remains the authoritative state-confirmed toggle seam (before/after `dpFuelFill` check in `PitCommandEngine`);
+  - preserves existing suppression/baseline update behavior while preventing false `Pit Cmd Fail` caused by stale snapshot timing during `OFF -> MAN`.
+- Tyre Control regression follow-up landed (manual mode-change confirmation window restore):
+  - restored `BeginOrClearManualConfirmation(mode)` arming in `PitTyreControlEngine.SetMode(...)`;
+  - prevents immediate manual-truth reconciliation from remapping fresh manual mode selections to stale MFD truth before first enforcement send attempts;
+  - restores expected tyre control-engine send attempts after `ModeCycle`/`SetDry`/`SetWet` manual actions while keeping existing bounded reconcile fallback behavior.
 - Tyre Control PR review follow-up landed (complete AUTO intent match + unknown service-enforcement hold):
   - AUTO plugin-owned delayed convergence now requires full relevant pending-intent agreement (`service` and `compound` when both are pending/relevant), preventing single-dimension matches from masking external/manual takeover;
   - tyre-service enforcement retries are now held while service truth is unknown/unavailable (`HasTireServiceSelection=false`), so telemetry gaps do not burn bounded retry budget;

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -46,6 +46,7 @@ This is the canonical technical document for the pit/custom command stack and re
 - Mode state machine: `OFF -> DRY -> WET -> AUTO -> OFF`.
 - Retry/cooldown bookkeeping for compound sends.
 - Service-state enforcement seam aligned to all-four tyre selection truth.
+- Manual mode-change confirmation window (`OFF`/`DRY`/`WET`) delays immediate external-truth remap long enough for first bounded enforcement send/confirmation pass.
 
 ## Calculation blocks (high level)
 1. Receive an action from plugin-owned binding surface.
@@ -95,6 +96,7 @@ Canonical log wording and meaning live in `Docs/Internal/SimHubLogMessages.md`; 
 - Tyre compound send failure paths are bounded by retry/cooldown budget to avoid per-tick resend spam.
 - External pit-menu edits can cancel AUTO once and force safety recovery state in fuel control.
 - AUTO exit (`AUTO -> OFF`) is guarded by live MFD truth (`dpFuelFill`): if fuel fill is already OFF, the engine must not send a fuel toggle and should only publish OFF state recovery (`Source=STBY`, AUTO cleared).
+- Fuel `OFF -> MAN` uses the existing `Pit.ToggleFuel` stateful confirmation seam and must not add a second blocking snapshot wait loop in the fuel-control engine.
 
 ## Test checklist
 - Bind and press representative built-in pit actions from SimHub Controls & Events.

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -96,7 +96,7 @@ Canonical log wording and meaning live in `Docs/Internal/SimHubLogMessages.md`; 
 - Tyre compound send failure paths are bounded by retry/cooldown budget to avoid per-tick resend spam.
 - External pit-menu edits can cancel AUTO once and force safety recovery state in fuel control.
 - AUTO exit (`AUTO -> OFF`) is guarded by live MFD truth (`dpFuelFill`): if fuel fill is already OFF, the engine must not send a fuel toggle and should only publish OFF state recovery (`Source=STBY`, AUTO cleared).
-- Fuel `OFF -> MAN` uses the existing `Pit.ToggleFuel` stateful confirmation seam and must not add a second blocking snapshot wait loop in the fuel-control engine.
+- Fuel `OFF -> MAN` toggle flow must stay non-blocking in `PitFuelControlEngine.TryToggleFuelFillEnabled(...)`: no wait/re-poll loops, but a single immediate post-send snapshot read must still verify `dpFuelFill` matches expected ON/OFF before reporting success.
 
 ## Test checklist
 - Bind and press representative built-in pit actions from SimHub Controls & Events.

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -721,17 +721,24 @@ namespace LaunchPlugin
                 return false;
             }
 
-            // ToggleFuel already uses PitCommandEngine state confirmation (before/after dpFuelFill).
-            // Re-polling snapshot telemetry here can stall ModeCycle and falsely fail when cache refresh
-            // cadence lags behind the validated toggle action result.
             if (!_fuelToggleSender())
             {
                 return false;
             }
 
-            _suppressManualOverrideUntilUtc = DateTime.UtcNow.AddMilliseconds(PluginSendSuppressionMs);
             var startSnapshot = _snapshotProvider();
+            if (startSnapshot == null)
+            {
+                return false;
+            }
+
             UpdateObservedExternalState(startSnapshot);
+            if (startSnapshot.TelemetryFuelFillEnabled != expectedEnabled)
+            {
+                return false;
+            }
+
+            _suppressManualOverrideUntilUtc = DateTime.UtcNow.AddMilliseconds(PluginSendSuppressionMs);
             return true;
         }
 

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 
 namespace LaunchPlugin
 {
@@ -722,6 +721,9 @@ namespace LaunchPlugin
                 return false;
             }
 
+            // ToggleFuel already uses PitCommandEngine state confirmation (before/after dpFuelFill).
+            // Re-polling snapshot telemetry here can stall ModeCycle and falsely fail when cache refresh
+            // cadence lags behind the validated toggle action result.
             if (!_fuelToggleSender())
             {
                 return false;
@@ -730,20 +732,7 @@ namespace LaunchPlugin
             _suppressManualOverrideUntilUtc = DateTime.UtcNow.AddMilliseconds(PluginSendSuppressionMs);
             var startSnapshot = _snapshotProvider();
             UpdateObservedExternalState(startSnapshot);
-
-            DateTime deadlineUtc = DateTime.UtcNow.AddMilliseconds(PluginSendSuppressionMs);
-            while (DateTime.UtcNow <= deadlineUtc)
-            {
-                var snapshot = _snapshotProvider();
-                if (snapshot != null && snapshot.TelemetryFuelFillEnabled == expectedEnabled)
-                {
-                    return true;
-                }
-
-                Thread.Sleep(60);
-            }
-
-            return false;
+            return true;
         }
 
         private static string SourceToText(PitFuelControlSource source)

--- a/PitTyreControlEngine.cs
+++ b/PitTyreControlEngine.cs
@@ -159,6 +159,7 @@ namespace LaunchPlugin
             Mode = mode;
             ResetAttemptState();
             ResetPendingPluginIntentState();
+            BeginOrClearManualConfirmation(mode);
             PublishSelectionFeedback(actionName, string.Format("TYRE CHANGE {0}", ModeToText(mode)));
         }
 


### PR DESCRIPTION
### Motivation
- Investigate and fix a regression that caused plugin-owned control-engine sends to appear to fail while built-in pit actions still worked. 
- Two concrete failure modes were identified: `ModeCycle` OFF->MAN for fuel appearing frozen due to a blocking re-poll, and tyre mode changes not issuing sends because manual confirmation arming was missing.

### Description
- Removed the redundant blocking re-poll loop from `PitFuelControlEngine.TryToggleFuelFillEnabled(...)` so the engine no longer waits again for telemetry after `Pit.ToggleFuel` and instead accepts the `PitCommandEngine`-confirmed toggle result immediately (file: `PitFuelControlEngine.cs`).
- Restored the manual confirmation arming call `BeginOrClearManualConfirmation(mode)` inside `PitTyreControlEngine.SetMode(...)` so manual tyre mode changes get a bounded confirmation window before external-truth reconciliation runs (file: `PitTyreControlEngine.cs`).
- Updated canonical docs and internal status to record the fixes and the intended behavior: `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.
- These fixes are narrow and caller-side (control-engine) corrections and do not change transport architecture, built-in pit action contracts, or the dispatch/fallback transport seams in `PitCommandEngine`.

### Testing
- Ran `git diff --check` to validate patch cleanliness and it succeeded.
- Attempted `dotnet build LaunchPlugin.csproj -v minimal` to compile the plugin but the environment lacks the .NET SDK so the build could not be executed (`dotnet` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97444df7c832f9f7e0ca860ae23bd)