### PR TITLE
Harden PB persistence and make LapRef SessionBest handoff immediate

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,18 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-23 — LapRef/PB seam reliability follow-up (validated-lap PB writes + immediate LapRef refresh)
+- Classification: **both** (driver-visible SessionBest/PB timing reliability improvement + internal seam hardening).
+- Moved PB write ownership to the accepted validated-lap seam in `UpdateLiveFuelCalcs`:
+  - PB compare/write now uses the same authoritative lap-time candidate used by LapRef validated capture (freshness-guarded `CarIdxLastLapTime` handoff).
+  - This removes fragile dependency on delayed native best-lap event timing for PB persistence.
+- Added a bounded second `UpdateLapReferenceContext(...)` pass in the existing 500ms group immediately after accepted-lap processing so SessionBest/ProfileBest handoff visibility no longer waits an extra update cycle.
+- Kept scope/invariants intact:
+  - condition-specific wet/dry PB ownership remains unchanged,
+  - cleared/non-positive PB values still behave as unavailable baseline,
+  - sector persistence remains optional and only writes when real sectors exist,
+  - no H2H delta semantics or dashboard JSON contracts changed.
+
 ### 2026-04-23 — PR follow-up: restore OFF->MAN progression for ModeCycle-only Fuel Control bindings
 - Classification: **both** (driver-visible mode-cycle progression restore + narrow explicit-command ownership correction).
 - Updated `PitFuelControlEngine.ModeCycle()` OFF branch so it no longer exits on selection-only state mutation.

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -123,6 +123,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Profile] Session start snapshot: Car='...'  Track='...'`** — Live snapshot cleared and session identity pushed to Fuel tab on session change.【F:LalaLaunch.cs†L3308-L3365】
 - **`[LalaPlugin:Profile] New live combo detected. Auto-selecting profile for Car='...' Track='...'`** — Auto-selection fired once per new car/track combo in DataUpdate.【F:LalaLaunch.cs†L3598-L3625】
 - **`[LalaPlugin:Pace] PB Updated: car @ track -> lap`** — PB update accepted via ProfilesManagerViewModel.【F:ProfilesManagerViewModel.cs†L66-L88】
+- **`[LalaPlugin:Pace] validated-lap PB gate candidate=... wet=... car='...' trackKey='...' -> accepted|rejected`** — Accepted-lap PB write gate decision from `UpdateLiveFuelCalcs`; emitted on every validated-lap PB evaluation (Info on acceptance, verbose-debug on rejection).
 - **`[LalaPlugin:LapRef] Session best updated (dry|wet): <seconds>s`** — LapRef captured a new in-session validated best snapshot for the active condition.
 - **`[LalaPlugin:LapRef] Profile PB sectors persisted (dry|wet) for <car> @ '<track>'.`** — Profile PB update included real fixed-sector data and wrote condition-specific PB sector fields.
 - **`[LalaPlugin:Profiles] Track resolved: key='...'`** — Track resolution during profile operations.【F:ProfilesManagerViewModel.cs†L160-L182】

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-23 LapRef/PB reliability follow-up landed (bounded seam fix):
+  - PB writes now execute on the accepted validated-lap seam in `UpdateLiveFuelCalcs` using the same authoritative lap-time handoff as LapRef validated capture (instead of waiting for native best-lap event timing);
+  - added a bounded second `UpdateLapReferenceContext(...)` pass in the 500ms cadence immediately after accepted-lap processing so SessionBest/ProfileBest handoff visibility does not lag an extra update cycle;
+  - periodic native best-lap seam remains for readback refresh only; condition-specific wet/dry PB routing and optional sector persistence semantics remain unchanged.
 - 2026-04-23 PR follow-up restored `OFF -> MAN` progression for ModeCycle-only Fuel Control bindings:
   - `PitFuelControlEngine.ModeCycle()` OFF branch now issues an explicit fuel-amount command attempt (`#fuel ...$`) using the selected source target instead of selection-only state mutation;
   - keeps Fuel Control ownership explicit-command based (no `Pit.ToggleFuel` / `#!fuel` reintroduction) while allowing non-AUTO MAN truth to advance via MFD telemetry `dpFuelFill`;

