### PR TITLE
Align Pit Fuel Control feedback and guards with FuelModes CSV contract

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,14 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-24 — Pit Fuel Control review follow-up: AUTO+PLAN ModeCycle impossible-state no-send recovery
+- Classification: **internal-only** (contract-alignment correction; no new surface area).
+- Updated `PitFuelControlEngine.ModeCycle()` AUTO branch to explicitly guard impossible `AUTO + PLAN` before the AUTO->OFF send path:
+  - now recovers to `Source=STBY`, `AutoArmed=false`,
+  - remains AUTO/disarmed,
+  - sends no raw command and publishes no OFF feedback from this impossible-state branch.
+- This aligns runtime behavior with the already-updated CSV row (`AUTO / PLAN / ModeCycle => no-send recovery`) and avoids unintended `#-fuel$` sends from impossible PLAN-in-AUTO state.
+
 ### 2026-04-23 — Pit Fuel Control contract alignment follow-up: direct-command wording + AUTO/MAN feedback parity + invalid PLAN failure feedback
 - Classification: **both** (driver-visible Fuel Control feedback/state-contract alignment + internal guard correction).
 - Updated `PitFuelControlEngine` to align direct-command behavior with `FuelModesLogicCSV.csv` while preserving explicit raw command ownership (`#fuel$`, `#-fuel$`, `#fuel X$`, additive overshoot payload):

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,21 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-23 — Pit Fuel Control contract alignment follow-up: direct-command wording + AUTO/MAN feedback parity + invalid PLAN failure feedback
+- Classification: **both** (driver-visible Fuel Control feedback/state-contract alignment + internal guard correction).
+- Updated `PitFuelControlEngine` to align direct-command behavior with `FuelModesLogicCSV.csv` while preserving explicit raw command ownership (`#fuel$`, `#-fuel$`, `#fuel X$`, additive overshoot payload):
+  - `MAN -> AUTO` immediate source send branch now keeps the source-send feedback (`AUTO REFUEL SET <SRC> X L`) instead of overriding with generic mode text;
+  - AUTO source sends now use AUTO wording (`AUTO REFUEL SET ...`) and AUTO over-space wording (`AUTO FUEL <requested>L >MAX`) instead of MAN wording;
+  - `MAN STBY/PLAN -> AUTO STBY` feedback now uses `AUTO REFUEL STBY`;
+  - `AUTO -> OFF` now publishes `REFUEL OFF`;
+  - MAN invalid `SetPlan` (planner/live mismatch) now publishes `Pit Cmd Fail` instead of silently no-op;
+  - impossible `AUTO + PLAN` state is now guarded to safe no-send recovery (`AUTO STBY`, disarmed) and no longer falls through to PUSH source send.
+- Updated subsystem/docs contract surfaces (`FuelModesLogicCSV.csv`, subsystem doc) to match the corrected behavior wording and impossible-state handling.
+- Preserved invariants:
+  - no `Pit.ToggleFuel` use inside Fuel Control,
+  - no retry loops or command-transport redesign,
+  - no Tyre Control changes.
+
 ### 2026-04-23 — Pit Fuel Control testing/polish pass: OFF->MAN feedback alignment + raw-command observability + max-feedback table alignment
 - Classification: **both** (driver-visible OFF->MAN send/feedback correction + internal observability/docs alignment).
 - Updated Fuel Control OFF->MAN behavior in `PitFuelControlEngine.ModeCycle()`:

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,14 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-23 Pit Fuel Control contract-alignment follow-up landed (direct-command model preserved; feedback/guard rows aligned):
+  - `PitFuelControlEngine` now keeps source-send feedback on `MAN -> AUTO` (`AUTO REFUEL SET <SRC> X L`) and no longer overwrites with generic mode text;
+  - AUTO source sends now use AUTO wording (`AUTO REFUEL SET ...`) and AUTO max/over-space wording (`AUTO FUEL <requested>L >MAX`), while MAN max feedback remains `FUEL MAX`;
+  - `MAN STBY/PLAN -> AUTO STBY` now publishes `AUTO REFUEL STBY`;
+  - `AUTO -> OFF` now publishes `REFUEL OFF` while still sending explicit `#-fuel$`;
+  - invalid MAN `SetPlan` (planner/live mismatch) now publishes `Pit Cmd Fail` instead of silent no-op;
+  - impossible `AUTO + PLAN` state is now guarded to no-send recovery (`AUTO STBY`, disarmed) and cannot fall through to PUSH send.
+  - `Pit.ToggleFuel` action remains unchanged/available as an independent manual binding and is not used by Fuel Control ownership logic.
 - 2026-04-23 Pit Fuel Control testing/polish pass landed (command payload fix + observability + table alignment):
   - `PitFuelControlEngine.ModeCycle()` OFF->MAN sends `#fuel$` (no `#+fuel$` additive form) and uses `FUEL MAN STBY` feedback.
   - `PitCommandEngine.ExecuteRawPitCommand(...)` empty-after-normalization blocked path now logs both raw and normalized payload text for diagnosis.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-24 review follow-up landed for Fuel Control impossible-state ModeCycle handling:
