### PR TITLE
League Race Phase 1: settings UI usability & preview clarity fixes

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1581,3 +1581,15 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - `GlobalSettingsView.xaml.cs`: removed `using (...)` around `Microsoft.Win32.OpenFileDialog` because it is not `IDisposable`; dialog flow and reload behavior unchanged.
 - `PitCommandEngine`: added narrow public wrapper `PublishInfoMessage(string)` and switched Push/Save mode-cycle feedback call site to that seam; severity mapping/hold behavior unchanged.
 - `LaunchPluginSettings`: changed `LeagueClassMode` default initializer to literal `0` to avoid illegal instance-member reference in initializer; runtime normalization/behavior unchanged.
+### 2026-04-30 — League Race Phase 1 UI usability follow-up
+- Classification: **both** (settings UX visibility/clarity improvements + internal behavior-safe normalization).
+- League Class settings UI now defaults/normalizes player override to **Auto-detect** when persisted manual override is invalid (manual selected with blank class name).
+- Added explicit column headers for player override and suffix fallback rows, plus a detected-classes readout table after CSV load (read-only in this phase).
+- Classification mode now controls section visibility:
+  - `CSV only`: CSV path/status + detected classes visible; suffix fallback hidden.
+  - `Name suffix only`: suffix fallback visible; CSV path/status hidden.
+  - `CSV then name suffix`: both visible.
+- Player preview text now uses clearer wording:
+  - explicit unavailable text when live identity is not yet available,
+  - otherwise shows `Player`, `Source`, and `Resolved class`.
+- Preserved safe color-hex handling (invalid hex renders transparent preview) and avoided per-tick preview spam by retaining snapshot-based refresh gating.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1582,6 +1582,8 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - `PitCommandEngine`: added narrow public wrapper `PublishInfoMessage(string)` and switched Push/Save mode-cycle feedback call site to that seam; severity mapping/hold behavior unchanged.
 - `LaunchPluginSettings`: changed `LeagueClassMode` default initializer to literal `0` to avoid illegal instance-member reference in initializer; runtime normalization/behavior unchanged.
 ### 2026-04-30 — League Race Phase 1 UI usability follow-up
+
+- Follow-up fix: removed unintended `LeagueClassShowCsvSection` visibility gate from the Pit Commands transport selector row in `GlobalSettingsView.xaml`, restoring always-visible access to pit transport mode regardless of League Class classification mode.
 - Classification: **both** (settings UX visibility/clarity improvements + internal behavior-safe normalization).
 - League Class settings UI now defaults/normalizes player override to **Auto-detect** when persisted manual override is invalid (manual selected with blank class name).
 - Added explicit column headers for player override and suffix fallback rows, plus a detected-classes readout table after CSV load (read-only in this phase).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -889,6 +889,8 @@ Branch: work
 - `Docs/RepoStatus.md`
 - `CHANGELOG.md`
 - 2026-04-30 League Race Phase 1 UI usability follow-up landed:
+
+  - follow-up fix: Pit command transport row visibility no longer depends on League Class CSV mode visibility; control is now always visible within Pit Commands settings.
   - player override invalid-manual persisted states now normalize to Auto-detect (manual remains active only when explicitly selected and valid);
   - League Class settings now show explicit column headers for player override and suffix fallback rule rows;
   - CSV-mode UI now displays detected class rows (read-only Phase 1 visibility table with class/short/rank/colour preview);

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -888,3 +888,9 @@ Branch: work
 - `Docs/Internal/Development_Changelog.md`
 - `Docs/RepoStatus.md`
 - `CHANGELOG.md`
+- 2026-04-30 League Race Phase 1 UI usability follow-up landed:
+  - player override invalid-manual persisted states now normalize to Auto-detect (manual remains active only when explicitly selected and valid);
+  - League Class settings now show explicit column headers for player override and suffix fallback rule rows;
+  - CSV-mode UI now displays detected class rows (read-only Phase 1 visibility table with class/short/rank/colour preview);
+  - mode-driven section visibility now matches classifier mode (`CSV only`, `Name suffix only`, `CSV then name suffix`);
+  - player preview now reports clear identity-unavailable text and, when available, shows player/source/resolved-class summary.

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -123,7 +123,7 @@
                                Foreground="#FFC107"
                                TextWrapping="Wrap"
                                Text="Note: pit commands are most reliable when iRacing is in the foreground/focus." />
