### PR TITLE
Fix StrategyDash phase compile errors in LalaLaunch (PR #660 follow-up)

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,12 @@
+### 2026-05-04 — StrategyDash phase compile-fix follow-up (PR #660)
+- Classification: **internal-only** (build fix; no fuel/planner/pit semantics redesign).
+- Fixed `LalaLaunch.UpdateStrategyDashAdvice(...)` phase detection to consume real call-path session booleans (`isRaceRunning`, `isGridOrFormation`) instead of removed/non-existent fields.
+- Kept StrategyDash phase contract unchanged:
+  - `1 = PLANNING`
+  - `2 = GRID FORMATION` (grid + formation combined)
+  - `3 = RACE`
+- Scope bounded to StrategyDash phase input plumbing only; no changes to Fuel DATA/MODE/SOURCE behavior, `PitFuelControlEngine`, `Fuel.Delta.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Pit.*`, boxed refuel latch behavior, or `Pit.FuelControl.*` semantics.
+
 ### 2026-05-04 — League Race header checkbox-column alignment follow-up
 - Classification: **internal-only** (UI layout correction; no runtime/resolver/settings semantic changes).
 - Fixed League Class table header misalignment by reserving a fixed checkbox column width (`18`) for both header and row grids in `Detected classes` and `Fallback rules` sections.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,4 +1,9 @@
 ## Documentation sync status
+- 2026-05-04 StrategyDash phase compile-fix follow-up (PR #660) landed:
+  - `UpdateStrategyDashAdvice(...)` phase detection now takes explicit real-state booleans from the existing pre-race call path (`isRaceRunning`, `isGridOrFormation`) instead of referencing removed non-existent fields;
+  - StrategyDash phase contract is preserved (`1=PLANNING`, `2=GRID FORMATION`, `3=RACE`) with grid+formation still combined;
+  - no changes were made to fuel data/source/mode behavior, `PitFuelControlEngine`, `Fuel.Delta.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Pit.*`, boxed refuel latches, or `Pit.FuelControl.*` semantics.
+
 - 2026-05-04 League Race header alignment follow-up landed:
   - fixed class-table header offset by reserving a fixed checkbox column width (`18`) in both header grids and row grids for Detected classes and Fallback rules;
   - keeps existing bindings/tooltips/edit semantics unchanged (layout-only alignment correction).

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1311,10 +1311,10 @@ namespace LaunchPlugin
             double maxTankCapacity,
             double contingencyLitres,
             string contingencyText,
-            double oneStopNextRefuelTargetLitres)
+            double oneStopNextRefuelTargetLitres,
+            bool isRaceRunning,
+            bool isGridFormation)
         {
-            bool isRaceRunning = string.Equals(_sessionState, "Racing", StringComparison.OrdinalIgnoreCase);
-            bool isGridFormation = _isOnGrid || _isFormationLap || _isRaceStarting;
             StrategyDash_Phase = isRaceRunning ? 3 : (isGridFormation ? 2 : 1);
             StrategyDash_PhaseText = StrategyDash_Phase == 3 ? "RACE" : (StrategyDash_Phase == 2 ? "GRID FORMATION" : "PLANNING");
 
@@ -1370,7 +1370,9 @@ namespace LaunchPlugin
             double fallbackFuelPerLap,
             double effectiveMaxTank,
             double maxTankCapacity,
-            bool allowSetupFallback)
+            bool allowSetupFallback,
+            bool isRaceRunning,
+            bool isGridOrFormation)
         {
             int selectedStrategy = NormalizeStrategyMode(FuelCalculator?.SelectedPreRaceMode ?? 3);
             PreRace_Selected = selectedStrategy;
@@ -1568,7 +1570,7 @@ namespace LaunchPlugin
             else
                 contingencyText = "CONT 0";
 
-            UpdateStrategyDashAdvice(selectedStrategy, requiredStrategy, currentFuel, plannedSingleStopRefuel, effectiveMaxTank, maxTankCapacity, contingencyLitres, contingencyText, oneStopTarget);
+            UpdateStrategyDashAdvice(selectedStrategy, requiredStrategy, currentFuel, plannedSingleStopRefuel, effectiveMaxTank, maxTankCapacity, contingencyLitres, contingencyText, oneStopTarget, isRaceRunning, isGridOrFormation);
         }
 
         // Stable model inputs
@@ -4194,7 +4196,9 @@ namespace LaunchPlugin
                     fallbackFuelPerLap,
                     effectiveMaxTank,
                     maxTankCapacity,
-                    allowSetupFallback: isGridOrFormation);
+                    allowSetupFallback: isGridOrFormation,
+                    isRaceRunning: isRaceRunning,
+                    isGridOrFormation: isGridOrFormation);
 
                 Fuel_Delta_LitresCurrent = 0;
                 Fuel_Delta_LitresPlan = 0;
@@ -4385,7 +4389,9 @@ namespace LaunchPlugin
                     fallbackFuelPerLap,
                     effectiveMaxTank,
                     maxTankCapacity,
-                    allowSetupFallback: isGridOrFormation);
+                    allowSetupFallback: isGridOrFormation,
+                    isRaceRunning: isRaceRunning,
+                    isGridOrFormation: isGridOrFormation);
 
                 PitStopsRequiredByFuel = Math.Max(0, stopsRequiredByFuel);
                 PitStopsRequiredByPlan = plannedStops;


### PR DESCRIPTION
### Motivation
- A recent refactor left `UpdateStrategyDashAdvice(...)` referencing removed/non-existent session-phase fields, causing CS0103 compile errors. 
- Keep StrategyDash phase authority tied to existing real session-state inputs and avoid adding new persistent fields. 
- Preserve the intended StrategyDash phase contract (`1 = PLANNING`, `2 = GRID FORMATION`, `3 = RACE`) and keep StrategyDash pre-green focused.

### Description
- Changed `UpdateStrategyDashAdvice(...)` to accept explicit boolean phase inputs (`isRaceRunning`, `isGridFormation`) instead of referencing removed fields like `_sessionState`, `_isOnGrid`, `_isFormationLap`, and `_isRaceStarting`.
- Extended `UpdatePreRaceOutputs(...)` signature to forward the existing computed session booleans (`isRaceRunning`, `isGridOrFormation`) and updated all pre-race call sites to pass those booleans through to the StrategyDash advice path.
- Preserved all existing StrategyDash mapping and downstream logic (phase numeric/text mapping and advisory outputs) without introducing new persistent state or changing fuel/pit semantics.
- Updated documentation entries in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` to record the compile-fix and scope constraints.

### Testing
- Attempted `dotnet build` in this environment but it could not be executed because `dotnet` is not installed here (`/bin/bash: dotnet: command not found`).
- Verified with a code search (`rg`) that the removed symbols (`_sessionState`, `_isOnGrid`, `_isFormationLap`, `_isRaceStarting`) are no longer referenced in `LalaLaunch.cs`.
- Confirmed the updated call-paths: `UpdatePreRaceOutputs(...)` now forwards `isRaceRunning` and `isGridOrFormation` and `UpdateStrategyDashAdvice(...)` consumes those values, preserving the original StrategyDash phase contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f6ea7b8c832fa42bfda28653a2e2)