### PR TITLE
Fix Fuel/Tyre fault pipeline final-state consistency and ownership-leak edge cases

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -33,6 +33,20 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-28 — Pit Fuel/Tyre fault-pipeline consistency + ownership-leak follow-up
+- Classification: **internal-only** (diagnostic fault-pipeline correctness/consistency; no command-path behavior redesign).
+- Fuel follow-up:
+  - external mirror/takeover handling now clears pending owned mirror expectations before remap/cancel state application;
+  - request-fault bit evaluation is now ownership-gated (`IsAutoModeActive || AutoArmed`) so stale pending expectations cannot leak after ownership surrender.
+- Tyre follow-up:
+  - AUTO correction-send ticks now explicitly suppress `Pit.TyreControl.Fault` to `0` in the same tick as the correction send;
+  - unmappable requested-compound truth (`HasTireServiceSelection && IsTireServiceSelected && HasRequestedCompound && !hasTruth`) now hard-suppresses fault to `0` across mode paths.
+- Preserved invariants:
+  - no command payload changes,
+  - no transport/timing/retry changes,
+  - no fuel math changes,
+  - no tyre mode-cycle/AUTO ownership redesign.
+
 ### 2026-04-28 — Pit Tyre AUTO-correction settle-window fault timing hotfix
 - Classification: **internal-only** (diagnostic export timing correction; no command/AUTO behavior change).
 - Updated `PitTyreControlEngine.OnTelemetryTick()` to re-evaluate settle suppression *after* `HandleAuto(...)` before assigning `Pit.TyreControl.Fault`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -9,6 +9,12 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+- 2026-04-28 Pit Fuel/Tyre fault-pipeline consistency pass landed:
+  - Fuel fault request-bit evaluation is now ownership-gated (`IsAutoModeActive || AutoArmed`) and external mirror/takeover handling explicitly clears pending owned mirror expectations;
+  - closes stale owned-request leakage so post-surrender mirror states cannot keep `Pit.FuelControl.Fault=2` latched after ownership transitions;
+  - Tyre AUTO correction-send ticks now force `Pit.TyreControl.Fault=0` in the same tick as correction issue (post-handler settle evaluation retained);
+  - Tyre unmappable requested-compound truth (`service selected + requested compound present + !hasTruth`) now hard-suppresses fault to `0` across mode paths;
+  - no command payload/timing/retry/transport/fuel-math/tyre-mode behavior changes were introduced.
 - 2026-04-28 Pit Tyre AUTO-correction settle-window fault timing hotfix landed:
   - `PitTyreControlEngine.OnTelemetryTick()` now re-checks settle-window state after `HandleAuto(...)` and before `Pit.TyreControl.Fault` assignment;
   - AUTO correction-send ticks are now suppressed to `Pit.TyreControl.Fault = 0` as intended by settle-window gating;

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -126,6 +126,8 @@ Fault export contract (diagnostic/visual only):
 - Both exports intentionally suppress evaluation during each subsystem’s existing post-command settle/suppression windows to avoid normal latency flash.
 - Both exports compute from final post-tick state after mirror/remap/cancel handling; they are not latched from pre-remap state.
 - During intentional same-tick mirror/remap/cancel transitions (external mirror, truth-mirror, AUTO cancel), fault export is suppressed to `0` for that tick to avoid one-tick false non-zero flashes.
+- Fuel request-fault evaluation is ownership-gated (`AUTO`/armed ownership only), and external mirror/takeover handling clears pending owned mirror expectations so stale request ownership cannot leak after surrender.
+- Tyre AUTO correction-send ticks are explicitly fault-suppressed (`0`) in the same tick as correction issue, and settle-window gating is evaluated from post-handler state.
 - `Pit.TyreControl.Fault` additionally suppresses DRY/WET evaluation when requested-compound truth is present but cannot be mapped to a known dry/wet family (unknown/unmappable truth => `0`).
 - Fault exports never trigger command sends/retries/corrections.
 

--- a/PitFuelControlEngine.cs
+++ b/PitFuelControlEngine.cs
@@ -733,6 +733,8 @@ namespace LaunchPlugin
 
         private void HandleExternalMirrorChange(bool currentFuelFillEnabled, bool requestedFuelChanged)
         {
+            ClearPendingOwnedMirrorExpectations();
+
             if (IsAutoModeActive)
             {
                 DisarmAutoAndForceStby(clearSuppressWindow: true);
@@ -877,6 +879,14 @@ namespace LaunchPlugin
             }
         }
 
+        private void ClearPendingOwnedMirrorExpectations()
+        {
+            _hasPendingOwnedRequestedFuelLitres = false;
+            _pendingOwnedRequestedFuelLitres = -1;
+            _hasPendingOwnedFuelFillEnabled = false;
+            _pendingOwnedFuelFillEnabled = false;
+        }
+
         private void ExpireSatisfiedOwnedMirrorExpectations(int currentRequestedLitres, bool currentFuelFillEnabled, bool requestedFuelChanged, bool fuelFillChanged)
         {
             if (!requestedFuelChanged && _hasPendingOwnedRequestedFuelLitres && currentRequestedLitres == _pendingOwnedRequestedFuelLitres)
@@ -955,7 +965,8 @@ namespace LaunchPlugin
             }
 
             bool requestFault = false;
