### PR TITLE
Fix Strategy Max Fuel Override slider/text sync after preset apply

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,14 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-28 — Strategy max-fuel override UI desync fix after preset apply
+- Classification: **both** (driver-visible Strategy UI binding correction + internal consistency with existing planner authority contract).
+- Updated `FuelCalcs.MaxFuelOverrideDisplayValue` profile-mode getter to always mirror authoritative `MaxFuelOverride`.
+  - removes stale `_appliedPreset` display override that could hold slider/textbox visuals at preset value while strategy math and helper percent used updated manual value.
+- Preserved invariants:
+  - Live Snapshot max-fuel lock/authority remains unchanged (still sourced from live cap and non-editable),
+  - no fuel math, pit fuel control, or export contract changes.
+
 ### 2026-04-24 — Pit feedback dash visual mapping correction (Caution steady, Warning 750ms blink)
 - Classification: **both** (dash-facing visual contract correction + documentation alignment).
 - Corrected pit feedback dash visual mapping in subsystem/dash/inventory docs:

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,15 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-28 — Strategy max-fuel display follow-up: remove preset-state display dependency path
+- Classification: **internal-only** (binding/notification hygiene to lock in Issue #552 behavior contract).
+- Updated `RaisePresetStateChanged()` to stop raising `MaxFuelOverrideDisplayValue` notifications.
+  - `MaxFuelOverrideDisplayValue` is now explicitly authoritative-value driven (`MaxFuelOverride` in Profile mode, live cap in Live Snapshot mode), so preset badge/state changes no longer imply a display-value ownership path.
+- Preserved invariants:
+  - preset apply still writes `MaxFuelOverride` in Profile mode,
+  - `MaxFuelOverride` setter remains the owner of dependent display/percent/warning notifications + strategy/preset refresh,
+  - no fuel maths or Live Snapshot lock semantics changed.
+
 ### 2026-04-28 — Strategy max-fuel override UI desync fix after preset apply
 - Classification: **both** (driver-visible Strategy UI binding correction + internal consistency with existing planner authority contract).
 - Updated `FuelCalcs.MaxFuelOverrideDisplayValue` profile-mode getter to always mirror authoritative `MaxFuelOverride`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 # Repository status
 
 Validated against commit: HEAD
-Last updated: 2026-04-24
+Last updated: 2026-04-28
 Branch: work
 
 ## Current repo/link status
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-28 Issue #552 fix landed for Strategy max-fuel override control sync:
+  - in Profile mode, Max Fuel Override slider/textbox now stay bound to the authoritative planner value after preset apply and during manual drag/edit;
+  - helper percent text and strategy calculations continue to update from the same authoritative value;
+  - Live Snapshot lock/authority behavior is unchanged (control remains live-cap-owned and non-editable).
 - 2026-04-24 PR #626 follow-up visual contract correction landed:
   - pit feedback dash mapping now documents `Caution` as steady (no blink) and `Warning` as blink for 1 second at 750ms;
   - no `PitCommandEngine` runtime behavior changes were made in this correction.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,10 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-28 Issue #552 follow-up landed for max-fuel display ownership cleanup:
+  - `RaisePresetStateChanged()` no longer raises `MaxFuelOverrideDisplayValue` notifications;
+  - max-fuel display ownership is now explicit: Profile display follows authoritative `MaxFuelOverride`, Live Snapshot display follows live cap branch;
+  - no strategy fuel math, preset application semantics, or Live Snapshot lock behavior changes.
 - 2026-04-28 Issue #552 fix landed for Strategy max-fuel override control sync:
   - in Profile mode, Max Fuel Override slider/textbox now stay bound to the authoritative planner value after preset apply and during manual drag/edit;
   - helper percent text and strategy calculations continue to update from the same authoritative value;

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2005,15 +2005,6 @@ namespace LaunchPlugin
                 return 0.0;
             }
 
-            if (_appliedPreset != null)
-            {
-                var presetValue = GetPresetMaxFuelOverrideLitres(_appliedPreset);
-                if (presetValue.HasValue)
-                {
-                    return presetValue.Value;
-                }
-            }
-
             return MaxFuelOverride;
         }
         set => MaxFuelOverride = value;

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -893,7 +893,6 @@ namespace LaunchPlugin
         OnPropertyChanged(nameof(AppliedPreset));
         OnPropertyChanged(nameof(PresetBadge));
         OnPropertyChanged(nameof(IsPresetModifiedFlag));
-        OnPropertyChanged(nameof(MaxFuelOverrideDisplayValue));
     }
 
     public string FuelPerLapText
@@ -2005,6 +2004,7 @@ namespace LaunchPlugin
                 return 0.0;
             }
 
+            // Profile mode display must always reflect the authoritative planner value.
             return MaxFuelOverride;
         }
         set => MaxFuelOverride = value;


### PR DESCRIPTION
### Motivation
- Fix Issue #552 where applying a Race Preset could leave the Max Fuel Override slider/textbox visually stuck on the preset value in Profile mode while calculations and helper percentage used the authoritative planner value, and preserve existing Live Snapshot lock/authority behavior.

### Description
- Remove the preset-backed display override from `FuelCalcs.MaxFuelOverrideDisplayValue` so Profile-mode UI always reflects the authoritative `MaxFuelOverride`, leaving the Live Snapshot branch unchanged; files changed: `FuelCalcs.cs`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.

### Testing
- Ran static/code-path inspections to verify `CalculateStrategy` and helper percent use `MaxFuelOverride` and that the UI slider is bound to `MaxFuelOverrideDisplayValue`, and attempted an automated build with `dotnet build LaunchPlugin.sln -c Release` which failed in this environment because the `dotnet` SDK is not installed (no compiled binary verification possible here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0abcb9080832f9ddd9ef2b0d6aab7)