-                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0" Visibility="{Binding LeagueClassShowCsvSection, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <TextBlock VerticalAlignment="Center" Margin="0,0,8,0" Text="Pit command transport"/>
                         <ComboBox Width="330"
                                   SelectedValue="{Binding Settings.PitCommandTransportMode, Mode=TwoWay}"
@@ -220,13 +220,32 @@
                         <styles:SHButtonPrimary Content="Browse" Margin="8,0,0,0" Click="BrowseLeagueClassCsv_Click"/>
                         <styles:SHButtonPrimary Content="Reload" Margin="8,0,0,0" Click="ReloadLeagueClassCsv_Click"/>
                     </StackPanel>
-                    <TextBlock Margin="0,6,0,0" Foreground="LightGray" Text="{Binding LeagueClassStatus.ConfigStatusText, StringFormat='Status: {0}'}"/>
-                    <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.LoadedCount, StringFormat='Loaded rows: {0}'}"/>
-                    <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.ValidDriverCount, StringFormat='Valid drivers: {0}'}"/>
-                    <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.InvalidRowCount, StringFormat='Invalid rows: {0}'}"/>
-                    <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.DuplicateRowCount, StringFormat='Duplicate rows: {0}'}"/>
+                    <StackPanel Visibility="{Binding LeagueClassShowCsvSection, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <TextBlock Margin="0,6,0,0" Foreground="LightGray" Text="{Binding LeagueClassStatus.ConfigStatusText, StringFormat='Status: {0}'}"/>
+                        <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.LoadedCount, StringFormat='Loaded rows: {0}'}"/>
+                        <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.ValidDriverCount, StringFormat='Valid drivers: {0}'}"/>
+                        <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.InvalidRowCount, StringFormat='Invalid rows: {0}'}"/>
+                        <TextBlock Foreground="LightGray" Text="{Binding LeagueClassStatus.DuplicateRowCount, StringFormat='Duplicate rows: {0}'}"/>
+                        <TextBlock Margin="0,8,0,2" Text="Detected classes" FontWeight="SemiBold"/>
+                        <TextBlock FontWeight="SemiBold" Text="Enabled   CSV Class Name   Short Name   Rank   Colour Hex   Colour Preview"/>
+                        <ItemsControl ItemsSource="{Binding LeagueClassStatus.DetectedClassRows}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+                                        <CheckBox IsChecked="{Binding Enabled}" IsEnabled="False" VerticalAlignment="Center"/>
+                                        <TextBox Width="130" Margin="6,0,0,0" Text="{Binding ClassName}" IsReadOnly="True"/>
+                                        <TextBox Width="100" Margin="6,0,0,0" Text="{Binding ShortName}" IsReadOnly="True"/>
+                                        <TextBox Width="50" Margin="6,0,0,0" Text="{Binding Rank}" IsReadOnly="True"/>
+                                        <TextBox Width="90" Margin="6,0,0,0" Text="{Binding ColourHex}" IsReadOnly="True"/>
+                                        <Border Width="18" Height="18" Margin="6,2,0,0" BorderBrush="#777" BorderThickness="1" Background="{Binding ColourHex, Converter={StaticResource HexToBrushConverter}}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
 
                     <TextBlock Margin="0,8,0,2" Text="Player race class" FontWeight="SemiBold"/>
+                    <TextBlock FontWeight="SemiBold" Text="Class Name   Short Name   Rank   Colour Hex   Colour Preview"/>
                     <StackPanel Orientation="Horizontal">
                         <ComboBox Width="180" SelectedValue="{Binding Settings.LeagueClassPlayerOverrideMode, Mode=TwoWay}" SelectedValuePath="Tag">
                             <ComboBoxItem Content="Auto-detect" Tag="0"/>
@@ -240,8 +259,9 @@
                     </StackPanel>
                     <TextBlock Margin="0,6,0,0" Foreground="LightGray" Text="{Binding LeagueClassPlayerPreviewText}"/>
 
