### PR TITLE
Fix Strategy Live Detect race-definition source resolution

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,7 @@
+- 2026-05-04 Strategy Live Detect review fix-up landed:
+  - when `CurrentSessionInfo.IsRace==true` but current-session race length is unusable, Live Detect now continues to `Sessions01..64` fallback scanning so declared race definitions can still be recovered;
+  - replaced telemetry-path lap-count casts in Live Detect detection with tolerant long parsing (`SafeReadLong`) for current-session and SessionsXX underscore/non-underscore lap properties to avoid invalid-cast throw paths.
+
 - 2026-05-04 Strategy Live Detect race-definition source/underscore fix landed:
   - Live Detect now prioritizes `CurrentSessionInfo` only when `CurrentSessionInfo.IsRace==true`, resolving race length from underscore fields first (`_SessionLaps`, `_SessionTime`) with non-underscore compatibility fallback only when underscore values are unusable;
   - `Sessions01..64` fallback now runs only when current session is not race/unavailable/has no usable length, and helper wording now distinguishes `race found, no valid length` from `no declared race found`;

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,8 @@
+- 2026-05-04 Strategy Live Detect race-definition source/underscore fix landed:
+  - Live Detect now prioritizes `CurrentSessionInfo` only when `CurrentSessionInfo.IsRace==true`, resolving race length from underscore fields first (`_SessionLaps`, `_SessionTime`) with non-underscore compatibility fallback only when underscore values are unusable;
+  - `Sessions01..64` fallback now runs only when current session is not race/unavailable/has no usable length, and helper wording now distinguishes `race found, no valid length` from `no declared race found`;
+  - bounded Live Detect result-change log now includes source/session/IsRace/limit flags/raw length fields plus selected basis/reason for diagnostics.
+
 - 2026-05-03 League Race CSV detected-classes editing layer landed:
   - Classification: **both** (user-facing League Class UI editability + resolver/settings persistence behavior alignment).
   - Added persisted class-definition layer `LeagueClassDefinitions` keyed by CSV class name with editable fields: `Enabled`, `ShortName`, `Rank`, `ColourHex` (CSV class name remains read-only in UI).

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,7 @@
+- 2026-05-04 Strategy Live Detect review fix-up 2 landed:
+  - `CurrentSessionInfo` race-length detection now respects race limit flags (`IsLimitedSessionLaps`/`IsLimitedTime`) before accepting `_SessionLaps`/`_SessionTime`, with Sessions fallback still active when flagged current-session length is unusable;
+  - hardened `SafeReadLong` decimal conversion with explicit `long` range guard to prevent overflow throw paths in telemetry updates.
+
 - 2026-05-04 Strategy Live Detect review fix-up landed:
   - when `CurrentSessionInfo.IsRace==true` but current-session race length is unusable, Live Detect now continues to `Sessions01..64` fallback scanning so declared race definitions can still be recovered;
   - replaced telemetry-path lap-count casts in Live Detect detection with tolerant long parsing (`SafeReadLong`) for current-session and SessionsXX underscore/non-underscore lap properties to avoid invalid-cast throw paths.

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -194,7 +194,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Strategy] live-cap authority available=... source=... litres=...`** — Strategy live-cap resolver state from runtime-authoritative seam.
 - **`[LalaPlugin:Strategy] UpdateLiveDisplay: live max tank refresh ...`** — Strategy live snapshot max-tank display refresh event.
 - **`[LalaPlugin:Strategy] RefreshLiveSnapshot requested.`** — Explicit strategy-side live-snapshot refresh action invoked.
-- **`[LalaPlugin:Strategy] Live Detect changed: session=... basis=... value=... reason=...`** — Emitted only when Live Detect result changes (session/basis/value/reason), to bound diagnostic noise while validating declared-race detection.
+- **`[LalaPlugin:Strategy] Live Detect changed: source=... session=... isRace=... isLimitedSessionLaps=... sessionLaps=... isLimitedTime=... sessionTime=... basis=... value=... reason=...`** — Emitted only when Live Detect result-signature changes, with source/session/limit fields included for bounded declared-race diagnostics.
 
 ## Message system v1
 - **`[LalaPlugin:MSGV1] <message>`** — General MSGV1 engine logs (e.g., stack outputs).【F:Messaging/MessageEngine.cs†L478-L560】

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,7 @@
+- 2026-05-04 Strategy Live Detect P1 review follow-up landed:
+  - fallback scan of `Sessions01..64` now still runs when `CurrentSessionInfo.IsRace==true` but current-session race length is missing/invalid, allowing fallback recovery of valid declared race definitions;
+  - Live Detect lap-count reads now use tolerant parsing for current-session and SessionsXX (`_SessionLaps` then `SessionLaps`) so invalid/null/string values degrade safely to `0` in telemetry path.
+
 - 2026-05-04 Strategy Live Detect race-definition source fix landed:
   - race-definition detection now prioritizes `CurrentSessionInfo` only when `CurrentSessionInfo.IsRace==true` and reads underscore session length authority first (`_SessionLaps`/`_SessionTime`), with non-underscore compatibility fallback after underscore attempts;
   - `Sessions01..64` fallback applies only when current session race data is unavailable/non-race/lengthless, and helper text now reports `race found, no valid length` when a race is visible but unusable;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,8 @@
+- 2026-05-04 Strategy Live Detect race-definition source fix landed:
+  - race-definition detection now prioritizes `CurrentSessionInfo` only when `CurrentSessionInfo.IsRace==true` and reads underscore session length authority first (`_SessionLaps`/`_SessionTime`), with non-underscore compatibility fallback after underscore attempts;
+  - `Sessions01..64` fallback applies only when current session race data is unavailable/non-race/lengthless, and helper text now reports `race found, no valid length` when a race is visible but unusable;
+  - bounded result-change logging now includes source/session/limit/raw-length fields with selected basis/reason for Live Detect diagnostics.
+
 - 2026-05-03 League Race CSV detected-classes editing layer landed:
   - added persisted user-editable class-definition layer (`LeagueClassDefinitions`) keyed by CSV class name, with editable `Enabled`, `ShortName`, `Rank`, and `ColourHex`;
   - detected-classes table now binds to settings-owned editable rows; CSV class name remains read-only while enabled/rank/short/colour fields are editable with live colour preview;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,7 @@
+- 2026-05-04 Strategy Live Detect P1/P2 review follow-up landed:
+  - current-session race definition acceptance now requires matching limit flags (`IsLimitedSessionLaps` for laps, `IsLimitedTime` for timed) in addition to positive values;
+  - `SafeReadLong` now range-checks decimal values before casting, so out-of-range decimals safely return fallback instead of throwing.
+
 - 2026-05-04 Strategy Live Detect P1 review follow-up landed:
   - fallback scan of `Sessions01..64` now still runs when `CurrentSessionInfo.IsRace==true` but current-session race length is missing/invalid, allowing fallback recovery of valid declared race definitions;
   - Live Detect lap-count reads now use tolerant parsing for current-session and SessionsXX (`_SessionLaps` then `SessionLaps`) so invalid/null/string values degrade safely to `0` in telemetry path.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -311,4 +311,4 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 - Fuel-per-lap source/helper text now renders below the input to avoid narrow-width clipping.
 - Track Condition now has explicit `Auto` / `Dry` / `Wet` ownership states. Auto clears manual override and shows `Automatic (dry|wet)`; manual states show `Manual override: dry|wet`.
 - Race Type now includes persistent `Live Detect` ownership. While selected, race type/length consume declared race metadata (`SessionInfo.SessionsXX` where `IsRace==true`) and race-length controls are read-only.
-- Live Detect now shows helper text under Race Type (`session, basis, value` or `no declared race found`) and never silently defaults the UI to Lap-Limited when no valid declared race definition is available.
+- Live Detect now shows helper text under Race Type (`current race/session, basis, value`; `race found, no valid length`; or `no declared race found`) and never silently defaults the UI to Lap-Limited when no valid declared race definition is available.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -5271,7 +5271,12 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(IsTimeLimitedRace));
             OnPropertyChanged(nameof(ShowEffectiveLapLimitedRace));
             OnPropertyChanged(nameof(ShowEffectiveTimeLimitedRace));
-            _liveDetectHelperText = "Live Detect: no declared race found";
+            _liveDetectHelperText = string.IsNullOrWhiteSpace(detectedSessionLabel)
+                ? "Live Detect: no declared race found"
+                : string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Live Detect: {0}, race found, no valid length",
+                    detectedSessionLabel.Trim());
             OnPropertyChanged(nameof(LiveDetectHelperText));
         }
 

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3037,51 +3037,115 @@ namespace LaunchPlugin
             double? detectedRaceMinutes = null;
             int detectedSessionIndex = 0;
             string detectedSessionName = string.Empty;
-            string unavailableReason = "no declared race found";
-            for (int i = 1; i <= 64; i++)
+            string detectedSource = "none";
+            bool detectedIsRace = false;
+            bool detectedIsLimitedSessionLaps = false;
+            bool detectedIsLimitedTime = false;
+            long detectedSessionLapsRaw = 0L;
+            double detectedSessionTimeRaw = 0.0;
+            string selectedReason = "no declared race found";
+
+            bool currentIsRace = SafeReadBool(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.IsRace", false);
+            if (currentIsRace)
             {
-                string idx = i.ToString("00", CultureInfo.InvariantCulture);
-                bool isRace = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsRace", false);
-                if (!isRace) continue;
-                if (detectedSessionIndex == 0)
+                detectedSource = "CurrentSessionInfo";
+                detectedIsRace = true;
+                detectedSessionName = "current race";
+                detectedIsLimitedSessionLaps = SafeReadBool(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.IsLimitedSessionLaps", false);
+                detectedIsLimitedTime = SafeReadBool(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.IsLimitedTime", false);
+                detectedSessionLapsRaw = Convert.ToInt64(pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.CurrentSessionInfo._SessionLaps") ?? 0L);
+                if (detectedSessionLapsRaw <= 0L)
                 {
-                    detectedSessionIndex = i;
-                    detectedSessionName = (pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionName") ?? string.Empty).ToString();
-                    unavailableReason = "declared race has no valid lap/time definition";
+                    detectedSessionLapsRaw = Convert.ToInt64(pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.CurrentSessionInfo.SessionLaps") ?? 0L);
+                }
+                detectedSessionTimeRaw = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo._SessionTime", 0.0);
+                if (detectedSessionTimeRaw <= 0.0)
+                {
+                    detectedSessionTimeRaw = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.SessionTime", 0.0);
                 }
 
-                bool isLimitedLaps = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedSessionLaps", false);
-                object sessionLapsRaw = pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionLaps");
-                long sessionLapsValue = 0L;
-                if (sessionLapsRaw != null)
+                if (detectedSessionLapsRaw > 0L)
                 {
-                    long.TryParse(sessionLapsRaw.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out sessionLapsValue);
-                }
-                bool isLimitedTime = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedTime", false);
-                double sessionTimeSeconds = SafeReadDouble(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionTime", 0.0);
-
-                if (isLimitedLaps && sessionLapsValue > 0)
-                {
-                    // Prefer any valid lap-limited race definition over timed definitions.
                     detectedLapLimited = true;
-                    detectedRaceLaps = sessionLapsValue;
-                    detectedSessionIndex = i;
-                    detectedSessionName = (pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionName") ?? string.Empty).ToString();
-                    detectedTimeLimited = null;
-                    detectedRaceMinutes = null;
-                    unavailableReason = string.Empty;
-                    break;
+                    detectedRaceLaps = detectedSessionLapsRaw;
+                    selectedReason = "lap-limited";
                 }
-                else if (isLimitedTime && sessionTimeSeconds > 0.0)
+                else if (detectedSessionTimeRaw > 0.0)
                 {
-                    // Keep timed candidate only as fallback if no valid lap-limited race is found.
-                    if (!detectedTimeLimited.HasValue || detectedRaceMinutes.GetValueOrDefault() <= 0.0)
+                    detectedTimeLimited = true;
+                    detectedRaceMinutes = detectedSessionTimeRaw / 60.0;
+                    selectedReason = "time-limited";
+                }
+                else
+                {
+                    selectedReason = "race found, no valid length";
+                }
+            }
+            else
+            {
+                bool foundRaceSession = false;
+                for (int i = 1; i <= 64; i++)
+                {
+                    string idx = i.ToString("00", CultureInfo.InvariantCulture);
+                    bool isRace = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsRace", false);
+                    if (!isRace) continue;
+
+                    if (!foundRaceSession)
                     {
-                        detectedTimeLimited = true;
-                        detectedRaceMinutes = sessionTimeSeconds / 60.0;
+                        foundRaceSession = true;
                         detectedSessionIndex = i;
-                        detectedSessionName = (pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionName") ?? string.Empty).ToString();
-                        unavailableReason = string.Empty;
+                        detectedSessionName = $"Session{idx}";
+                        detectedSource = "SessionsXX";
+                        detectedIsRace = true;
+                        selectedReason = "race found, no valid length";
+                    }
+
+                    bool isLimitedLaps = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedSessionLaps", false);
+                    bool isLimitedTime = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedTime", false);
+                    long sessionLapsValue = Convert.ToInt64(pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}._SessionLaps") ?? 0L);
+                    if (sessionLapsValue <= 0L)
+                    {
+                        sessionLapsValue = Convert.ToInt64(pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionLaps") ?? 0L);
+                    }
+                    double sessionTimeSeconds = SafeReadDouble(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}._SessionTime", 0.0);
+                    if (sessionTimeSeconds <= 0.0)
+                    {
+                        sessionTimeSeconds = SafeReadDouble(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionTime", 0.0);
+                    }
+
+                    if (isLimitedLaps && sessionLapsValue > 0L)
+                    {
+                        detectedLapLimited = true;
+                        detectedRaceLaps = sessionLapsValue;
+                        detectedSessionIndex = i;
+                        detectedSessionName = $"Session{idx}";
+                        detectedSource = "SessionsXX";
+                        detectedIsRace = true;
+                        detectedIsLimitedSessionLaps = isLimitedLaps;
+                        detectedSessionLapsRaw = sessionLapsValue;
+                        detectedIsLimitedTime = isLimitedTime;
+                        detectedSessionTimeRaw = sessionTimeSeconds;
+                        selectedReason = "lap-limited";
+                        detectedTimeLimited = null;
+                        detectedRaceMinutes = null;
+                        break;
+                    }
+                    else if (isLimitedTime && sessionTimeSeconds > 0.0)
+                    {
+                        if (!detectedTimeLimited.HasValue || detectedRaceMinutes.GetValueOrDefault() <= 0.0)
+                        {
+                            detectedTimeLimited = true;
+                            detectedRaceMinutes = sessionTimeSeconds / 60.0;
+                            detectedSessionIndex = i;
+                            detectedSessionName = $"Session{idx}";
+                            detectedSource = "SessionsXX";
+                            detectedIsRace = true;
+                            detectedIsLimitedSessionLaps = isLimitedLaps;
+                            detectedSessionLapsRaw = sessionLapsValue;
+                            detectedIsLimitedTime = isLimitedTime;
+                            detectedSessionTimeRaw = sessionTimeSeconds;
+                            selectedReason = "time-limited";
+                        }
                     }
                 }
             }
@@ -3097,7 +3161,7 @@ namespace LaunchPlugin
                 detectedSessionIndex,
                 liveDetectBasis,
                 liveDetectValue,
-                unavailableReason ?? string.Empty);
+                selectedReason ?? string.Empty);
             if (!string.Equals(signature, _lastLiveDetectLogSignature, StringComparison.Ordinal))
             {
                 _lastLiveDetectLogSignature = signature;
@@ -3107,11 +3171,17 @@ namespace LaunchPlugin
                 SimHub.Logging.Current.Info(
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "[LalaPlugin:Strategy] Live Detect changed: session={0} basis={1} value={2:0.###} reason={3}",
+                        "[LalaPlugin:Strategy] Live Detect changed: source={0} session={1} isRace={2} isLimitedSessionLaps={3} sessionLaps={4} isLimitedTime={5} sessionTime={6:0.###} basis={7} value={8:0.###} reason={9}",
+                        detectedSource,
                         sessionLabel,
+                        detectedIsRace,
+                        detectedIsLimitedSessionLaps,
+                        detectedSessionLapsRaw,
+                        detectedIsLimitedTime,
+                        detectedSessionTimeRaw,
                         liveDetectBasis,
                         liveDetectValue,
-                        string.IsNullOrWhiteSpace(unavailableReason) ? "n/a" : unavailableReason));
+                        string.IsNullOrWhiteSpace(selectedReason) ? "n/a" : selectedReason));
             }
 
             // --- 1) Gather required data ---

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3046,6 +3046,7 @@ namespace LaunchPlugin
             string selectedReason = "no declared race found";
 
             bool currentIsRace = SafeReadBool(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.IsRace", false);
+            bool shouldScanSessionFallback = !currentIsRace;
             if (currentIsRace)
             {
                 detectedSource = "CurrentSessionInfo";
@@ -3053,10 +3054,10 @@ namespace LaunchPlugin
                 detectedSessionName = "current race";
                 detectedIsLimitedSessionLaps = SafeReadBool(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.IsLimitedSessionLaps", false);
                 detectedIsLimitedTime = SafeReadBool(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.IsLimitedTime", false);
-                detectedSessionLapsRaw = Convert.ToInt64(pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.CurrentSessionInfo._SessionLaps") ?? 0L);
+                detectedSessionLapsRaw = SafeReadLong(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo._SessionLaps", 0L);
                 if (detectedSessionLapsRaw <= 0L)
                 {
-                    detectedSessionLapsRaw = Convert.ToInt64(pluginManager.GetPropertyValue("DataCorePlugin.GameRawData.CurrentSessionInfo.SessionLaps") ?? 0L);
+                    detectedSessionLapsRaw = SafeReadLong(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.SessionLaps", 0L);
                 }
                 detectedSessionTimeRaw = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo._SessionTime", 0.0);
                 if (detectedSessionTimeRaw <= 0.0)
@@ -3079,9 +3080,10 @@ namespace LaunchPlugin
                 else
                 {
                     selectedReason = "race found, no valid length";
+                    shouldScanSessionFallback = true;
                 }
             }
-            else
+            if (shouldScanSessionFallback)
             {
                 bool foundRaceSession = false;
                 for (int i = 1; i <= 64; i++)
@@ -3102,10 +3104,10 @@ namespace LaunchPlugin
 
                     bool isLimitedLaps = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedSessionLaps", false);
                     bool isLimitedTime = SafeReadBool(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.IsLimitedTime", false);
-                    long sessionLapsValue = Convert.ToInt64(pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}._SessionLaps") ?? 0L);
+                    long sessionLapsValue = SafeReadLong(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}._SessionLaps", 0L);
                     if (sessionLapsValue <= 0L)
                     {
-                        sessionLapsValue = Convert.ToInt64(pluginManager.GetPropertyValue($"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionLaps") ?? 0L);
+                        sessionLapsValue = SafeReadLong(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}.SessionLaps", 0L);
                     }
                     double sessionTimeSeconds = SafeReadDouble(pluginManager, $"DataCorePlugin.GameRawData.SessionData.SessionInfo.Sessions{idx}._SessionTime", 0.0);
                     if (sessionTimeSeconds <= 0.0)
@@ -13809,6 +13811,54 @@ namespace LaunchPlugin
             {
                 return fallback;
             }
+        }
+
+        private static long SafeReadLong(PluginManager pluginManager, string propertyName, long fallback)
+        {
+            if (pluginManager == null || string.IsNullOrWhiteSpace(propertyName))
+            {
+                return fallback;
+            }
+
+            object raw;
+            try
+            {
+                raw = pluginManager.GetPropertyValue(propertyName);
+            }
+            catch
+            {
+                return fallback;
+            }
+
+            if (raw == null)
+            {
+                return fallback;
+            }
+
+            switch (raw)
+            {
+                case long l:
+                    return l;
+                case int i:
+                    return i;
+                case short s:
+                    return s;
+                case byte b:
+                    return b;
+                case double d when !double.IsNaN(d) && !double.IsInfinity(d):
+                    return (long)d;
+                case float f when !float.IsNaN(f) && !float.IsInfinity(f):
+                    return (long)f;
+                case decimal m:
+                    return (long)m;
+            }
+
+            if (long.TryParse(Convert.ToString(raw), NumberStyles.Any, CultureInfo.InvariantCulture, out long parsed))
+            {
+                return parsed;
+            }
+
+            return fallback;
         }
 
         private static bool SafeReadBool(PluginManager pluginManager, string propertyName, bool fallback)

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -3065,13 +3065,13 @@ namespace LaunchPlugin
                     detectedSessionTimeRaw = SafeReadDouble(pluginManager, "DataCorePlugin.GameRawData.CurrentSessionInfo.SessionTime", 0.0);
                 }
 
-                if (detectedSessionLapsRaw > 0L)
+                if (detectedIsLimitedSessionLaps && detectedSessionLapsRaw > 0L)
                 {
                     detectedLapLimited = true;
                     detectedRaceLaps = detectedSessionLapsRaw;
                     selectedReason = "lap-limited";
                 }
-                else if (detectedSessionTimeRaw > 0.0)
+                else if (detectedIsLimitedTime && detectedSessionTimeRaw > 0.0)
                 {
                     detectedTimeLimited = true;
                     detectedRaceMinutes = detectedSessionTimeRaw / 60.0;
@@ -13850,6 +13850,10 @@ namespace LaunchPlugin
                 case float f when !float.IsNaN(f) && !float.IsInfinity(f):
                     return (long)f;
                 case decimal m:
+                    if (m > long.MaxValue || m < long.MinValue)
+                    {
+                        return fallback;
+                    }
                     return (long)m;
             }
 


### PR DESCRIPTION
### Motivation
- Live Detect could report “no declared race found” even when SimHub provided a valid declared race via underscore session fields (`_SessionLaps` / `_SessionTime`), because the detection code read non-underscore properties first and did not prioritise `CurrentSessionInfo` correctly.
- The change ensures Strategy Live Detect uses the correct source/field priority: use `CurrentSessionInfo` only when `CurrentSessionInfo.IsRace == true`, prefer underscore fields first, and only fall back to `Sessions01..64` when current-session race data is not a race or has no usable length.

### Description
- Updated `UpdateLiveFuelCalcs(...)` in `LalaLaunch.cs` to read `DataCorePlugin.GameRawData.CurrentSessionInfo.IsRace` and to resolve `_SessionLaps` / `_SessionTime` first from `CurrentSessionInfo`, with non-underscore compatibility fallback and a `Sessions01..64` scan only when the current session is not race/unavailable/lengthless.
- Scanning of `Sessions01..64` was hardened to read underscore properties first (`_SessionLaps`, `_SessionTime`) and to prefer lap-limited definitions before timed fallbacks, and to set an explicit selected reason (`lap-limited`, `time-limited`, `race found, no valid length`, or `no declared race found`).
- Expanded the bounded Live Detect INFO log to include `source`, `session`, `isRace`, `isLimitedSessionLaps`, raw lap/time values, basis, value and the selected reason while still emitting only on signature changes (to bound noise). 
- Adjusted `FuelCalcs.UpdateLiveDetectedRaceDefinition(...)` in `FuelCalcs.cs` so the UI helper text reports `race found, no valid length` when a race session exists but has no usable length, and preserved existing lap/time helper wording.
- Synchronized docs and changelogs in `Docs/Internal/SimHubLogMessages.md`, `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` to reflect the new detection priority, underscore-first reads, and expanded log contract.
- Files changed: `LalaLaunch.cs`, `FuelCalcs.cs`, `Docs/Internal/SimHubLogMessages.md`, `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.

### Testing
- Attempted to build with `dotnet build -v minimal` but the environment has no `dotnet` installed, so compilation was not executed here (build not performed).
- Performed targeted static verifications including `rg` searches and inspected the updated code regions with `nl`/`sed` to verify the new detection flow, logging signature, and helper-text updates, and those inspections passed.
- Verified git staging/commit state with `git status --short` and committed the changes as `Fix Strategy Live Detect race-definition source resolution`.
- No automated unit/integration tests were executed in this environment due to missing SDK; recommend running a local `dotnet build` and any existing unit test suite after checkout to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8aa5fb378832fbf6436f8a491a958)