-            if (_hasPendingOwnedRequestedFuelLitres)
+            bool ownershipActive = IsAutoModeActive || AutoArmed;
+            if (ownershipActive && _hasPendingOwnedRequestedFuelLitres)
             {
                 requestFault = currentRequestedLitres != _pendingOwnedRequestedFuelLitres;
             }

--- a/PitTyreControlEngine.cs
+++ b/PitTyreControlEngine.cs
@@ -135,11 +135,11 @@ namespace LaunchPlugin
             bool inSettleWindow = DateTime.UtcNow < _settleUntilUtc;
             bool inSendFailureHoldWindow = DateTime.UtcNow < _sendFailureHoldUntilUtc;
             bool remapAppliedThisTick = false;
+            bool autoCorrectionSendIssuedThisTick = false;
 
             if (Mode == PitTyreControlMode.Auto)
             {
-                remapAppliedThisTick = HandleAuto(snapshot, hasTruth, truthMode, inSettleWindow);
-                UpdateTruthHistory(hasTruth, truthMode);
+                remapAppliedThisTick = HandleAuto(snapshot, hasTruth, truthMode, inSettleWindow, out autoCorrectionSendIssuedThisTick);
             }
             else
             {
@@ -166,12 +166,19 @@ namespace LaunchPlugin
                 return;
             }
 
+            if (autoCorrectionSendIssuedThisTick)
+            {
+                Fault = 0;
+                return;
+            }
+
             bool inSettleWindowAfterHandlers = DateTime.UtcNow < _settleUntilUtc;
             Fault = ComputeFault(snapshot, hasTruth, truthMode, inSettleWindowAfterHandlers);
         }
 
-        private bool HandleAuto(PitTyreControlSnapshot snapshot, bool hasTruth, PitTyreControlMode truthMode, bool inSettleWindow)
+        private bool HandleAuto(PitTyreControlSnapshot snapshot, bool hasTruth, PitTyreControlMode truthMode, bool inSettleWindow, out bool autoCorrectionSendIssuedThisTick)
         {
+            autoCorrectionSendIssuedThisTick = false;
             bool desiredWet = snapshot.WeatherDeclaredWet;
             PitTyreControlMode desiredMode = desiredWet ? PitTyreControlMode.Wet : PitTyreControlMode.Dry;
             bool desiredChanged = !_autoLastDesiredWet.HasValue || _autoLastDesiredWet.Value != desiredWet;
@@ -201,6 +208,8 @@ namespace LaunchPlugin
                     {
                         SendModeCommand("Pit.TyreControl.Auto.CorrectionDry", "#t tc 0", "TYRE AUTO CHANGE DRY", "auto-correction", PitTyreControlMode.Auto);
                     }
+
+                    autoCorrectionSendIssuedThisTick = true;
                 }
 
                 _autoPendingInitialEvaluation = false;
@@ -299,6 +308,14 @@ namespace LaunchPlugin
         private int ComputeFault(PitTyreControlSnapshot snapshot, bool hasTruth, PitTyreControlMode truthMode, bool inSettleWindow)
         {
             if (snapshot == null || inSettleWindow)
+            {
+                return 0;
+            }
+
+            if (snapshot.HasTireServiceSelection &&
+                snapshot.IsTireServiceSelected &&
+                snapshot.HasRequestedCompound &&
+                !hasTruth)
             {
                 return 0;
             }


### PR DESCRIPTION
### Motivation
- Ensure diagnostic `Pit.FuelControl.Fault` and `Pit.TyreControl.Fault` are computed from the final, post-handler tick state and do not reflect intermediate/stale state.
- Prevent owned-request expectations from leaking into Fuel fault after external takeover/surrender.
- Eliminate one-tick false flashes during Tyre AUTO correction/send and suppress faults when tyre truth is unknown/unmappable.

### Description
- Fuel: clear pending owned-mirror expectations at the start of `HandleExternalMirrorChange(...)` and added `ClearPendingOwnedMirrorExpectations()` to fully remove pending ownership state on takeover.
- Fuel: gate request-fault evaluation in `ComputeFault(...)` so request-fault is considered only when ownership is active (`IsAutoModeActive || AutoArmed`).
- Tyre: track when an AUTO correction send was issued in-tick via `autoCorrectionSendIssuedThisTick` (added an out-parameter to `HandleAuto(...)`) and suppress `Pit.TyreControl.Fault = 0` for that same tick to avoid same-tick flashes.
- Tyre: make `ComputeFault(...)` return `0` when tyre service is selected and a requested compound is present but truth mapping is unknown/unmappable (`hasTruth == false`), enforcing unknown-truth => no fault.
- Documentation: updated `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md`, `Docs/RepoStatus.md`, and `Docs/Internal/Development_Changelog.md` to record the behavioral contract and the invariants preserved.

### Testing
- Attempted automated build: ran `dotnet build LaunchPlugin.sln` in the environment, which failed because `dotnet` is not present (environment limitation); build therefore not executed here (failed).
- Performed static/source-level verification: reviewed diffs and code paths to confirm fault now computes from post-handler state, pending ownership is cleared on external mirror handling, Tyre AUTO correction tick suppression is applied, and unmappable-truth suppression is implemented (inspection succeeded).
- Committed changes and updated internal docs; no unit/integration tests were executed in this container due to missing .NET tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d0e620b8832f91835156204fce7b)