-                    <TextBlock Margin="0,8,0,2" Text="Fallback rules (suffix)" FontWeight="SemiBold"/>
-                    <ItemsControl ItemsSource="{Binding Settings.LeagueClassFallbackRules}">
+                    <TextBlock Margin="0,8,0,2" Text="Fallback rules (suffix)" FontWeight="SemiBold" Visibility="{Binding LeagueClassShowFallbackSection, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                    <TextBlock FontWeight="SemiBold" Text="Enabled   Match Suffix   Class Name   Short Name   Rank   Colour Hex   Colour Preview" Visibility="{Binding LeagueClassShowFallbackSection, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                    <ItemsControl ItemsSource="{Binding Settings.LeagueClassFallbackRules}" Visibility="{Binding LeagueClassShowFallbackSection, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="0,2,0,2">

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -123,7 +123,7 @@
                                Foreground="#FFC107"
                                TextWrapping="Wrap"
                                Text="Note: pit commands are most reliable when iRacing is in the foreground/focus." />
-                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0" Visibility="{Binding LeagueClassShowCsvSection, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                         <TextBlock VerticalAlignment="Center" Margin="0,0,8,0" Text="Pit command transport"/>
                         <ComboBox Width="330"
                                   SelectedValue="{Binding Settings.PitCommandTransportMode, Mode=TwoWay}"

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4765,6 +4765,8 @@ namespace LaunchPlugin
 
             OnPropertyChanged(nameof(LeagueClassStatus));
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            OnPropertyChanged(nameof(LeagueClassShowCsvSection));
+            OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
         }
 
         public string LeagueClassPlayerPreviewText
@@ -4778,8 +4780,8 @@ namespace LaunchPlugin
                 var info = _leagueClassResolver.ResolvePlayerPreview(Settings, playerCustomerId, playerName);
                 if (info.Valid)
                 {
-                    string suffix = !string.IsNullOrWhiteSpace(playerName) ? (" for " + playerName) : string.Empty;
-                    return $"Detected: {info.Name} ({info.Source}){suffix}";
+                    string livePlayerText = !string.IsNullOrWhiteSpace(playerName) ? playerName : "(name unavailable)";
+                    return $"Player: {livePlayerText} | Source: {info.Source} | Resolved class: {info.Name}";
                 }
 
                 if (Settings != null && Settings.LeagueClassPlayerOverrideMode == 1)
@@ -4792,9 +4794,17 @@ namespace LaunchPlugin
                     return "Live player identity not available yet";
                 }
 
-                return "Detected: unresolved";
+                return $"Player: {playerName} | Source: NONE | Resolved class: unresolved";
             }
         }
+
+        public bool LeagueClassShowCsvSection => Settings != null &&
+            ((LeagueClassMode)Settings.LeagueClassMode == LeagueClassMode.CsvOnly ||
+             (LeagueClassMode)Settings.LeagueClassMode == LeagueClassMode.CsvThenName);
+
+        public bool LeagueClassShowFallbackSection => Settings != null &&
+            ((LeagueClassMode)Settings.LeagueClassMode == LeagueClassMode.NameOnly ||
+             (LeagueClassMode)Settings.LeagueClassMode == LeagueClassMode.CsvThenName);
 
         private bool TryGetLivePlayerIdentityPreview(out int? customerId, out string driverName)
         {
@@ -4843,6 +4853,8 @@ namespace LaunchPlugin
             _leagueClassPreviewIdentitySnapshot = identitySnapshot;
             _leagueClassPreviewSettingsSnapshot = settingsSnapshot;
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            OnPropertyChanged(nameof(LeagueClassShowCsvSection));
+            OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
         }
 
         private void ApplyLeagueClassEnableModeGuard()
@@ -4862,6 +4874,8 @@ namespace LaunchPlugin
                 OnPropertyChanged(nameof(Settings));
                 OnPropertyChanged(nameof(LeagueClassStatus));
                 OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+                OnPropertyChanged(nameof(LeagueClassShowCsvSection));
+                OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
             }
 
             _leagueClassLastEnabledState = isEnabled;
