### PR TITLE
Fix League Race detected-classes table refresh and row edit notifications

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -7,6 +7,13 @@
   - Disabled class definitions now mark CSV-resolved league class invalid (`Source=Native` fallback path), so drivers safely fall back to native class behavior; manual player override path remains independent.
   - CSV reload merge behavior now preserves edits for matching class names, adds defaults for new names, and prunes removed names by mirroring current detected CSV class set.
 
+- 2026-05-04 League Race detected-classes UI binding/notification fix landed:
+  - `LaunchPluginSettings.LeagueClassDefinitions` now raises `PropertyChanged` when CSV reload replaces the list, so WPF `ItemsControl` refreshes rows immediately;
+  - `LeagueClassDefinition` now implements `INotifyPropertyChanged` for `Enabled`, `ShortName`, `Rank`, and `ColourHex` so row edits update UI bindings/live preview consistently;
+  - plugin now subscribes to League Class definition row changes to save settings immediately and refresh resolver-consumer preview paths without restart;
+  - scope remains UI/settings/resolver-binding only (no Opponents/H2H/CarSA/PitExit/ClassLeader cohort ownership changes).
+
+
 - 2026-05-03 Build triage follow-up (PR range #647-#652):
 - 2026-05-03 Strategy Live Detect functional follow-up (#633) landed:
   - added Live Detect helper text under Race Type showing detected declared race session + basis + value, or explicit unavailable wording when no valid declared race exists;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -6,6 +6,13 @@
   - disabled detected classes now resolve invalid in League Class path and safely fall back to native class behavior; manual player override path remains independent;
   - CSV reload preserves edits by class-name key for existing rows, adds defaults for new class names, and drops removed class names (settings list mirrors currently detected CSV classes).
 
+- 2026-05-04 League Race detected-classes UI binding/notification fix landed:
+  - `LaunchPluginSettings.LeagueClassDefinitions` now raises `PropertyChanged` when CSV reload replaces the list, so WPF `ItemsControl` refreshes rows immediately;
+  - `LeagueClassDefinition` now implements `INotifyPropertyChanged` for `Enabled`, `ShortName`, `Rank`, and `ColourHex` so row edits update UI bindings/live preview consistently;
+  - plugin now subscribes to League Class definition row changes to save settings immediately and refresh resolver-consumer preview paths without restart;
+  - scope remains UI/settings/resolver-binding only (no Opponents/H2H/CarSA/PitExit/ClassLeader cohort ownership changes).
+
+
 - 2026-05-03 Build triage follow-up (PR range #647-#652):
   - fixed Fuel per Lap helper TextBlock XAML compile break by removing duplicate Style assignment in `FuelCalculatorView.xaml` while preserving existing source-text trigger behavior (`FuelPerLapSourceInfo` / Profile / Live);
   - confirmed `InvertBooleanConverter` and `LapTimeValidationRule` class/namespace wiring are valid in-project; reported lookup errors were downstream/designer fallout from the XAML parse failure;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5167,6 +5167,8 @@ namespace LaunchPlugin
         private DateTime _customMessageSaveDueUtc = DateTime.MinValue;
         private bool _friendsDirty = true;
         private LaunchPluginSettings _subscribedLeagueClassSettings;
+        private List<LeagueClassDefinition> _subscribedLeagueClassDefinitions;
+        private readonly HashSet<LeagueClassDefinition> _leagueClassDefinitionSubscriptions = new HashSet<LeagueClassDefinition>();
         private bool _isSavingSettings;
         private bool _carSaBestLapFallbackInfoLogged;
         private const double CarSaLapTimeUpdateVisibilitySeconds = 3.0;
@@ -11526,6 +11528,8 @@ namespace LaunchPlugin
                 _subscribedLeagueClassSettings.PropertyChanged -= OnLeagueClassSettingsPropertyChanged;
                 _subscribedLeagueClassSettings = null;
             }
+            UnsubscribeAllLeagueClassDefinitionEntries();
+            _subscribedLeagueClassDefinitions = null;
 
             if (settings == null)
             {
@@ -11535,11 +11539,20 @@ namespace LaunchPlugin
             _subscribedLeagueClassSettings = settings;
             _subscribedLeagueClassSettings.PropertyChanged += OnLeagueClassSettingsPropertyChanged;
             _leagueClassLastEnabledState = settings.LeagueClassEnabled;
+            HookLeagueClassDefinitions(settings.LeagueClassDefinitions);
         }
 
         private void OnLeagueClassSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             string propertyName = e?.PropertyName ?? string.Empty;
+            if (string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassDefinitions), StringComparison.Ordinal))
+            {
+                HookLeagueClassDefinitions(_subscribedLeagueClassSettings?.LeagueClassDefinitions);
+                OnPropertyChanged(nameof(LeagueClassStatus));
+                OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+                return;
+            }
+
             if (!string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassEnabled), StringComparison.Ordinal) &&
                 !string.Equals(propertyName, nameof(LaunchPluginSettings.LeagueClassMode), StringComparison.Ordinal))
             {
@@ -11551,6 +11564,68 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
             OnPropertyChanged(nameof(LeagueClassShowCsvSection));
             OnPropertyChanged(nameof(LeagueClassShowFallbackSection));
+        }
+
+        private void HookLeagueClassDefinitions(List<LeagueClassDefinition> definitions)
+        {
+            if (ReferenceEquals(_subscribedLeagueClassDefinitions, definitions))
+            {
+                return;
+            }
+
+            UnsubscribeAllLeagueClassDefinitionEntries();
+            _subscribedLeagueClassDefinitions = definitions;
+            SubscribeLeagueClassDefinitionEntries(definitions);
+        }
+
+        private void SubscribeLeagueClassDefinitionEntries(IList<LeagueClassDefinition> entries)
+        {
+            if (entries == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                SubscribeLeagueClassDefinitionEntry(entries[i]);
+            }
+        }
+
+        private void SubscribeLeagueClassDefinitionEntry(LeagueClassDefinition entry)
+        {
+            if (entry == null)
+            {
+                return;
+            }
+
+            if (_leagueClassDefinitionSubscriptions.Add(entry))
+            {
+                entry.PropertyChanged += OnLeagueClassDefinitionPropertyChanged;
+            }
+        }
+
+        private void UnsubscribeAllLeagueClassDefinitionEntries()
+        {
+            if (_leagueClassDefinitionSubscriptions.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var entry in _leagueClassDefinitionSubscriptions)
+            {
+                if (entry != null)
+                {
+                    entry.PropertyChanged -= OnLeagueClassDefinitionPropertyChanged;
+                }
+            }
+
+            _leagueClassDefinitionSubscriptions.Clear();
+        }
+
+        private void OnLeagueClassDefinitionPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(LeagueClassPlayerPreviewText));
+            SaveSettings();
         }
 
         private void SubscribeCustomMessageEntries(IList<CustomMessageSlot> entries)
