### PR TITLE
Fix compile blockers: OpenFileDialog using, pit feedback access, and LeagueClassMode init

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1569,3 +1569,9 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Fixed launch trace housekeeping analysis to explicitly skip the summary CSV header row that follows `[LaunchSummaryHeader]`.
 - Prevented valid mixed trace files from routing `TimestampUtc,...` through telemetry row parsing, eliminating the false telemetry DateTime parse error during Launch Analysis file scans.
 - Kept launch trace naming/CSV format/summary schema unchanged; empty/header-only cleanup and completed trace retention rules remain intact.
+
+## 2026-04-30 — Build-fix pass (CS1674/CS0122/CS0236)
+- Classification: **internal-only** (compile/legal-access fixes only; no runtime behavior redesign).
+- `GlobalSettingsView.xaml.cs`: removed `using (...)` around `Microsoft.Win32.OpenFileDialog` because it is not `IDisposable`; dialog flow and reload behavior unchanged.
+- `PitCommandEngine`: added narrow public wrapper `PublishInfoMessage(string)` and switched Push/Save mode-cycle feedback call site to that seam; severity mapping/hold behavior unchanged.
+- `LaunchPluginSettings`: changed `LeagueClassMode` default initializer to literal `0` to avoid illegal instance-member reference in initializer; runtime normalization/behavior unchanged.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -15,6 +15,12 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+
+- 2026-04-30 Build-fix pass landed (compile-only):
+  - fixed League Class CSV browse dialog disposal compile error by removing `using` wrapper around `OpenFileDialog`;
+  - fixed Push/Save mode-cycle feedback accessibility by routing through a new public `PitCommandEngine.PublishInfoMessage(...)` wrapper;
+  - fixed League Class settings initializer legality by setting `LaunchPluginSettings.LeagueClassMode` default to literal `0`;
+  - no intended behavior changes to pit-command transport, feedback hold/severity semantics, or League Class runtime logic.
 - 2026-04-30 League Race Class Phase 1 cleanup pass landed:
   - player preview now uses live player identity when available (CustomerId/UserID + name), with explicit not-available wording while telemetry identity is missing;
   - CSV reload now handles read exceptions safely and reports non-fatal status text instead of throwing during init/reload;

--- a/GlobalSettingsView.xaml.cs
+++ b/GlobalSettingsView.xaml.cs
@@ -348,16 +348,14 @@ namespace LaunchPlugin
                 return;
             }
 
-            using (var dialog = new Microsoft.Win32.OpenFileDialog())
+            var dialog = new Microsoft.Win32.OpenFileDialog();
+            dialog.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
+            dialog.CheckFileExists = true;
+            dialog.Multiselect = false;
+            if (dialog.ShowDialog() == true)
             {
-                dialog.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
-                dialog.CheckFileExists = true;
-                dialog.Multiselect = false;
-                if (dialog.ShowDialog() == true)
-                {
-                    Plugin.Settings.LeagueClassCsvPath = dialog.FileName;
-                    Plugin.ReloadLeagueClassConfig();
-                }
+                Plugin.Settings.LeagueClassCsvPath = dialog.FileName;
+                Plugin.ReloadLeagueClassConfig();
             }
         }
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -324,7 +324,7 @@ namespace LaunchPlugin
             Settings.PitFuelControlPushSaveMode = nextMode;
             SaveSettings();
             string modeText = nextMode == 1 ? "PROFILE" : "LIVE";
-            _pitCommandEngine.PublishMessage($"PUSH/SAVE {modeText}");
+            _pitCommandEngine.PublishInfoMessage($"PUSH/SAVE {modeText}");
             _pitFuelControlEngine?.RefreshCurrentSourceTarget("Pit.FuelControl.PushSaveModeCycle");
             SimHub.Logging.Current.Info($"[LalaPlugin:PitFuelControl] PitFuelControlPushSaveModeCycle -> mode={modeText}");
         }
@@ -17553,7 +17553,7 @@ namespace LaunchPlugin
         public double PitFuelPushSaveProfileGuardPct { get; set; } = 10.0;
         public bool EnableAutoDashSwitch { get; set; } = true;
         public bool LeagueClassEnabled { get; set; } = false;
-        public int LeagueClassMode { get; set; } = (int)LeagueClassMode.CsvOnly;
+        public int LeagueClassMode { get; set; } = 0;
         public string LeagueClassCsvPath { get; set; } = string.Empty;
         public int LeagueClassPlayerOverrideMode { get; set; } = 0; // 0=Auto,1=Manual
         public string LeagueClassPlayerOverrideClassName { get; set; } = string.Empty;

--- a/PitCommandEngine.cs
+++ b/PitCommandEngine.cs
@@ -723,6 +723,11 @@ namespace LaunchPlugin
             return string.Equals(processName, "iRacingSim64DX11", StringComparison.OrdinalIgnoreCase);
         }
 
+        public void PublishInfoMessage(string message)
+        {
+            PublishMessage(message, PitCommandSeverity.Info);
+        }
+
         private void PublishMessage(string message, PitCommandSeverity severity)
         {
             string nextText = message ?? string.Empty;


### PR DESCRIPTION
### Motivation
- Repair three compile failures without changing runtime behavior: CS1674 from disposing a non-`IDisposable` dialog, CS0122 from calling an inaccessible pit-feedback method, and CS0236 from an illegal instance-member reference in a field initializer. 
- Keep all existing pit-command severity/hold semantics, dialog behavior, and League Class runtime logic unchanged. 

### Description
- Replaced the `using (var dialog = new Microsoft.Win32.OpenFileDialog())` pattern with a plain `var dialog = new Microsoft.Win32.OpenFileDialog();` and preserved the same `ShowDialog()`/reload flow in `GlobalSettingsView.xaml.cs`. 
- Added a narrow public wrapper `PublishInfoMessage(string)` in `PitCommandEngine.cs` that calls the existing internal `PublishMessage(..., PitCommandSeverity.Info)`. 
- Updated the Push/Save mode-cycle call site in `LalaLaunch.cs` to use `_pitCommandEngine.PublishInfoMessage(...)` instead of calling the inaccessible `PublishMessage(...)` directly. 
- Fixed `LaunchPluginSettings.LeagueClassMode` initializer to a literal safe default (`0`) to avoid referencing instance members at field initialization time. 
- Recorded the compile-fix pass in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`. 

### Testing
- Attempted `dotnet build -v minimal` to verify compilation but the environment lacks the .NET SDK (`dotnet: command not found`), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cda90bbc832fb4d25002a61a2d01)