+  - `PitFuelControlEngine.ModeCycle()` now guards impossible `AUTO + PLAN` before AUTO->OFF send logic;
+  - impossible branch now recovers to `Source=STBY` + `AutoArmed=false`, remains AUTO/disarmed, and sends no command;
+  - closes residual mismatch where `AUTO + PLAN + ModeCycle` could still send `#-fuel$` despite CSV no-send recovery row.
 - 2026-04-23 Pit Fuel Control contract-alignment follow-up landed (direct-command model preserved; feedback/guard rows aligned):
   - `PitFuelControlEngine` now keeps source-send feedback on `MAN -> AUTO` (`AUTO REFUEL SET <SRC> X L`) and no longer overwrites with generic mode text;
   - AUTO source sends now use AUTO wording (`AUTO REFUEL SET ...`) and AUTO max/over-space wording (`AUTO FUEL <requested>L >MAX`), while MAN max feedback remains `FUEL MAX`;

--- a/Docs/Subsystems/FuelModesLogicCSV.csv
+++ b/Docs/Subsystems/FuelModesLogicCSV.csv
@@ -15,7 +15,7 @@ MAN,PLAN,SetPlan,direct PLAN send plugin action,REFUEL SET PLAN X L,Sends Planne
 invalid PLAN -> Pit Cmd Fail",MAN STBY,PLAN send only when planner/live match is valid
 AUTO,PUSH/NORM/SAVE,ModeCycle,select OFF and STBY,REFUEL OFF,Sends #-fuel$,Refuel OFF,OFF,If send fails -> Pit Cmd Fail,AUTO STBY,
 AUTO,STBY,ModeCycle,select OFF and STBY,REFUEL OFF,Sends #-fuel$,Refuel OFF,OFF,If send fails -> Pit Cmd Fail,AUTO STBY,
-AUTO,PLAN,ModeCycle,,FUEL MODE OFF,Sends #-fuel$,Refuel OFF,OFF,PLAN blocked in AUTO,AUTO STBY,PLAN in AUTO Should never be possible
+AUTO,PLAN,ModeCycle,recover impossible state to AUTO STBY (disarmed),None,No command sent,No change,AUTO STBY,PLAN blocked in AUTO and must not send PUSH fallback,None (safe no-send recovery),PLAN in AUTO Should never be possible
 AUTO,PUSH/NORM/SAVE,SourceCycle,select next SRC in order which fires command,AUTO REFUEL SET <SRC> X L,Sends new fuel amount,Refuel ON X L set,AUTOwith SRC that was just sent,Immediate send,AUTO STBY,
 AUTO,STBY,SourceCycle,select next SRC in order which fires command,AUTO REFUEL SET <SRC> X L,Sends new fuel amount,Refuel ON X L set,AUTOwith SRC that was just sent,STBY cleared on send,AUTO STBY,
 AUTO,PLAN,none,none,none,none,no change,AUTO STBY,PLAN blocked in AUTO,AUTO STBY,PLAN in AUTO Should never be possible

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -101,9 +101,11 @@ Canonical log wording and meaning live in `Docs/Internal/SimHubLogMessages.md`; 
 - Fuel Control mode ownership is explicit-command only (no internal `Pit.ToggleFuel` use):
   - `OFF -> MAN` explicitly sends MFD refuel ON (`#fuel$`) and then mirrors MAN truth (`Source=STBY`, AUTO disarmed);
   - OFF is a hard guard: `SourceCycle`/`SetPush`/`SetNorm`/`SetSave`/`SetPlan` send nothing and hold `OFF STBY`;
