### PR TITLE
Ensure enabling LeagueClass auto-activates CsvThenName when mode is Disabled

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -41,6 +41,12 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 
 ## Post-v1.0 development
 
+### 2026-04-30 — League Class enable-time mode guard (Disabled -> CsvThenName)
+- Classification: **both** (runtime behavior guard + docs alignment).
+- Added a narrow enable-edge guard in `LalaLaunch` so when `LeagueClassEnabled` flips `false -> true` and `LeagueClassMode` is still `Disabled (0)`, mode is auto-set to `CsvThenName (3)`.
+- Preserved user intent for all non-disabled modes (no override when user already selected `CsvOnly`, `NameOnly`, or `CsvThenName`).
+- Purpose: prevent an inactive enabled state and ensure League Class preview/resolution paths become active immediately after enable.
+
 ### 2026-04-30 — Pit Fuel Control Push/Save profile-assisted mode + guard
 - Classification: **both** (new dash-facing controls/exports + bounded internal target-selection behavior change).
 - Added `Pit.FuelControl.PushSaveMode` (`0=LIVE`, `1=PROFILE`) and `Pit.FuelControl.PushSaveModeText` exports plus new action `Pit.FuelControl.PushSaveModeCycle`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -16,6 +16,11 @@ Branch: work
 
 ## Documentation sync status
 
+- 2026-04-30 League Class enable-time mode guard landed:
+  - added a narrow runtime guard that auto-corrects `LeagueClassMode` from `Disabled (0)` to `CsvThenName (3)` only when `LeagueClassEnabled` transitions from false to true;
+  - preserves all existing user-selected non-disabled modes;
+  - ensures League Class preview/resolution activates immediately when users enable League Class without touching mode.
+
 - 2026-04-30 Build-fix pass landed (compile-only):
   - fixed League Class CSV browse dialog disposal compile error by removing `using` wrapper around `OpenFileDialog`;
   - fixed Push/Save mode-cycle feedback accessibility by routing through a new public `PitCommandEngine.PublishInfoMessage(...)` wrapper;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4749,6 +4749,7 @@ namespace LaunchPlugin
         private readonly LeagueClassResolver _leagueClassResolver = new LeagueClassResolver();
         private string _leagueClassPreviewIdentitySnapshot = string.Empty;
         private string _leagueClassPreviewSettingsSnapshot = string.Empty;
+        private bool _leagueClassLastEnabledState = false;
         public LeagueClassStatus LeagueClassStatus => _leagueClassResolver.Status;
 
         public void ReloadLeagueClassConfig()
@@ -4842,6 +4843,28 @@ namespace LaunchPlugin
             _leagueClassPreviewIdentitySnapshot = identitySnapshot;
             _leagueClassPreviewSettingsSnapshot = settingsSnapshot;
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+        }
+
+        private void ApplyLeagueClassEnableModeGuard()
+        {
+            if (Settings == null)
+            {
+                return;
+            }
+
+            bool isEnabled = Settings.LeagueClassEnabled;
+            if (isEnabled &&
+                !_leagueClassLastEnabledState &&
+                Settings.LeagueClassMode == (int)LeagueClassMode.Disabled)
+            {
+                Settings.LeagueClassMode = (int)LeagueClassMode.CsvThenName;
+                SaveSettings();
+                OnPropertyChanged(nameof(Settings));
+                OnPropertyChanged(nameof(LeagueClassStatus));
+                OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            }
+
+            _leagueClassLastEnabledState = isEnabled;
         }
 
         private string BuildLeagueClassIdentitySnapshot(PluginManager pluginManager)
@@ -7692,6 +7715,7 @@ namespace LaunchPlugin
             EnforceHardDebugSettings(Settings);
             TryFlushPendingCustomMessageSaveDebounce(false);
             EvaluateDarkMode(pluginManager);
+            ApplyLeagueClassEnableModeGuard();
             MaybeRefreshLeagueClassPreview(pluginManager);
             if (!data.GameRunning || data.NewData == null) return;
 


### PR DESCRIPTION
### Motivation
- Fix a regression where `LeagueClassMode` defaulted to `Disabled (0)`, so toggling `LeagueClassEnabled` to true left the subsystem inactive and preview/resolution did not run.

### Description
- Added `ApplyLeagueClassEnableModeGuard()` to `LalaLaunch.cs` that detects an enable transition (`LeagueClassEnabled` false→true) and, only when `LeagueClassMode == Disabled (0)`, sets `LeagueClassMode` to `CsvThenName (3)`, saves settings, and signals property updates; the method is invoked in the main runtime master-guard path just before preview refresh and uses a `_leagueClassLastEnabledState` latch to detect the transition.
- Updated docs: `Docs/RepoStatus.md` and `Docs/Internal/Development_Changelog.md` to record the change.

### Testing
- Attempted `dotnet build` in this environment but it failed because `dotnet` is not installed here, so a compile verification could not be completed automatically.
- Local static checks used during the rollout included file scans and a successful commit of the changes to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cf4a78b8832fb4303f23a86b1fdc)