### PR TITLE
Tyre Control: avoid false PIT CMD FAIL by confirming compound family before timeout

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,18 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-23 — Tyre Control follow-up: compound confirmation timeout no longer reverts successful DRY/WET MFD changes
+- Classification: **both** (driver-visible false timeout failure/remap fix + narrow confirmation-path correction).
+- Updated `PitTyreControlEngine.EnsureCompound(...)` pending-confirmation behavior:
+  - confirmation success now triggers as soon as requested compound truth exists and matches the desired DRY/WET family (`snapshot.HasRequestedCompound` + family match),
+  - confirmation state is cleared immediately on that family convergence so timeout failure cannot run after convergence.
+- Restored bounded timeout failure handling for truly unconfirmed sends:
+  - timeout now again publishes `PIT CMD FAIL` + manual-truth remap only when requested-family convergence did not occur inside the confirmation window.
+- Preserved invariants:
+  - no retry-loop reintroduction,
+  - no `#t$` service command reintroduction,
+  - no transport or broad tyre-control redesign.
+
 ### 2026-04-23 — Pit command transport regression fix: block chat-open `T` leakage into typed raw/custom commands
 - Classification: **both** (driver-visible pit raw/custom command text integrity fix + transport-path hardening).
 - Updated `PitCommandEngine` chat-injection transport sequencing only (no tyre/fuel control state-machine changes):

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-23 Tyre Control follow-up landed (compound confirmation timeout no longer reverts successful DRY/WET MFD changes):
+  - `PitTyreControlEngine.EnsureCompound(...)` pending confirmation now succeeds immediately when requested compound truth exists and matches desired DRY/WET family (`HasRequestedCompound` + family match), without waiting for tyre-service ON confirmation;
+  - successful family convergence now clears pending compound confirmation state before timeout evaluation, preventing false timeout failure from undoing already-successful MFD compound changes;
+  - bounded timeout failure handling remains active only for truly unconfirmed windows (`PIT CMD FAIL` + manual truth remap when no requested-family convergence occurred).
 - 2026-04-23 Pit command transport regression fix landed (chat-open `T` leak guard):
   - `PitCommandEngine` now force-closes chat (`Esc`) before opener (`T`) in both direct-postmessage and legacy-sendinput chat-injection paths;
   - prevents stale-open chat from absorbing the opener key into outgoing typed payloads (`t#...` / `tt#...`) for raw/custom pit commands such as `#tc 0`;

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -66,6 +66,7 @@ This is the canonical technical document for the pit/custom command stack and re
    - DRY/WET/AUTO drive compound request semantics with a single raw `#tc ...$` send (no `#t$` pre-send),
    - each DRY/WET/AUTO `#tc ...$` send records both pending compound intent and pending service-ON intent so delayed OFF->ON service convergence is preserved as plugin-owned intent,
    - AUTO follows declared wetness,
+   - pending compound confirmation succeeds as soon as requested compound family truth (`PitSvTireCompound`) matches the desired DRY/WET family (service-flag ON confirmation is not required for this compound-success seam),
    - each action/AUTO enforcement event performs at most one send attempt per target and then waits for a short confirmation window; on unconfirmed timeout, publish `PIT CMD FAIL`, remap mode to MFD truth, and do not retry.
 
 ## Outputs (exports + logs)

--- a/PitTyreControlEngine.cs
+++ b/PitTyreControlEngine.cs
@@ -339,9 +339,7 @@ namespace LaunchPlugin
                 ClearPendingServiceIntentIfMatched(snapshot);
 
                 if (snapshot.HasRequestedCompound &&
-                    IsRequestedCompoundInDesiredFamily(snapshot.RequestedCompound, desiredWet) &&
-                    snapshot.HasTireServiceSelection &&
-                    snapshot.IsTireServiceSelected)
+                    IsRequestedCompoundInDesiredFamily(snapshot.RequestedCompound, desiredWet))
                 {
                     _compoundConfirmationPending = false;
                     _compoundConfirmationDeadlineUtc = DateTime.MinValue;
@@ -356,7 +354,7 @@ namespace LaunchPlugin
 
                 _compoundConfirmationPending = false;
                 _compoundConfirmationDeadlineUtc = DateTime.MinValue;
-                //HandleUnconfirmedCommand(snapshot, "compound-confirmation-timeout");
+                HandleUnconfirmedCommand(snapshot, "compound-confirmation-timeout");
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Live tests showed successful `#tc` compound sends could still trigger a later `PIT CMD FAIL` and remap back to stale MFD mode when the confirmation timeout ran after the MFD had already converged. 
- The intent is to treat requested-compound family convergence as immediate confirmation and prevent the timeout path from undoing an already-successful DRY/WET change.

### Description
- In `PitTyreControlEngine.EnsureCompound(...)` the compound-confirmation success check now accepts `snapshot.HasRequestedCompound` + `IsRequestedCompoundInDesiredFamily(...)` as sufficient for confirmation and clears `_compoundConfirmationPending` and its deadline immediately. 
- The unconfirmed timeout failure path was re-enabled to run only when the confirmation window actually expires without requested-family convergence (previously it could run despite family convergence or was commented-out). 
- Documentation was updated to reflect the new confirmation semantics in `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md` and changelogs/status notes were added in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`. 
- Files changed: `PitTyreControlEngine.cs`, `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.

### Testing
- Ran `git diff --check` which produced no whitespace errors and committed the changes successfully. 
- Attempted `dotnet build LaunchPlugin.csproj -c Release` but the environment lacks the `dotnet` SDK so a binary build could not be performed in-container. 
- No additional automated unit tests exist for this path; behavioral validation was implemented via logic inspection and matching subsystem docs to the intended narrow-scope invariant (no retries, no `#t$`, no transport redesign).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea69ad8a1c832f8b406bcf25eb3c95)