@@ -18203,7 +18278,18 @@ namespace LaunchPlugin
             new LeagueClassFallbackRule(),
             new LeagueClassFallbackRule()
         };
-        public List<LeagueClassDefinition> LeagueClassDefinitions { get; set; } = new List<LeagueClassDefinition>();
+        private List<LeagueClassDefinition> _leagueClassDefinitions = new List<LeagueClassDefinition>();
+        public List<LeagueClassDefinition> LeagueClassDefinitions
+        {
+            get { return _leagueClassDefinitions; }
+            set
+            {
+                var normalized = value ?? new List<LeagueClassDefinition>();
+                if (ReferenceEquals(_leagueClassDefinitions, normalized)) return;
+                _leagueClassDefinitions = normalized;
+                OnPropertyChanged(nameof(LeagueClassDefinitions));
+            }
+        }
         private int _darkModeMode = 1;
         public int DarkModeMode
         {

--- a/LeagueClassResolver.cs
+++ b/LeagueClassResolver.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.IO;
 using System.Linq;
 
@@ -46,13 +48,77 @@ namespace LaunchPlugin
         public int Rank { get; set; }
     }
 
-    public sealed class LeagueClassDefinition
+    public sealed class LeagueClassDefinition : INotifyPropertyChanged
     {
-        public string CsvClassName { get; set; } = string.Empty;
-        public bool Enabled { get; set; } = true;
-        public string ShortName { get; set; } = string.Empty;
-        public int Rank { get; set; }
-        public string ColourHex { get; set; } = string.Empty;
+        private string _csvClassName = string.Empty;
+        private bool _enabled = true;
+        private string _shortName = string.Empty;
+        private int _rank;
+        private string _colourHex = string.Empty;
+
+        public string CsvClassName
+        {
+            get { return _csvClassName; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_csvClassName, normalized, StringComparison.Ordinal)) return;
+                _csvClassName = normalized;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool Enabled
+        {
+            get { return _enabled; }
+            set
+            {
+                if (_enabled == value) return;
+                _enabled = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string ShortName
+        {
+            get { return _shortName; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_shortName, normalized, StringComparison.Ordinal)) return;
+                _shortName = normalized;
+                OnPropertyChanged();
+            }
+        }
+
+        public int Rank
+        {
+            get { return _rank; }
+            set
+            {
+                if (_rank == value) return;
+                _rank = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string ColourHex
+        {
+            get { return _colourHex; }
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_colourHex, normalized, StringComparison.Ordinal)) return;
+                _colourHex = normalized;
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 
     public sealed class LeagueClassFallbackRule


### PR DESCRIPTION
### Motivation
- The detected-classes ItemsControl was bound to `Settings.LeagueClassDefinitions`, but CSV reload replaced the plain `List<LeagueClassDefinition>` without raising `PropertyChanged`, so WPF kept the old (empty) reference and rendered no rows.
- Row edits (Enabled/ShortName/Rank/ColourHex) also used auto-properties, so live UI updates, preview refresh and settings persistence were unreliable.
- The goal is to make the UI refresh immediately after CSV reload and to ensure row edits update bindings, live preview and saved settings without touching runtime Opponents/H2H/CarSA/PitExit/ClassLeader code.

### Description
- Made `LeagueClassDefinition` implement `INotifyPropertyChanged` and added change-notifying backing fields for `CsvClassName`, `Enabled`, `ShortName`, `Rank`, and `ColourHex` so row edits raise property notifications.
- Changed `LaunchPluginSettings.LeagueClassDefinitions` from an auto-property to a backing-field property that raises `OnPropertyChanged(nameof(LeagueClassDefinitions))` when the list is replaced so WPF rebinds the ItemsControl after reload.
- Added plugin-side subscribe/unsubscribe hooks in `LalaLaunch` to monitor `LeagueClassDefinition.PropertyChanged` on each row, call `SaveSettings()` on edits, and refresh preview-dependent properties so edits persist and resolver consumers immediately see changes.
- Updated internal docs (`Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`) to record the fix and scope (UI/settings/resolver-binding only).

### Testing
- Attempted `dotnet build -v minimal` in this environment and it failed with `dotnet: command not found`, so a full compile/test run was not possible here (failure).
- Code-level verification performed via repository inspection confirmed the collection-property notification and row-level `INotifyPropertyChanged` implementations are present and plugin subscribes to row changes (no automated build was executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a970bca0832f8e4b2c6e4303838e)