--- a/Docs/Subsystems/LapRef.md
+++ b/Docs/Subsystems/LapRef.md
@@ -1,7 +1,7 @@
 # LapRef (Offline Reference Lap Comparison)
 
 Validated against commit: HEAD
-Last updated: 2026-04-20
+Last updated: 2026-04-23
 Branch: work
 
 ## Purpose
@@ -53,6 +53,7 @@ Player-row sector display continuity is H2H-style:
 2. LapRef resolves authoritative validated lap time from player `CarIdxLastLapTime` when fresh/consistent with the validated-gate candidate; otherwise it keeps the gate candidate for that capture tick. It then captures snapshot from the player's CarSA fixed-sector cache (if available).
 3. Snapshot competes for in-memory session-best snapshot ownership (including sectors), while published session-best lap-time truth is kept aligned to trusted best-lap authority each tick.
 4. Existing profile PB seam persists lap-time PB; sector fields are persisted condition-wise when available.
+   - PB write now executes on the same accepted validated-lap seam as LapRef capture (authoritative lap-time handoff shared), removing dependency on delayed native best-lap event timing.
 5. Each tick, LapRef rematerializes profile-best from active profile + track + wet/dry condition.
    - Profile-best lookup is **condition-specific only** (`dry -> dry`, `wet -> wet`) for `LapRef.ProfileBest.*`.
    - LapRef does not fall back from wet PB to dry PB for profile-best reference publication.
@@ -60,6 +61,7 @@ Player-row sector display continuity is H2H-style:
    - publishes player sector boxes directly from the current CarSA fixed-sector cache snapshot (H2H-style read-only consumption),
    - updates only the minimal current-lap comparable snapshot needed for truthful compare/cumulative outputs,
    - re-arms current-lap comparable eligibility on rollover/lap advance while keeping static references unchanged.
+   - receives a second bounded refresh pass in the 500ms accepted-lap processing cadence so a newly captured SessionBest/ProfileBest handoff is visible without an extra lap/update-cycle wait.
 
 PB safety note:
 - Profile PB remains telemetry-owned (validated-lap seam); Profiles UI no longer permits manual PB entry.

--- a/Docs/Subsystems/Profiles_And_PB.md
+++ b/Docs/Subsystems/Profiles_And_PB.md
@@ -1,7 +1,7 @@
 # Profiles and Personal Bests
 
 Validated against commit: HEAD
-Last updated: 2026-04-22
+Last updated: 2026-04-23
 Branch: work
 
 ## Purpose
@@ -65,6 +65,10 @@ PB laps are captured when:
 - Lap improves the stored PB for the active condition.
 - Session context allows PB capture.
 - PB values are telemetry-owned in Profiles; the PB display is read-only in the Profiles workflow (no manual PB editing path).
+
+Authoritative write seam:
+- PB persistence now runs directly on the accepted validated-lap gate in `UpdateLiveFuelCalcs`, using the same authoritative lap-time handoff used for LapRef validated capture (`CarIdxLastLapTime` freshness-guarded against the accepted-lap candidate).
+- The periodic native best-lap event remains a readback refresh seam for downstream consumers, but no longer owns PB write timing.
 
 PB metadata (source + timestamp) is stored separately for dry and wet laps. The **active condition** (dry vs wet) is driven by live wet-mode detection (tyre compound), so PB capture always aligns to the current surface mode.
 PB write gating treats `0`/non-positive cleared PB values as unavailable (same as `null`) so first valid relearn lap after a clear can persist.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3113,6 +3113,28 @@ namespace LaunchPlugin
                         _lastValidLapMs = (int)Math.Round(pbGateLapSec * 1000.0);
                         _lastValidLapNumber = completedLapsNow;
                         _lastValidLapWasWet = lapConditionWet;
+
+                        if (_lastValidLapMs > 0)
+                        {
+                            bool pbAccepted = ProfilesViewModel.TryUpdatePBByCondition(
+                                CurrentCarModel,
+                                CurrentTrackKey,
+                                _lastValidLapMs,
+                                lapConditionWet,
+                                _lastValidatedLapRefSectorMs);
+
+                            string pbLog =
+                                $"[LalaPlugin:Pace] validated-lap PB gate candidate={_lastValidLapMs}ms wet={lapConditionWet} " +
+                                $"car='{CurrentCarModel}' trackKey='{CurrentTrackKey}' -> {(pbAccepted ? "accepted" : "rejected")}";
+                            if (pbAccepted)
+                            {
+                                SimHub.Logging.Current.Info(pbLog);
+                            }
+                            else if (IsVerboseDebugLoggingOn)
+                            {
+                                SimHub.Logging.Current.Debug(pbLog);
+                            }
+                        }
                     }
 
                     if (recordPaceForStats)