-  - `MAN -> AUTO`: `PUSH`/`NORM`/`SAVE` send immediately and arm AUTO on success; `STBY` and `PLAN` both enter `AUTO STBY` with no send (PLAN is inhibited in AUTO switching);
-  - `AUTO -> OFF` always attempts explicit raw OFF command `#-fuel$`; on send failure AUTO remains unchanged, on success exits AUTO and mirrors OFF truth;
-  - `SetPlan` is MAN-only direct send (`REFUEL SET PLAN X L` semantics). PLAN is blocked in OFF/AUTO and blocked when PLAN validity/session match is false.
+  - `MAN -> AUTO`: `PUSH`/`NORM`/`SAVE` send immediately and arm AUTO on success with `AUTO REFUEL SET <SRC> X L` feedback; `STBY` and `PLAN` both enter `AUTO STBY` with no send and `AUTO REFUEL STBY` feedback (PLAN is inhibited in AUTO switching);
+  - `AUTO -> OFF` always attempts explicit raw OFF command `#-fuel$`; on send failure AUTO remains unchanged, on success exits AUTO and mirrors OFF truth with `REFUEL OFF` feedback;
+  - `SetPlan` is MAN-only direct send (`REFUEL SET PLAN X L` semantics). PLAN is blocked in OFF/AUTO and blocked when PLAN validity/session match is false (`Pit Cmd Fail` in MAN when PLAN validity fails);
+  - AUTO source sends (`SourceCycle`/`SetPush`/`SetNorm`/`SetSave`) use AUTO feedback wording (`AUTO REFUEL SET <SRC> X L`) and AUTO over-space wording (`AUTO FUEL <requested>L >MAX`), while MAN over-space wording remains `FUEL MAX`;
+  - impossible `AUTO + PLAN` state is guarded as no-send recovery (`AUTO STBY`, disarmed) and must not fall through to a PUSH send.
   - External MFD/fuel-request changes are mirror-only:
     - while in AUTO, plugin sends nothing and publishes `AUTO REFUEL CANCELLED BY MFD`, then mirrors to `OFF STBY`/`MAN STBY` based on MFD truth;
     - while in MAN/OFF, plugin sends nothing and mirrors with `REFUEL SET OFF BY MFD`, `REFUEL SET ON BY MFD`, or `FUEL CHANGED BY MFD`;

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -233,6 +233,13 @@ namespace LaunchPlugin
                 return;
             }
 
+            if (Source == PitFuelControlSource.Plan)
+            {
+                Source = PitFuelControlSource.Stby;
+                AutoArmed = false;
+                return;
+            }
+
             bool sentOff = _chatCommandSender != null &&
                            _chatCommandSender("Pit.FuelControl.ModeCycle", "#-fuel$", "REFUEL OFF");
             if (!sentOff)

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -123,6 +123,13 @@ namespace LaunchPlugin
 
             if (effectiveMode == PitFuelControlMode.Auto)
             {
+                if (Source == PitFuelControlSource.Plan)
+                {
+                    Source = PitFuelControlSource.Stby;
+                    AutoArmed = false;
+                    return;
+                }
+
                 Source = NextAutoSource(Source);
             }
             else
@@ -199,7 +206,7 @@ namespace LaunchPlugin
                 if (Source == PitFuelControlSource.Stby)
                 {
                     AutoArmed = false;
-                    PublishSelectionFeedback("Pit.FuelControl.ModeCycle", "FUEL AUTO STBY");
+                    PublishSelectionFeedback("Pit.FuelControl.ModeCycle", "AUTO REFUEL STBY");
                     return;
                 }
 
@@ -207,7 +214,7 @@ namespace LaunchPlugin
                 {
                     Source = PitFuelControlSource.Stby;
                     AutoArmed = false;
-                    PublishSelectionFeedback("Pit.FuelControl.ModeCycle", "FUEL AUTO STBY");
+                    PublishSelectionFeedback("Pit.FuelControl.ModeCycle", "AUTO REFUEL STBY");
                     return;
                 }
 
@@ -215,7 +222,6 @@ namespace LaunchPlugin
                 if (sent)
                 {
                     AutoArmed = true;
-                    PublishSelectionFeedback("Pit.FuelControl.ModeCycle", "FUEL MODE AUTO");
                 }
                 else
                 {
@@ -228,7 +234,7 @@ namespace LaunchPlugin
             }
 
             bool sentOff = _chatCommandSender != null &&
