### PR TITLE
League Class: disabled-mode UI cleanup and CSV path binding fix

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,8 @@
+## 2026-05-01 — League Class UI disabled-mode + CSV path binding cleanup
+- Classification: **both** (settings UI behavior clarity + persisted-setting binding reliability).
+- League Class settings UI now collapses all lower controls when disabled and shows only master enable plus disabled status text.
+- CSV browse path write remains settings-owned (`LeagueClassCsvPath`) and now immediately reflects in the textbox after browse assignment.
+- Reload button path is now guarded against disabled-mode invocation (no-op when disabled); re-enable flow keeps saved settings and existing enable-time mode guard behavior.
 ## 2026-05-01 — League Race Phase 2 compile blocker hotfix (undefined live identity fields)
 - Classification: **internal-only** (compile fix only; no runtime behavior change).
 - Replaced `LeagueClass.Player.*` export bindings that referenced undefined `_liveLeagueClassIdentityCustomerId/_liveLeagueClassIdentityName` symbols with a resolver helper that reads live player identity via `TryGetLivePlayerIdentityPreview(...)` and resolves through existing `LeagueClassResolver` seams.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,9 @@
+- 2026-05-01 League Class disabled-mode UI/state cleanup landed:
+  - League Class settings now hide the entire lower configuration area while disabled, showing only the section header, master enable toggle, and disabled helper text;
+  - CSV browse now writes directly to persisted `Settings.LeagueClassCsvPath` and immediately mirrors the chosen value in the textbox;
+  - Reload action now no-ops while disabled by UI flow (control hidden with disabled section) and explicit click-guard;
+  - re-enable preserves persisted CSV/fallback/manual settings, with existing enable-time mode guard (`Disabled` -> `CsvThenName`) unchanged.
+
 - 2026-04-30 Pit Fuel Control Push/Save mode UI/control-surface pass landed:
   - added `Push/Save Profile Mode` toggle in Dash Control -> Global Dash Functions -> Fuel (OFF=`LIVE`, ON=`PROFILE`) bound to `Settings.PitFuelControlPushSaveMode`;
   - selector shares the existing setting with `Pit.FuelControl.PushSaveModeCycle` action path (no UI-local independent state);

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -196,6 +196,7 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+                    </StackPanel>
                 </StackPanel>
             </Expander>
 
@@ -207,6 +208,21 @@
                 <StackPanel Margin="0,10,0,0">
                     <styles:SHToggleCheckbox Content="Enable League Class System"
                                              IsChecked="{Binding Settings.LeagueClassEnabled, Mode=TwoWay}"/>
+                    <TextBlock Margin="0,4,0,0" Foreground="LightGray" Text="League Class system disabled">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Settings.LeagueClassEnabled}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+
+                    <StackPanel Margin="0,6,0,0" Visibility="{Binding Settings.LeagueClassEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                         <TextBlock Text="Classification mode" VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <ComboBox Width="320"
@@ -279,6 +295,7 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+                    </StackPanel>
                 </StackPanel>
             </Expander>
 <StackPanel Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">

--- a/GlobalSettingsView.xaml
+++ b/GlobalSettingsView.xaml
@@ -196,7 +196,6 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    </StackPanel>
                 </StackPanel>
             </Expander>
 
@@ -223,7 +222,7 @@
 
 
                     <StackPanel Margin="0,6,0,0" Visibility="{Binding Settings.LeagueClassEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                         <TextBlock Text="Classification mode" VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <ComboBox Width="320"
                                   SelectedValue="{Binding Settings.LeagueClassMode, Mode=TwoWay}"
@@ -298,7 +297,7 @@
                     </StackPanel>
                 </StackPanel>
             </Expander>
-<StackPanel Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel Visibility="{Binding HardDebugEnabledForUi, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock Text="DEBUG" FontSize="16" FontWeight="Bold" Margin="0,5,10,0"/>
                 <styles:SHToggleCheckbox x:Name="DebugMasterToggle"
                                          Content="Enable debugging mode"

