### PR TITLE
Fix League Class player override colour preview binding

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,8 @@
+
+## 2026-05-01 — League Race Phase 1 player override colour preview binding fix
+- Classification: **internal-only** (UI binding correction only; no resolver/settings/export behavior changes).
+- `GlobalSettingsView.xaml`: fixed the Player race class preview swatch binding to source from the override colour hex textbox text via `HexToBrushConverter`, matching CSV/fallback preview behavior and preserving transparent output for invalid/blank hex.
+
 ## 2026-04-30 — Pit Fuel Control Push/Save mode UI surface + binding row
 - Classification: **both** (plugin settings/binding UI surface only + docs alignment).
 - Notification hardening: `PitFuelControlPushSaveModeCycle` now explicitly raises Push/Save mode property change notifications after programmatic setting updates so an open toggle UI reflects hardware/dash cycle presses immediately.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -22,6 +22,12 @@ Branch: work
 - No Git remote is configured in this checkout (`git remote -v` returns empty).
 
 ## Documentation sync status
+
+- 2026-05-01 League Race Phase 1 player override colour preview UI fix landed:
+  - fixed Player race class preview swatch binding in `GlobalSettingsView.xaml` to use the same hex-to-brush conversion path as CSV/fallback previews via the override colour hex textbox source;
+  - invalid/blank override hex remains safe and renders transparent;
+  - no resolver/settings/export semantic changes were introduced.
+
 - Runtime fuel pit-space cap authority fix (2026-04-29):
   - live pit-space exports (`Fuel.Pit.TankSpaceAvailable`, `Fuel.Pit.WillAdd`, `Fuel.Pit.FuelOnExit`) now resolve cap from runtime live tank authority first (`EffectiveLiveMaxTank` seam);
   - stale Strategy/Profile `MaxFuelOverride` no longer silently clamps runtime pit-space when live cap authority exists;

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -257,8 +257,8 @@
                         <TextBox Width="120" Margin="8,0,0,0" Text="{Binding Settings.LeagueClassPlayerOverrideClassName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="Class name"/>
                         <TextBox Width="90" Margin="8,0,0,0" Text="{Binding Settings.LeagueClassPlayerOverrideShortName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="Short"/>
                         <TextBox Width="50" Margin="8,0,0,0" Text="{Binding Settings.LeagueClassPlayerOverrideRank, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="Rank"/>
-                        <TextBox Width="90" Margin="8,0,0,0" Text="{Binding Settings.LeagueClassPlayerOverrideColourHex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="#RRGGBB"/>
-                        <Border Width="18" Height="18" Margin="6,2,0,0" BorderBrush="#777" BorderThickness="1" Background="{Binding Settings.LeagueClassPlayerOverrideColourHex, Converter={StaticResource HexToBrushConverter}}"/>
+                        <TextBox x:Name="LeagueClassPlayerOverrideColourHexTextBox" Width="90" Margin="8,0,0,0" Text="{Binding Settings.LeagueClassPlayerOverrideColourHex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="#RRGGBB"/>
+                        <Border Width="18" Height="18" Margin="6,2,0,0" BorderBrush="#777" BorderThickness="1" Background="{Binding Text, ElementName=LeagueClassPlayerOverrideColourHexTextBox, Converter={StaticResource HexToBrushConverter}}"/>
                     </StackPanel>
                     <TextBlock Margin="0,6,0,0" Foreground="LightGray" Text="{Binding LeagueClassPlayerPreviewText}"/>
 


### PR DESCRIPTION
### Motivation
- The Player override colour preview swatch in the League Race Phase 1 settings was not rendering because the XAML binding path did not match the other CSV/fallback rows and therefore the `HexToBrushConverter` was not being fed the textbox text as expected.

### Description
- Renamed the player override colour hex textbox and changed the preview `Border.Background` to bind to the textbox `Text` via the existing `HexToBrushConverter` in `GlobalSettingsView.xaml`, and updated `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` to record the UI-only fix.

### Testing
- Performed repository verification and validation commands (`rg`/file inspection to locate bindings, `git diff -- GlobalSettingsView.xaml Docs/RepoStatus.md Docs/Internal/Development_Changelog.md` to confirm the change, and `git commit`) and all checks/commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ed12fb8c832fa94eb0d25a092e2b)