### PR TITLE
Fix pit command chat-open `T` leaking into raw/custom payloads

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,17 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-23 — Pit command transport regression fix: block chat-open `T` leakage into typed raw/custom commands
+- Classification: **both** (driver-visible pit raw/custom command text integrity fix + transport-path hardening).
+- Updated `PitCommandEngine` chat-injection transport sequencing only (no tyre/fuel control state-machine changes):
+  - direct postmessage path now sends `Esc` pre-close before `T` open-chat, then types payload + submit;
+  - legacy foreground sendinput path now sends `Esc` before `T` as the same stale-open guard.
+- Fix intent/outcome:
+  - prevents stale-open chat state from absorbing the opener key into payload text (no `t#...` / `tt#...` corruption),
+  - raw pit commands like `#tc 0` are now transported as exact payload text.
+- Preserved invariants:
+  - no command-architecture redesign, no tyre control logic change, no new retry/poll loop behavior.
+
 ### 2026-04-23 — PR follow-up: expire satisfied Fuel Control owned-mirror expectations without requiring a change tick
 - Classification: **internal-only** (ownership guard hardening; no new action/export surface).
 - Updated `PitFuelControlEngine` owned-mirror tracking to immediately clear pending requested-fuel / fuel-fill expectations whenever current observed telemetry is already at the queued expected value, even when no same-tick telemetry delta occurs.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-23 Pit command transport regression fix landed (chat-open `T` leak guard):
+  - `PitCommandEngine` now force-closes chat (`Esc`) before opener (`T`) in both direct-postmessage and legacy-sendinput chat-injection paths;
+  - prevents stale-open chat from absorbing the opener key into outgoing typed payloads (`t#...` / `tt#...`) for raw/custom pit commands such as `#tc 0`;
+  - scope remained transport-only (no tyre/fuel control logic redesign).
 - 2026-04-23 PR follow-up landed for Fuel Control owned-mirror expectation expiry:
   - pending owned requested-fuel / fuel-fill expectations are now cleared whenever currently observed telemetry already equals the queued expected values, even without a same-tick change event;
   - closes stale-pending ownership attribution after suppression-window or baseline-init convergence, preventing later manual MFD same-value edits from being masked as plugin-owned.

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -93,6 +93,7 @@ Canonical log wording and meaning live in `Docs/Internal/SimHubLogMessages.md`; 
 ## Failure modes / edge cases
 - No usable iRacing process/window: command send attempt fails and feedback/log surfaces should make this visible.
 - Direct transport partial-state uncertainty: Auto mode suppresses unsafe fallback on that press to avoid duplicate corruption.
+- Chat-open leak prevention is explicit in both transport paths: command transport force-sends `Esc` before `T` so stale-open chat does not absorb the opener key into outgoing raw/custom command payload (`t#...` / `tt#...` corruption).
 - Transport success for custom/raw/stateless commands is attempt-only; in-sim effect is unverified by design.
 - Tyre control has no resend loop: each target change sends once, then either confirms in-window or fails once (`PIT CMD FAIL`) and falls back to current MFD truth.
 - External pit-menu edits can cancel AUTO once and force safety recovery state in fuel control.

--- a/PitCommandEngine.cs
+++ b/PitCommandEngine.cs
@@ -47,7 +47,6 @@ namespace LaunchPlugin
 
         private readonly HashSet<string> _onceWarnings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private DateTime _messageUntilUtc = DateTime.MinValue;
-        private bool _postMessageChatStateMayBeOpen;
 
         public string DisplayText { get; private set; } = string.Empty;
         public string LastAction { get; private set; } = string.Empty;
@@ -484,31 +483,32 @@ namespace LaunchPlugin
                 return false;
             }
 
+            bool preCloseAttempted = false;
             bool chatOpenAttempted = false;
             bool textSendAttempted = false;
             bool submitAttempted = false;
+            bool preCloseSucceeded = false;
             bool chatOpenSucceeded = false;
 
-            if (!_postMessageChatStateMayBeOpen)
+            preCloseAttempted = true;
+            if (PostVirtualKey(iracingWindow, Keys.Escape))
             {
-                chatOpenAttempted = true;
-                if (!PostVirtualKey(iracingWindow, Keys.T))
-                {
-                    reason = "postmessage-open-chat-failed";
-                    SimHub.Logging.Current.Warn($"[LalaPlugin:PitCommand] transport=postmessage abort=true reason={reason} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted}");
-                    return false;
-                }
+                preCloseSucceeded = true;
+                chatStateMutated = true;
+            }
 