--- a/GlobalSettingsView.xaml.cs
+++ b/GlobalSettingsView.xaml.cs
@@ -355,7 +355,6 @@ namespace LaunchPlugin
             if (dialog.ShowDialog() == true)
             {
                 Plugin.Settings.LeagueClassCsvPath = dialog.FileName;
-                LeagueClassCsvPathTextBox.Text = Plugin.Settings.LeagueClassCsvPath ?? string.Empty;
                 Plugin.ReloadLeagueClassConfig();
             }
         }

--- a/GlobalSettingsView.xaml.cs
+++ b/GlobalSettingsView.xaml.cs
@@ -355,13 +355,19 @@ namespace LaunchPlugin
             if (dialog.ShowDialog() == true)
             {
                 Plugin.Settings.LeagueClassCsvPath = dialog.FileName;
+                LeagueClassCsvPathTextBox.Text = Plugin.Settings.LeagueClassCsvPath ?? string.Empty;
                 Plugin.ReloadLeagueClassConfig();
             }
         }
 
         private void ReloadLeagueClassCsv_Click(object sender, RoutedEventArgs e)
         {
-            Plugin?.ReloadLeagueClassConfig();
+            if (Plugin?.Settings == null || !Plugin.Settings.LeagueClassEnabled)
+            {
+                return;
+            }
+
+            Plugin.ReloadLeagueClassConfig();
         }
 
     }

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -17803,7 +17803,18 @@ namespace LaunchPlugin
         public bool EnableAutoDashSwitch { get; set; } = true;
         public bool LeagueClassEnabled { get; set; } = false;
         public int LeagueClassMode { get; set; } = 0;
-        public string LeagueClassCsvPath { get; set; } = string.Empty;
+        private string _leagueClassCsvPath = string.Empty;
+        public string LeagueClassCsvPath
+        {
+            get { return _leagueClassCsvPath; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_leagueClassCsvPath, normalized, StringComparison.Ordinal)) return;
+                _leagueClassCsvPath = normalized;
+                OnPropertyChanged(nameof(LeagueClassCsvPath));
+            }
+        }
         public int LeagueClassPlayerOverrideMode { get; set; } = 0; // 0=Auto,1=Manual
         public string LeagueClassPlayerOverrideClassName { get; set; } = string.Empty;
         public string LeagueClassPlayerOverrideShortName { get; set; } = string.Empty;


### PR DESCRIPTION
### Motivation
- Fix UX and state binding issues where the CSV file path textbox could appear empty despite a persisted path, Reload did nothing while disabled, and the settings view looked half-configured when League Class was disabled.
- Make disabled-mode explicit by hiding lower configuration controls so users immediately see the system is inactive and avoid confusing manual-override visibility while disabled.
- Preserve persisted settings ownership and existing enable-time mode guard so re-enabling restores prior config without unexpected clearing.

### Description
- Wrapped the League Race configuration area in `GlobalSettingsView.xaml` with a visibility guard bound to `Settings.LeagueClassEnabled` and added a short helper `TextBlock` that shows "League Class system disabled" when off, collapsing all lower controls while disabled.
- Kept CSV ownership in persisted settings and updated the Browse flow in `GlobalSettingsView.xaml.cs` to write the chosen path to `Plugin.Settings.LeagueClassCsvPath` and immediately mirror it into `LeagueClassCsvPathTextBox.Text` so the textbox reflects the persisted value right away.
- Added a guard in the Reload handler so `ReloadLeagueClassCsv_Click` no-ops when `Plugin.Settings.LeagueClassEnabled` is false, avoiding a confusing no-op Reload; re-enable still calls `Plugin.ReloadLeagueClassConfig()` normally.
- Updated `Docs/RepoStatus.md` and `Docs/Internal/Development_Changelog.md` with a short note describing the disabled-mode UI behavior and CSV binding fix.

### Testing
- Ran `git status --short` to confirm working-tree changes were staged (succeeded).
- Attempted a local build with `dotnet build -v minimal`, which could not run in this environment because the `dotnet` SDK is not installed (failed); no other automated tests were available in this sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e9c3f2cc832fb91c898aa59715ff)