### PR TITLE
Fix Live Detect effective strategy basis and session-refresh recalculation

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,9 @@
+- 2026-05-04 Strategy Live Detect effective-basis/runtime-refresh fix landed:
+  - strategy calculation now resolves an explicit effective race basis/length (manual or Live Detect) and no longer falls through to Lap-Limited/manual laps when Live Detect has no valid detected definition;
+  - Live Detect timed sessions now always run strategy/stint/first-stint/total-fuel paths from detected minutes, while detected lap-limited sessions use detected laps;
+  - Live Detect race-definition updates now cache helper/basis changes even before selection and force recalculation when selected basis/value/availability changes;
+  - session-context transitions now trigger an immediate Live Detect refresh when Live Detect is selected, avoiding stale initial-session detection until radio toggling.
+
 - 2026-05-04 Strategy Live Detect review fix-up 2 landed:
   - `CurrentSessionInfo` race-length detection now respects race limit flags (`IsLimitedSessionLaps`/`IsLimitedTime`) before accepting `_SessionLaps`/`_SessionTime`, with Sessions fallback still active when flagged current-session length is unusable;
   - hardened `SafeReadLong` decimal conversion with explicit `long` range guard to prevent overflow throw paths in telemetry updates.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,9 @@
+- 2026-05-04 Strategy Live Detect effective-basis/runtime-refresh fix landed:
+  - strategy planner now computes from an explicit effective race basis/length seam (manual or Live Detect) and never silently defaults Live Detect-null basis to Lap-Limited/manual laps;
+  - timed Live Detect strategy paths (fuel total/stints/first-stint/after-zero) now consistently use detected minutes, while lap-limited Live Detect uses detected laps;
+  - Live Detect definition updates now force strategy recalculation on basis/value/availability helper changes when Live Detect is selected;
+  - session-id/type transitions now perform an immediate Live Detect refresh when Live Detect is selected, reducing stale detection on initial load/context transitions.
+
 - 2026-05-04 Strategy Live Detect P1/P2 review follow-up landed:
   - current-session race definition acceptance now requires matching limit flags (`IsLimitedSessionLaps` for laps, `IsLimitedTime` for timed) in addition to positive values;
   - `SafeReadLong` now range-checks decimal values before casting, so out-of-range decimals safely return fallback instead of throwing.

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -312,3 +312,10 @@ Reset semantics are shared with the Fuel Model and documented centrally in:
 - Track Condition now has explicit `Auto` / `Dry` / `Wet` ownership states. Auto clears manual override and shows `Automatic (dry|wet)`; manual states show `Manual override: dry|wet`.
 - Race Type now includes persistent `Live Detect` ownership. While selected, race type/length consume declared race metadata (`SessionInfo.SessionsXX` where `IsRace==true`) and race-length controls are read-only.
 - Live Detect now shows helper text under Race Type (`current race/session, basis, value`; `race found, no valid length`; or `no declared race found`) and never silently defaults the UI to Lap-Limited when no valid declared race definition is available.
+- Strategy calculation now resolves an explicit effective race basis/length seam:
+  - manual `Time-Limited` => `RaceMinutes`,
+  - manual `Lap-Limited` => `RaceLaps`,
+  - `Live Detect` timed => detected minutes,
+  - `Live Detect` lap-limited => detected laps,
+  - `Live Detect` with no valid detected basis => strategy stays invalid (`Live Detect race definition unavailable`) and does not silently run lap-based math.
+- Live Detect refresh now runs on session context transitions (session id/type changes) when Live Detect is selected, in addition to normal periodic polling.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -41,6 +41,45 @@ namespace LaunchPlugin
         }
     }
 
