### PR TITLE
Live Detect: show helper text, fix basis visibility, and add bounded diagnostics

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,4 +1,9 @@
 - 2026-05-03 Build triage follow-up (PR range #647-#652):
+- 2026-05-03 Strategy Live Detect functional follow-up (#633) landed:
+  - added Live Detect helper text under Race Type showing detected declared race session + basis + value, or explicit unavailable wording when no valid declared race exists;
+  - Live Detect effective-basis visibility now clears to none when unavailable (no silent Lap-Limited UI fallback), while ownership radio remains Live Detect;
+  - added bounded Strategy INFO log on Live Detect result-change only (`session/basis/value/reason`) for declared-race detection diagnostics.
+
   - fixed Fuel per Lap helper TextBlock XAML compile break by removing duplicate Style assignment in `FuelCalculatorView.xaml` while preserving existing source-text trigger behavior (`FuelPerLapSourceInfo` / Profile / Live);
   - confirmed `InvertBooleanConverter` and `LapTimeValidationRule` class/namespace wiring are valid in-project; reported lookup errors were downstream/designer fallout from the XAML parse failure;
   - fixed League Class race-context delegate accessibility seam by making `OpponentsEngine.NativeCarRow` publicly accessible to match the public delegate signature consumed by `LalaLaunch` (`IsRaceContextClassMatch`), with no opponent ordering/filtering logic changes.

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -194,6 +194,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Strategy] live-cap authority available=... source=... litres=...`** — Strategy live-cap resolver state from runtime-authoritative seam.
 - **`[LalaPlugin:Strategy] UpdateLiveDisplay: live max tank refresh ...`** — Strategy live snapshot max-tank display refresh event.
 - **`[LalaPlugin:Strategy] RefreshLiveSnapshot requested.`** — Explicit strategy-side live-snapshot refresh action invoked.
+- **`[LalaPlugin:Strategy] Live Detect changed: session=... basis=... value=... reason=...`** — Emitted only when Live Detect result changes (session/basis/value/reason), to bound diagnostic noise while validating declared-race detection.
 
 ## Message system v1
 - **`[LalaPlugin:MSGV1] <message>`** — General MSGV1 engine logs (e.g., stack outputs).【F:Messaging/MessageEngine.cs†L478-L560】

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -311,3 +311,4 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 - Fuel-per-lap source/helper text now renders below the input to avoid narrow-width clipping.
 - Track Condition now has explicit `Auto` / `Dry` / `Wet` ownership states. Auto clears manual override and shows `Automatic (dry|wet)`; manual states show `Manual override: dry|wet`.
 - Race Type now includes persistent `Live Detect` ownership. While selected, race type/length consume declared race metadata (`SessionInfo.SessionsXX` where `IsRace==true`) and race-length controls are read-only.
+- Live Detect now shows helper text under Race Type (`session, basis, value` or `no declared race found`) and never silently defaults the UI to Lap-Limited when no valid declared race definition is available.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -122,6 +122,7 @@ namespace LaunchPlugin
     private string _selectedTrack;
     private RaceType _raceType;
     private RaceType? _liveDetectedRaceType;
+    private string _liveDetectHelperText = "Live Detect: no declared race found";
     private double _lastLiveDetectedRaceLaps;
     private double _lastLiveDetectedRaceMinutes;
     private double _raceLaps;
@@ -1128,6 +1129,7 @@ namespace LaunchPlugin
     }
     public bool ShowEffectiveLapLimitedRace => IsLapLimitedRace || (IsLiveDetectRace && _liveDetectedRaceType == RaceType.LapLimited);
     public bool ShowEffectiveTimeLimitedRace => IsTimeLimitedRace || (IsLiveDetectRace && _liveDetectedRaceType == RaceType.TimeLimited);
+    public string LiveDetectHelperText => _liveDetectHelperText;
 
     public double RaceLaps
     {
@@ -5189,7 +5191,7 @@ namespace LaunchPlugin
 
     public bool IsRaceLengthEditable => !IsLiveDetectRace;
 
-    public void UpdateLiveDetectedRaceDefinition(bool? isLapLimited, double? raceLaps, bool? isTimeLimited, double? raceMinutes)
+    public void UpdateLiveDetectedRaceDefinition(string detectedSessionLabel, bool? isLapLimited, double? raceLaps, bool? isTimeLimited, double? raceMinutes)
     {
         if (!IsLiveDetectRace)
         {
@@ -5222,6 +5224,12 @@ namespace LaunchPlugin
                 RaceLaps = _lastLiveDetectedRaceLaps;
                 shouldRecalculate = false; // RaceLaps setter already recalculates
             }
+            _liveDetectHelperText = string.Format(
+                CultureInfo.InvariantCulture,
+                "Live Detect: {0}, lap-limited, {1:0} laps",
+                string.IsNullOrWhiteSpace(detectedSessionLabel) ? "declared race" : detectedSessionLabel.Trim(),
+                _lastLiveDetectedRaceLaps);
+            OnPropertyChanged(nameof(LiveDetectHelperText));
         }
         else if (hasTime)
         {
@@ -5245,6 +5253,26 @@ namespace LaunchPlugin
                 RaceMinutes = _lastLiveDetectedRaceMinutes;
                 shouldRecalculate = false; // RaceMinutes setter already recalculates
             }
+            _liveDetectHelperText = string.Format(
+                CultureInfo.InvariantCulture,
+                "Live Detect: {0}, time-limited, {1:0} min",
+                string.IsNullOrWhiteSpace(detectedSessionLabel) ? "declared race" : detectedSessionLabel.Trim(),
+                _lastLiveDetectedRaceMinutes);
+            OnPropertyChanged(nameof(LiveDetectHelperText));
+        }
+        else
+        {
+            if (_liveDetectedRaceType.HasValue)
+            {
+                shouldRecalculate = true;
+            }
+            _liveDetectedRaceType = null;
+            OnPropertyChanged(nameof(IsLapLimitedRace));
+            OnPropertyChanged(nameof(IsTimeLimitedRace));
+            OnPropertyChanged(nameof(ShowEffectiveLapLimitedRace));
+            OnPropertyChanged(nameof(ShowEffectiveTimeLimitedRace));
+            _liveDetectHelperText = "Live Detect: no declared race found";
+            OnPropertyChanged(nameof(LiveDetectHelperText));
         }
 
         if (shouldRecalculate)

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -535,7 +535,7 @@
                             ToolTip="Open the Preset Manager to create, rename, edit, or delete strategy presets."/>
                             </Grid>
 
-                            <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
+                        <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
                             <TextBlock Text="Race Type:" VerticalAlignment="Center" Margin="0,0,10,0"
                                        ToolTip="Choose whether the race is limited by laps or time."/>
                             <RadioButton Content="Lap-Limited" IsChecked="{Binding IsLapLimitedRace, Mode=TwoWay}" GroupName="RaceType"
@@ -545,6 +545,11 @@
                             <RadioButton Content="Live Detect" IsChecked="{Binding IsLiveDetectRace, Mode=TwoWay}" GroupName="RaceType" Margin="10,0,0,0"
                                          ToolTip="Use declared race session metadata as race type/length authority."/>
                         </StackPanel>
+                        <TextBlock Text="{Binding LiveDetectHelperText}"
+                                   Margin="0,-6,0,10"
+                                   FontSize="12"
+                                   Opacity="0.8"
+                                   Visibility="{Binding IsLiveDetectRace, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                         <ui:TitledSlider Title="Race Laps:" Minimum="1" Maximum="500" Value="{Binding RaceLaps, Mode=TwoWay}" Visibility="{Binding ShowEffectiveLapLimitedRace, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" IsEnabled="{Binding IsRaceLengthEditable}"
                                          ToolTip="Total race distance in laps."/>

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -873,6 +873,7 @@ namespace LaunchPlugin
         private double _lastLiveMaxHealthLoggedComputed = double.NaN;
         private double _lastLiveMaxHealthLoggedEffective = double.NaN;
         private string _lastLiveMaxHealthLoggedSource = string.Empty;
+        private string _lastLiveDetectLogSignature = string.Empty;
         private DateTime _lastFuelRuntimeRecoveryUtc = DateTime.MinValue;
         private DateTime _lastFuelRuntimeHealthCheckUtc = DateTime.MinValue;
         private int _fuelRuntimeUnhealthyStreak = 0;
@@ -3011,11 +3012,20 @@ namespace LaunchPlugin
             double? detectedRaceLaps = null;
             bool? detectedTimeLimited = null;
             double? detectedRaceMinutes = null;
+            int detectedSessionIndex = 0;
+            string detectedSessionName = string.Empty;
+            string unavailableReason = "no declared race found";
             for (int i = 1; i <= 64; i++)
             {
                 string idx = i.ToString("00", CultureInfo.InvariantCulture);
                 bool isRace = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsRace", false);
                 if (!isRace) continue;
+                if (detectedSessionIndex == 0)
+                {
+                    detectedSessionIndex = i;
+                    detectedSessionName = (pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionName") ?? string.Empty).ToString();
+                    unavailableReason = "declared race has no valid lap/time definition";
+                }
 
                 bool isLimitedLaps = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedSessionLaps", false);
                 object sessionLapsRaw = pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionLaps");
@@ -3032,8 +3042,11 @@ namespace LaunchPlugin
                     // Prefer any valid lap-limited race definition over timed definitions.
                     detectedLapLimited = true;
                     detectedRaceLaps = sessionLapsValue;
+                    detectedSessionIndex = i;
+                    detectedSessionName = (pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionName") ?? string.Empty).ToString();
                     detectedTimeLimited = null;
                     detectedRaceMinutes = null;
+                    unavailableReason = string.Empty;
                     break;
                 }
                 else if (isLimitedTime && sessionTimeSeconds > 0.0)
@@ -3043,10 +3056,40 @@ namespace LaunchPlugin
                     {
                         detectedTimeLimited = true;
                         detectedRaceMinutes = sessionTimeSeconds / 60.0;
+                        detectedSessionIndex = i;
+                        detectedSessionName = (pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionName") ?? string.Empty).ToString();
+                        unavailableReason = string.Empty;
                     }
                 }
             }
-            FuelCalculator?.UpdateLiveDetectedRaceDefinition(detectedLapLimited, detectedRaceLaps, detectedTimeLimited, detectedRaceMinutes);
+            FuelCalculator?.UpdateLiveDetectedRaceDefinition(detectedSessionName, detectedLapLimited, detectedRaceLaps, detectedTimeLimited, detectedRaceMinutes);
+
+            string liveDetectBasis = detectedLapLimited == true ? "lap" : (detectedTimeLimited == true ? "time" : "none");
+            double liveDetectValue = detectedLapLimited == true
+                ? detectedRaceLaps.GetValueOrDefault(0.0)
+                : (detectedTimeLimited == true ? detectedRaceMinutes.GetValueOrDefault(0.0) : 0.0);
+            string signature = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}|{1}|{2:0.###}|{3}",
+                detectedSessionIndex,
+                liveDetectBasis,
+                liveDetectValue,
+                unavailableReason ?? string.Empty);
+            if (!string.Equals(signature, _lastLiveDetectLogSignature, StringComparison.Ordinal))
+            {
+                _lastLiveDetectLogSignature = signature;
+                string sessionLabel = detectedSessionIndex > 0
+                    ? string.Format(CultureInfo.InvariantCulture, "Session{0:00} ({1})", detectedSessionIndex, string.IsNullOrWhiteSpace(detectedSessionName) ? "unnamed" : detectedSessionName.Trim())
+                    : "none";
+                SimHub.Logging.Current.Info(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "[LalaPlugin:Strategy] Live Detect changed: session={0} basis={1} value={2:0.###} reason={3}",
+                        sessionLabel,
+                        liveDetectBasis,
+                        liveDetectValue,
+                        string.IsNullOrWhiteSpace(unavailableReason) ? "n/a" : unavailableReason));
+            }
 
             // --- 1) Gather required data ---
             UpdateLiveMaxFuel(pluginManager);


### PR DESCRIPTION
### Motivation
- Make Live Detect behaviour visible to the user by showing which declared race session and basis (lap/time) is being applied. 
- Prevent a silent UI fallback to lap-limited when no valid declared race definition exists. 
- Provide bounded diagnostic logging to help debug detection mismatches without spamming logs.

### Description
- Added a `LiveDetectHelperText` view-model field and bound it in `FuelCalculatorView.xaml` as a small helper line shown only when Live Detect is selected. 
- Extended `FuelCalcs.UpdateLiveDetectedRaceDefinition(...)` to accept a detected session label, set/clear the effective basis reliably, update the helper text for lap/time/none cases, and force planner recompute on basis flips. 
- Updated `LalaLaunch.UpdateLiveFuelCalcs(...)` to scan `SessionInfo.Sessions01..64`, capture the detected session index/name, prefer valid lap-limited candidates (fallback to timed only), pass the session label into the fuel view-model, and compute a signature so we emit a single `Info` log only when the Live Detect result changes. 
- Updated docs: `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Internal/SimHubLogMessages.md`, and `Docs/Internal/Development_Changelog.md` to record the new helper text and the new `Live Detect changed: ...` diagnostic line.

### Testing
- Confirmed change set in working tree and created a commit (`git status` / `git commit` succeeded). 
- Attempted an automated build with `dotnet build`, but the environment lacks `dotnet` so the build could not be run here (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7dea4eb48832f896c5bfe970e543d)