### PR TITLE
Fix Strategy XAML duplicate Style and Opponents NativeCarRow accessibility build blockers

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,8 @@
+- 2026-05-03 Build triage follow-up (PR range #647-#652):
+  - fixed Fuel per Lap helper TextBlock XAML compile break by removing duplicate Style assignment in `FuelCalculatorView.xaml` while preserving existing source-text trigger behavior (`FuelPerLapSourceInfo` / Profile / Live);
+  - confirmed `InvertBooleanConverter` and `LapTimeValidationRule` class/namespace wiring are valid in-project; reported lookup errors were downstream/designer fallout from the XAML parse failure;
+  - fixed League Class race-context delegate accessibility seam by making `OpponentsEngine.NativeCarRow` publicly accessible to match the public delegate signature consumed by `LalaLaunch` (`IsRaceContextClassMatch`), with no opponent ordering/filtering logic changes.
+
 ## 2026-05-03 — Strategy follow-up (effective condition notifications + Live Detect planner-basis snapshot)
 - Classification: **internal-only** (view-model notification correctness + planner/live comparability correctness).
 - `SelectedTrackCondition` now raises `IsEffectiveDryCondition` and `IsEffectiveWetCondition` property notifications when condition changes (including auto-applied telemetry condition flips through the same setter path).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,8 @@
+- 2026-05-03 Build triage follow-up (PR range #647-#652):
+  - fixed Fuel per Lap helper TextBlock XAML compile break by removing duplicate Style assignment in `FuelCalculatorView.xaml` while preserving existing source-text trigger behavior (`FuelPerLapSourceInfo` / Profile / Live);
+  - confirmed `InvertBooleanConverter` and `LapTimeValidationRule` class/namespace wiring are valid in-project; reported lookup errors were downstream/designer fallout from the XAML parse failure;
+  - fixed League Class race-context delegate accessibility seam by making `OpponentsEngine.NativeCarRow` publicly accessible to match the public delegate signature consumed by `LalaLaunch` (`IsRaceContextClassMatch`), with no opponent ordering/filtering logic changes.
+
 - 2026-05-03 Strategy planner-basis/condition-notify follow-up landed:
   - effective track-condition visibility properties now notify on SelectedTrackCondition changes;
   - planner/live session-match snapshot now uses Live Detect effective basis/length (or reports non-comparable until detected basis exists).

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -412,7 +412,7 @@
                             <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Width="50" HorizontalAlignment="Left" Text="{Binding FuelPerLapText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      ToolTip="Fuel burn per lap (L/lap). Edit to override the suggested value." />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="2,4,0,0" VerticalAlignment="Center" Style="{StaticResource UnitHint}">
+                            <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="2,4,0,0" VerticalAlignment="Center">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Text" Value="{Binding FuelPerLapSourceInfo}"/>

--- a/Opponents.cs
+++ b/Opponents.cs
@@ -1626,7 +1626,7 @@ namespace LaunchPlugin
             }
         }
 
-        private class NativeCarRow
+        public class NativeCarRow
         {
             public int CarIdx;
             public string IdentityKey;


### PR DESCRIPTION
### Motivation
- Recent PRs in the #647–#652 range introduced build-time XAML parse failures and an accessibility mismatch causing compile errors: a duplicate `Style` assignment in the Strategy `FuelCalculatorView.xaml` broke XAML parsing/ designer resolution, and `OpponentsEngine.NativeCarRow` was not publicly accessible while consumed via a public race-context delegate from `LalaLaunch`.

### Description
- Removed the duplicate inline `Style` assignment on the Fuel-per-Lap helper `TextBlock` in `FuelCalculatorView.xaml`, preserving the existing `TextBlock.Style` trigger logic that selects `FuelPerLapSourceInfo` / Profile / Live labels.
- Made `OpponentsEngine.NativeCarRow` `public` so the type is legally visible to the `IsRaceContextClassMatch` delegate consumers in `LalaLaunch`, without changing opponent ordering, filtering, or League Class semantics.
- Added a short internal entry to `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` documenting the build-triage fixes.

### Testing
- Attempted full build with `dotnet build LalaRaceAssist.sln`, but the environment lacks the .NET SDK so the build could not be executed (`dotnet: command not found`).
- Ran targeted automated checks: repository greps (`rg`) to verify the edited XAML node and `NativeCarRow` declaration, and confirmed `InvertBooleanConverter` and `LapTimeValidationRule` are present and included in the project; these checks succeeded.
- Confirmed files were staged and committed; no further compile errors were observable via static inspection, and remaining XAML lookup/designer errors should clear after a clean build/rebuild in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72ca622c0832fabb2e465074bdba6)