-                chatOpenSucceeded = true;
-                chatStateMutated = true;
-                _postMessageChatStateMayBeOpen = true;
-                Thread.Sleep(40);
-            }
-            else
+            Thread.Sleep(12);
+            chatOpenAttempted = true;
+            if (!PostVirtualKey(iracingWindow, Keys.T))
             {
-                SimHub.Logging.Current.Info("[LalaPlugin:PitCommand] transport=postmessage chat-open-attempted=false chat-open-suppressed=state-maybe-open");
-                chatStateMutated = true;
+                reason = "postmessage-open-chat-failed";
+                SimHub.Logging.Current.Warn($"[LalaPlugin:PitCommand] transport=postmessage abort=true reason={reason} pre-close-attempted={preCloseAttempted} pre-close-succeeded={preCloseSucceeded} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted}");
+                return false;
             }
+
+            chatOpenSucceeded = true;
+            chatStateMutated = true;
+            Thread.Sleep(40);
 
             textSendAttempted = true;
             foreach (char c in command)
@@ -516,7 +516,7 @@ namespace LaunchPlugin
                 if (!PostMessage(iracingWindow, WmChar, (IntPtr)c, IntPtr.Zero))
                 {
                     reason = "postmessage-char-failed";
-                    SimHub.Logging.Current.Warn($"[LalaPlugin:PitCommand] transport=postmessage abort=true reason={reason} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted}");
+                    SimHub.Logging.Current.Warn($"[LalaPlugin:PitCommand] transport=postmessage abort=true reason={reason} pre-close-attempted={preCloseAttempted} pre-close-succeeded={preCloseSucceeded} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted}");
                     return false;
                 }
 
@@ -528,13 +528,12 @@ namespace LaunchPlugin
             if (!PostVirtualKey(iracingWindow, Keys.Enter))
             {
                 reason = "postmessage-submit-failed";
-                SimHub.Logging.Current.Warn($"[LalaPlugin:PitCommand] transport=postmessage abort=true reason={reason} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted}");
+                SimHub.Logging.Current.Warn($"[LalaPlugin:PitCommand] transport=postmessage abort=true reason={reason} pre-close-attempted={preCloseAttempted} pre-close-succeeded={preCloseSucceeded} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted}");
                 return false;
             }
 
-            _postMessageChatStateMayBeOpen = false;
             reason = "none";
-            SimHub.Logging.Current.Info($"[LalaPlugin:PitCommand] transport=postmessage direct-sequence chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted} chat-open-succeeded={chatOpenSucceeded}");
+            SimHub.Logging.Current.Info($"[LalaPlugin:PitCommand] transport=postmessage direct-sequence pre-close-attempted={preCloseAttempted} pre-close-succeeded={preCloseSucceeded} chat-open-attempted={chatOpenAttempted} text-send-attempted={textSendAttempted} submit-attempted={submitAttempted} chat-open-succeeded={chatOpenSucceeded}");
             return true;
         }
 
@@ -547,6 +546,8 @@ namespace LaunchPlugin
                 return false;
             }
 
+            TapVirtualKey(Keys.Escape);
+            Thread.Sleep(12);
             TapVirtualKey(Keys.T);
             Thread.Sleep(40);
 


### PR DESCRIPTION
### Motivation
- Raw pit commands (e.g. `#tc 0`) were being corrupted with a leading `t`/`tt` because the chat-open key (`T`) could be absorbed into the typed payload when chat was already open.  
- The change is narrow and transport-only: avoid changing tyre/fuel control logic or command architecture, and address the transport open/normalization sequence that allowed the opener key to land in the payload.

### Description
- Hardened the postmessage send path in `PitCommandEngine.TryPostMessageChatCommand(...)` to force-send `Esc` (pre-close) then `T` (open) before typing payload and submitting, and added explicit pre-close logging flags.  
- Hardened the legacy foreground send-input path (`TryForegroundSendInputChatCommand(...)`) to also send `Esc` before `T` to provide the same stale-open guard.  
- Removed the previous `_postMessageChatStateMayBeOpen` short-circuit and replaced it with an explicit pre-close/open sequence and tighter logging around the open/send/submit steps.  
- Updated docs to record the behaviour and rationale in `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md`, `Docs/RepoStatus.md`, and `Docs/Internal/Development_Changelog.md`.

### Testing
- Attempted an automated build with `dotnet build LaunchPlugin.sln`, but the environment lacks `dotnet` so the build could not be run here (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea61e39344832f8f67f518cbecbb50)