+    private bool TryGetEffectiveRaceBasis(out bool isTimeLimited, out double raceLength)
+    {
+        isTimeLimited = false;
+        raceLength = 0.0;
+
+        if (SelectedRaceType == RaceType.TimeLimited)
+        {
+            isTimeLimited = true;
+            raceLength = Math.Max(0.0, RaceMinutes);
+            return true;
+        }
+
+        if (SelectedRaceType == RaceType.LapLimited)
+        {
+            isTimeLimited = false;
+            raceLength = Math.Max(0.0, RaceLaps);
+            return true;
+        }
+
+        if (SelectedRaceType == RaceType.LiveDetect && _liveDetectedRaceType.HasValue)
+        {
+            if (_liveDetectedRaceType.Value == RaceType.TimeLimited)
+            {
+                isTimeLimited = true;
+                raceLength = Math.Max(0.0, _lastLiveDetectedRaceMinutes);
+                return true;
+            }
+
+            if (_liveDetectedRaceType.Value == RaceType.LapLimited)
+            {
+                isTimeLimited = false;
+                raceLength = Math.Max(0.0, _lastLiveDetectedRaceLaps);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     internal PlannerLiveSessionMatchSnapshot GetPlannerSessionMatchSnapshot()
     {
         string plannerCar = (SelectedCarProfile?.ProfileName ?? string.Empty).Trim();
@@ -58,41 +97,7 @@ namespace LaunchPlugin
             plannerTrack = _lastLoadedTrackKey.Trim();
         }
 
-        bool hasComparableBasis = true;
-        bool plannerTimeLimited = false;
-        double plannerRaceLength = 0.0;
-
-        if (SelectedRaceType == RaceType.TimeLimited)
-        {
-            plannerTimeLimited = true;
-            plannerRaceLength = Math.Max(0.0, RaceMinutes);
-        }
-        else if (SelectedRaceType == RaceType.LapLimited)
-        {
-            plannerTimeLimited = false;
-            plannerRaceLength = Math.Max(0.0, RaceLaps);
-        }
-        else if (SelectedRaceType == RaceType.LiveDetect && _liveDetectedRaceType.HasValue)
-        {
-            if (_liveDetectedRaceType.Value == RaceType.TimeLimited)
-            {
-                plannerTimeLimited = true;
-                plannerRaceLength = Math.Max(0.0, RaceMinutes);
-            }
-            else if (_liveDetectedRaceType.Value == RaceType.LapLimited)
-            {
-                plannerTimeLimited = false;
-                plannerRaceLength = Math.Max(0.0, RaceLaps);
-            }
-            else
-            {
-                hasComparableBasis = false;
-            }
-        }
-        else
-        {
-            hasComparableBasis = false;
-        }
+        bool hasComparableBasis = TryGetEffectiveRaceBasis(out bool plannerTimeLimited, out double plannerRaceLength);
 
         return new PlannerLiveSessionMatchSnapshot
         {
@@ -4697,9 +4702,33 @@ namespace LaunchPlugin
             }
             // ------------------------------------------------------------------------
 
+            bool hasEffectiveRaceBasis = TryGetEffectiveRaceBasis(out bool effectiveRaceIsTimeLimited, out double effectiveRaceLength);
+            if (!hasEffectiveRaceBasis || effectiveRaceLength <= 0.0)
+            {
+                ValidationMessage = IsLiveDetectRace
+                    ? "Error: Live Detect race definition unavailable."
+                    : "Error: Race length must be greater than zero.";
+            }
+
+            if (IsValidationMessageVisible)
+            {
+                TotalFuelNeeded = 0.0;
+                RequiredPitStops = 0;
+                StintBreakdown = "";
+                StopsSaved = 0;
+                TotalTimeDifference = "N/A";
+                ExtraTimeAfterLeader = "N/A";
+                StrategyLeaderExtraSecondsAfterZero = 0.0;
+                StrategyDriverExtraSecondsAfterZero = 0.0;
+                FirstStintFuel = 0.0;
+                PlannerNextAddLitres = 0.0;
+                PlannerTankBasisLitres = 0.0;
+                return;
+            }
+
             double num6 = 0.0;
-            double baseSeconds = RaceMinutes * 60.0;
-            if (IsTimeLimitedRace)
+            double baseSeconds = effectiveRaceIsTimeLimited ? (effectiveRaceLength * 60.0) : 0.0;
+            if (effectiveRaceIsTimeLimited)
             {
                 double availableDriveSeconds = baseSeconds;
                 int num7 = 0;
@@ -4737,15 +4766,15 @@ namespace LaunchPlugin
                 int num20 = 0;
                 if (num3 - num2 > 0.0 && num3 > 0.0)
                 {
-                    num20 = (int)Math.Floor(RaceLaps / (num2 / (num3 - num2)));
+                    num20 = (int)Math.Floor(effectiveRaceLength / (num2 / (num3 - num2)));
                 }
-                num6 = Math.Max(0.0, RaceLaps - (double)num20);
+                num6 = Math.Max(0.0, effectiveRaceLength - (double)num20);
             }
 
             double driveSecondsAvailable = baseSeconds;
             StrategyResult strategyResult;
 
-            if (IsTimeLimitedRace)
+            if (effectiveRaceIsTimeLimited)
             {
                 var provisional = CalculateSingleStrategy(
                     num6, fuelPerLap, num3, num2, num, driveSecondsAvailable, maxFuelLimit);
@@ -4793,7 +4822,7 @@ namespace LaunchPlugin
             }
 
             StrategyResult strategyResult2 = CalculateSingleStrategy(
-                num6, num24, num3 + num4, num2, num, RaceMinutes * 60.0, maxFuelLimit);
+                num6, num24, num3 + num4, num2, num, baseSeconds, maxFuelLimit);
 
             StopsSaved = strategyResult.Stops - strategyResult2.Stops;
             double num25 = strategyResult2.TotalTime - strategyResult.TotalTime;
@@ -4804,7 +4833,9 @@ namespace LaunchPlugin
 
         private void ApplyStrategyDriveTimeAfterZero(double raceClockSeconds, double leaderPaceSeconds, double playerPaceSeconds, StrategyResult strategyResult)
         {
-            if (IsTimeLimitedRace && playerPaceSeconds > 0.0)
+            bool isTimeLimited = TryGetEffectiveRaceBasis(out bool effectiveRaceIsTimeLimited, out _)
+                && effectiveRaceIsTimeLimited;
+            if (isTimeLimited && playerPaceSeconds > 0.0)
             {
                 var (leaderExtraSeconds, driverExtraSeconds) = ComputeDriveTimeAfterZero(
                     raceClockSeconds,
@@ -5193,11 +5224,6 @@ namespace LaunchPlugin
 
     public void UpdateLiveDetectedRaceDefinition(string detectedSessionLabel, bool? isLapLimited, double? raceLaps, bool? isTimeLimited, double? raceMinutes)
     {
-        if (!IsLiveDetectRace)
-        {
-            return;
-        }
-
         bool hasLap = isLapLimited == true && raceLaps.HasValue && raceLaps.Value > 0.0;
         bool hasTime = isTimeLimited == true && raceMinutes.HasValue && raceMinutes.Value > 0.0;
         bool shouldRecalculate = false;
@@ -5224,12 +5250,17 @@ namespace LaunchPlugin
                 RaceLaps = _lastLiveDetectedRaceLaps;
                 shouldRecalculate = false; // RaceLaps setter already recalculates
             }
-            _liveDetectHelperText = string.Format(
+            string helperText = string.Format(
                 CultureInfo.InvariantCulture,
                 "Live Detect: {0}, lap-limited, {1:0} laps",
                 string.IsNullOrWhiteSpace(detectedSessionLabel) ? "declared race" : detectedSessionLabel.Trim(),
                 _lastLiveDetectedRaceLaps);
-            OnPropertyChanged(nameof(LiveDetectHelperText));
+            if (!string.Equals(_liveDetectHelperText, helperText, StringComparison.Ordinal))
+            {
+                _liveDetectHelperText = helperText;
+                shouldRecalculate = true;
+                OnPropertyChanged(nameof(LiveDetectHelperText));
+            }
         }
         else if (hasTime)
         {
@@ -5253,12 +5284,17 @@ namespace LaunchPlugin
                 RaceMinutes = _lastLiveDetectedRaceMinutes;
                 shouldRecalculate = false; // RaceMinutes setter already recalculates
             }
-            _liveDetectHelperText = string.Format(
+            string helperText = string.Format(
                 CultureInfo.InvariantCulture,
                 "Live Detect: {0}, time-limited, {1:0} min",
                 string.IsNullOrWhiteSpace(detectedSessionLabel) ? "declared race" : detectedSessionLabel.Trim(),
                 _lastLiveDetectedRaceMinutes);
-            OnPropertyChanged(nameof(LiveDetectHelperText));
+            if (!string.Equals(_liveDetectHelperText, helperText, StringComparison.Ordinal))
+            {
+                _liveDetectHelperText = helperText;
+                shouldRecalculate = true;
+                OnPropertyChanged(nameof(LiveDetectHelperText));
+            }
         }
         else
         {
@@ -5271,16 +5307,21 @@ namespace LaunchPlugin
             OnPropertyChanged(nameof(IsTimeLimitedRace));
             OnPropertyChanged(nameof(ShowEffectiveLapLimitedRace));
             OnPropertyChanged(nameof(ShowEffectiveTimeLimitedRace));
-            _liveDetectHelperText = string.IsNullOrWhiteSpace(detectedSessionLabel)
+            string helperText = string.IsNullOrWhiteSpace(detectedSessionLabel)
                 ? "Live Detect: no declared race found"
                 : string.Format(
                     CultureInfo.InvariantCulture,
                     "Live Detect: {0}, race found, no valid length",
                     detectedSessionLabel.Trim());
-            OnPropertyChanged(nameof(LiveDetectHelperText));
+            if (!string.Equals(_liveDetectHelperText, helperText, StringComparison.Ordinal))
+            {
+                _liveDetectHelperText = helperText;
+                shouldRecalculate = true;
+                OnPropertyChanged(nameof(LiveDetectHelperText));
+            }
         }
 
-        if (shouldRecalculate)
+        if (shouldRecalculate && IsLiveDetectRace)
         {
             CalculateStrategy();
             RaisePresetStateChanged();

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -16645,6 +16645,11 @@ namespace LaunchPlugin
                 _finishTimingSessionType = sessionType;
                 _afterZeroResultLogged = false;
                 ResetFinishTimingState();
+
+                if (FuelCalculator != null && FuelCalculator.IsLiveDetectRace)
+                {
+                    UpdateLiveFuelCalcs(data, pluginManager);
+                }
             }
 
             if (!isRace)


### PR DESCRIPTION
### Motivation
- Correct strategy math when `SelectedRaceType == LiveDetect` so timed detections use minutes and lap detections use laps instead of falling through to the lap-limited/manual branch.
- Ensure strategy and planner snapshot logic use one shared effective race-basis source to avoid inconsistent branching and stale/no-data initial-load behaviour.
- Make Live Detect updates and session transitions reliably trigger strategy recalculation when the effective basis/value/availability changes while preserving existing UI semantics.

### Description
- Added `TryGetEffectiveRaceBasis(...)` in `FuelCalcs` to provide a single effective race-basis/resolved length seam used by planner, strategy, and session-match logic.
- Rewrote `CalculateStrategy()` and related paths to consume the effective basis/length (timed uses detected minutes, lap-limited uses detected laps) and to return an explicit validation error when Live Detect has no valid basis instead of silently defaulting to lap math.
- Updated `ApplyStrategyDriveTimeAfterZero(...)` and `GetPlannerSessionMatchSnapshot()` to use the effective-basis helper so after-zero and planner-match behavior follow the same semantics.
- Hardened `UpdateLiveDetectedRaceDefinition(...)` to cache helper-text/state changes, only raise recalculation when the detected basis/value/helper actually changes, and only force recalculation when Live Detect is selected.
- Trigger an immediate Live Detect refresh on session id/type transitions by calling `UpdateLiveFuelCalcs(...)` from `UpdateFinishTiming(...)` when Live Detect is active to avoid stale initial-session results.
- Synced documentation: `Docs/Subsystems/Fuel_Planner_Tab.md`, `Docs/RepoStatus.md`, and `Docs/Internal/Development_Changelog.md` were updated to record the effective-basis and refresh behaviour changes.

### Testing
- Attempted to validate build with `dotnet build -v minimal`, but `dotnet` is not available in this environment so an automated build could not be run here (build attempt reported `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e8139f68832fa8088618d37cdacb)