-                           _chatCommandSender("Pit.FuelControl.ModeCycle", "#-fuel$", "FUEL MODE OFF");
+                           _chatCommandSender("Pit.FuelControl.ModeCycle", "#-fuel$", "REFUEL OFF");
             if (!sentOff)
             {
                 PublishSelectionFeedback("Pit.FuelControl.ModeCycle", "Pit Cmd Fail");
@@ -414,6 +420,11 @@ namespace LaunchPlugin
 
             if (!PlanValid)
             {
+                if (effectiveMode == PitFuelControlMode.Man)
+                {
+                    PublishSelectionFeedback(actionName, "Pit Cmd Fail");
+                }
+
                 return;
             }
 
@@ -457,7 +468,8 @@ namespace LaunchPlugin
             string commandText = useMax
                 ? string.Format("#fuel +{0}$", MaxFuelOvershootLitres)
                 : string.Format("#fuel {0}$", roundedTarget);
-            string feedback = BuildFeedbackText(isAutoUpdate, showMaxFeedback, roundedTarget);
+            PitFuelControlMode feedbackMode = ResolveEffectiveMode();
+            string feedback = BuildFeedbackText(isAutoUpdate, showMaxFeedback, roundedTarget, feedbackMode);
             string actionName = !string.IsNullOrWhiteSpace(actionNameOverride)
                 ? actionNameOverride.Trim()
                 : (isAutoUpdate ? "Pit.FuelControl.AutoUpdate" : "Pit.FuelControl.SourceSet");
@@ -798,9 +810,10 @@ namespace LaunchPlugin
             }
         }
 
-        private string BuildFeedbackText(bool isAutoUpdate, bool showMaxFeedback, int roundedTarget)
+        private string BuildFeedbackText(bool isAutoUpdate, bool showMaxFeedback, int roundedTarget, PitFuelControlMode feedbackMode)
         {
             string sourceText = SourceToText(Source);
+            bool autoStyleFeedback = feedbackMode == PitFuelControlMode.Auto;
 
             if (isAutoUpdate)
             {
@@ -811,10 +824,14 @@ namespace LaunchPlugin
 
             if (showMaxFeedback)
             {
-                return "FUEL MAX";
+                return autoStyleFeedback
+                    ? string.Format("AUTO FUEL {0}L >MAX", roundedTarget)
+                    : "FUEL MAX";
             }
 
-            return string.Format("FUEL SET {0} {1}L", sourceText, roundedTarget);
+            return autoStyleFeedback
+                ? string.Format("AUTO REFUEL SET {0} {1}L", sourceText, roundedTarget)
+                : string.Format("REFUEL SET {0} {1}L", sourceText, roundedTarget);
         }
 
         private static PitFuelControlSource NextSource(PitFuelControlSource current)


### PR DESCRIPTION
### Motivation
- Bring `PitFuelControlEngine` feedback wording and impossible-state handling into alignment with the authoritative `Docs/Subsystems/FuelModesLogicCSV.csv` contract while preserving the explicit raw-command direct-send model. 
- Preserve existing invariants: do not reintroduce toggle-based control (`Pit.ToggleFuel`), retries, transport redesigns, or fuel-math changes. 

### Description
- Guarded the impossible `AUTO + PLAN` path in `SourceCycle()` so `PLAN` in `AUTO` recovers to `AUTO STBY` (disarmed) and does not fall through to a PUSH/send; the engine now sets `Source = STBY` and `AutoArmed = false` in that case. 
- Adjusted `ModeCycle()` feedback and send behaviour to match the CSV: `OFF -> MAN` still sends `#fuel$` and reports `FUEL MAN STBY`, MAN `STBY/PLAN` now publish `AUTO REFUEL STBY` when entering AUTO-disarmed, AUTO→OFF sends `#-fuel$` and reports `REFUEL OFF` on success, and MAN→AUTO source-entry keeps source-send feedback rather than a generic mode label. 
- Made `SetPlan` validity-gated and explicit: an invalid `SetPlan` in MAN now publishes `Pit Cmd Fail` instead of silently no-op, and `SetPlan` is blocked in OFF/AUTO. 
- Split AUTO vs MAN feedback formatting in the feedback builder so AUTO sends use `AUTO REFUEL SET <SRC> <N>L` / `AUTO FUEL <N>L >MAX` while MAN sends use `REFUEL SET <SRC> <N>L` / `FUEL MAX`. 
- Updated documentation to match code changes: `Docs/Subsystems/FuelModesLogicCSV.csv`, `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md`, and internal history files `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`. 

### Testing
- Ran repository searches that verified there are no occurrences of the forbidden `#+fuel$` sequence (succeeded). 
- Verified Fuel Control does not use `Pit.ToggleFuel`/`_fuelToggleSender` and that explicit raw command strings exist for OFF/MAN/AUTO transitions (succeeded via `rg` checks for `Pit.ToggleFuel`, `#fuel$`, `#-fuel$`, and `#fuel +{N}$`). 
- Confirmed the feedback/command string generation paths were adjusted by inspecting `PitFuelControlEngine.cs` and the CSV/MD files were updated (manual code inspection). 
- Attempted a `dotnet build` in the execution environment but it could not be run here due to `dotnet: command not found` (build not executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab010ea58832fba43fe89c4850dfc)