### PR TITLE
Fix LeagueClass live player resolver compile break

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4825,7 +4825,7 @@ namespace LaunchPlugin
             int? customerId;
             string driverName;
             TryGetLivePlayerIdentityPreview(out customerId, out driverName);
-            return ResolveLeagueClassInfo(customerId, driverName);
+            return ResolveLeagueClassPlayerInfo(customerId, driverName);
         }
 
         private static string LeagueClassSourceToExportText(LeagueClassSource source)


### PR DESCRIPTION
### Motivation
- Restore compilation after the Phase 2 merge by fixing a misstyped call in the live-player league-class helper while preserving the player/driver resolver ownership model and keeping Phase 2 metadata-only semantics.

### Description
- Replace the erroneous call in `ResolveLivePlayerLeagueClassInfo()` to call `ResolveLeagueClassPlayerInfo(customerId, driverName)` (instead of the non-existent `ResolveLeagueClassInfo(...)`) in `LalaLaunch.cs`.

### Testing
- Attempted `dotnet build` but `dotnet` is not installed in this environment so a full compile could not be executed; ran automated grep checks to verify symbol wiring and confirmed `LeagueClass.Player.*` uses `ResolveLivePlayerLeagueClassInfo()` and Opp/CarSA exports use `ResolveLeagueClassDriverInfo(...)`, then committed the change to `LalaLaunch.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4df284184832faa76e1c569a7842a)