@@ -7678,6 +7700,7 @@ namespace LaunchPlugin
             {
                 _poll500ms.Restart();
                 UpdateLiveFuelCalcs(data, pluginManager);
+                UpdateLapReferenceContext(playerCarIdx, carIdxLapDistPct, carIdxLap, sessionTypeName, playerLastLapTimeSec, playerBestLapTimeSec);
 
                 var currentBestLap = data.NewData?.BestLapTime ?? TimeSpan.Zero;
                 if (currentBestLap > TimeSpan.Zero && currentBestLap != _lastSeenBestLap)
@@ -7688,20 +7711,6 @@ namespace LaunchPlugin
                     int completedLapsNow = Convert.ToInt32(data.NewData?.CompletedLaps ?? 0);
                     bool lapValidForPb = _lastValidLapNumber == completedLapsNow && Math.Abs(_lastValidLapMs - lapMs) <= 2;
                     bool lapWasWetForPb = _lastValidLapWasWet;
-
-                    bool accepted = false;
-                    if (lapValidForPb)
-                    {
-                        accepted = ProfilesViewModel.TryUpdatePBByCondition(CurrentCarModel, CurrentTrackKey, lapMs, lapWasWetForPb, _lastValidatedLapRefSectorMs);
-                        string pbLog = $"[LalaPlugin:Pace] candidate={lapMs}ms car='{CurrentCarModel}' trackKey='{CurrentTrackKey}' -> {(accepted ? "accepted" : "rejected")}";
-                        if (accepted)
-                            SimHub.Logging.Current.Info(pbLog);
-                        else
-                            if (IsVerboseDebugLoggingOn)
-                            {
-                                SimHub.Logging.Current.Debug(pbLog);
-                            }
-                    }
 
                     var activeTrackStats = ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackKey)
                         ?? ActiveProfile?.ResolveTrackByNameOrKey(CurrentTrackName);


### PR DESCRIPTION
### Motivation
- Fix fragile seam where profile PB writes could miss accepted validated laps because PB write was effectively owned by a later native best-lap event, causing lost PBs and a one-update-cycle visual lag for LapRef SessionBest.
- Keep scope tightly to PB/session-best persistence and LapRef handoff timing without touching H2H semantics, dashboard JSON, or fuel math ownership.

### Description
- Move the PB write gate onto the accepted validated-lap path in `UpdateLiveFuelCalcs` so the same authoritative lap candidate used by LapRef capture is used for `TryUpdatePBByCondition(...)`, preserving wet/dry routing and optional sector payloads (`LalaLaunch.cs`).
- Add a bounded immediate refresh of LapRef context in the 500ms cadence by calling `UpdateLapReferenceContext(...)` right after `UpdateLiveFuelCalcs(...)` so a newly captured SessionBest/ProfileBest is published without waiting an extra tick (`LalaLaunch.cs`).
- Add explicit observability for the new PB gate with a `validated-lap PB gate candidate=...` log (info on accept, verbose debug on reject) and document the log in `Docs/Internal/SimHubLogMessages.md`.
- Update subsystem docs to record the authoritative write seam and the LapRef handoff/refresh behavior (`Docs/Subsystems/Profiles_And_PB.md`, `Docs/Subsystems/LapRef.md`) and record the change in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`.

### Testing
- Attempted `dotnet build LaunchPlugin.csproj -v minimal` but the environment lacks the `dotnet` tool so a compile was not executed (build unavailable in this runner).
- Ran repository scans and static inspections to validate modified call sites and doc alignment; no runtime automated tests were available or executed in this environment.
- Observability added: new info/debug log line emitted by the PB gate code path to aid diagnostics (manual validation expected during runtime testing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3cb56258832fa2bb8ecc80d5ffbf)