@@ -6842,6 +6856,12 @@ namespace LaunchPlugin
             if (settings.LeagueClassFallbackRules.Count > 3)
             {
                 settings.LeagueClassFallbackRules = settings.LeagueClassFallbackRules.Take(3).ToList();
+            }
+
+            if (settings.LeagueClassPlayerOverrideMode == 1 &&
+                string.IsNullOrWhiteSpace(settings.LeagueClassPlayerOverrideClassName))
+            {
+                settings.LeagueClassPlayerOverrideMode = 0;
             }
         }
 

--- a/LeagueClassResolver.cs
+++ b/LeagueClassResolver.cs
@@ -64,6 +64,7 @@ namespace LaunchPlugin
         public int DuplicateRowCount { get; set; }
         public int ValidDriverCount { get; set; }
         public IReadOnlyList<string> DetectedClasses { get; set; } = Array.Empty<string>();
+        public IReadOnlyList<LeagueClassFallbackRule> DetectedClassRows { get; set; } = Array.Empty<LeagueClassFallbackRule>();
     }
 
     public sealed class LeagueClassResolver
@@ -170,7 +171,22 @@ namespace LaunchPlugin
                 InvalidRowCount = invalid,
                 DuplicateRowCount = duplicate,
                 ValidDriverCount = _csvByCustomerId.Count,
-                DetectedClasses = _detectedClassNames.ToArray()
+                DetectedClasses = _detectedClassNames.ToArray(),
+                DetectedClassRows = _detectedClassNames
+                    .Select(name =>
+                    {
+                        var first = _csvByCustomerId.Values.FirstOrDefault(v => string.Equals(v.ClassName, name, StringComparison.OrdinalIgnoreCase));
+                        return new LeagueClassFallbackRule
+                        {
+                            Enabled = true,
+                            MatchSuffix = string.Empty,
+                            ClassName = name,
+                            ShortName = name,
+                            Rank = first?.Rank ?? 0,
+                            ColourHex = first?.ColourHex ?? string.Empty
+                        };
+                    })
+                    .ToArray()
             };
         }
 


### PR DESCRIPTION
### Motivation
- Fix Phase 1 League Class settings UI so users can inspect and validate class data without changing runtime classification logic or subsystem ownership.
- Address observed issues: manual player override defaulting to an invalid manual state, unlabeled input columns, invisible CSV-detected classes, mode selector not controlling section visibility, unclear fallback rules, and confusing player-preview text.

### Description
- UI: added explicit column headers and a read-only detected-classes table to `GlobalSettingsView.xaml`, and wired CSV/fallback visibility to mode-driven properties so sections show only for relevant modes (`CSV only`, `Name suffix only`, `CSV then name suffix`). (files: `GlobalSettingsView.xaml`)
- Preview & visibility: added `LeagueClassShowCsvSection` and `LeagueClassShowFallbackSection` properties, improved `LeagueClassPlayerPreviewText` wording to show `Player | Source | Resolved class`, and ensured property-change notifications update UI visibility and preview when snapshots change. (files: `LalaLaunch.cs`)
- CSV resolver: expanded `LeagueClassStatus` with `DetectedClassRows` and populated it from unique CSV class names so detected classes are visible as a phase-1 read-only table (short name/rank/colour + colour preview). (files: `LeagueClassResolver.cs`)
- Normalization: extended `NormalizeLeagueClassSettings(...)` to normalize an invalid persisted manual player override (manual selected with blank class name) back to Auto-detect so the UI no longer defaults to an unusable manual state. (files: `LalaLaunch.cs`)
- Docs: recorded the UI follow-up in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` to keep product docs in sync. (files: `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`)

### Testing
- Attempted build: ran `dotnet build -v minimal` in this environment but the `dotnet` CLI is not installed so a full compile could not be executed (failed).
- Static checks: exercised repository searches and file reads (`rg`, `sed`) to verify bindings, added properties, and resolver population logic; these checks succeeded.
- VCS: staged and committed the changes successfully (`git commit` succeeded).
- Behaviour confirmations by code inspection: player override normalization now sets invalid manual override back to Auto-detect during settings normalization, and preview update remains snapshot-gated to avoid per-tick spam (confirmed in `MaybeRefreshLeagueClassPreview` and `BuildLeagueClass*Snapshot` logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3dd2f7224832fb767920060784e9e)