### PR TITLE
Strategy: enforce exclusive race-definition ownership in Live Detect

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1828,3 +1828,8 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Persistence behavior:
   - pit-loss and condition lock toggles persist immediately through existing `ProfilesViewModel.SaveProfiles()` convention,
   - marker toggle uses the existing marker-store lock seam (`SetTrackMarkersLock`) and keeps existing marker persistence conventions.
+- 2026-05-04 Strategy tab race-configuration ownership cleanup landed:
+  - Race Preset control now hides while `Live Detect` race type is selected, preventing mixed manual/preset/live ownership cues.
+  - Entering or leaving `Live Detect` now clears selected/applied preset state (and modified badge state) so hidden preset influence cannot persist.
+  - Leaving `Live Detect` resets manual race length fields to neutral defaults (`RaceLaps=20`, `RaceMinutes=40`) before manual Lap/Time planning continues.
+  - Refresh Calcs ownership remains unchanged (recalculation-only; no preset reapply/live-detect retrigger path added).

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1833,3 +1833,7 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
   - Entering or leaving `Live Detect` now clears selected/applied preset state (and modified badge state) so hidden preset influence cannot persist.
   - Leaving `Live Detect` resets manual race length fields to neutral defaults (`RaceLaps=20`, `RaceMinutes=40`) before manual Lap/Time planning continues.
   - Refresh Calcs ownership remains unchanged (recalculation-only; no preset reapply/live-detect retrigger path added).
+### 2026-05-04 — Strategy race-ownership cleanup follow-up (P1 review)
+- Classification: **internal-only** (state-ownership correction; no fuel/detection formula changes).
+- `UpdateLiveDetectedRaceDefinition(...)` now updates manual `RaceLaps` / `RaceMinutes` only while `SelectedRaceType == LiveDetect`; outside Live Detect it still caches helper/basis state but does not mutate manual race-length ownership.
+- Exiting Live Detect now clears detected-length caches (`_lastLiveDetectedRaceLaps`, `_lastLiveDetectedRaceMinutes`) in addition to detected basis type, preventing stale basis reuse on later re-entry when fresh detection is unavailable.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,4 +1,10 @@
 ## Documentation sync status
+- 2026-05-04 Strategy tab race-configuration ownership cleanup landed:
+  - Race Preset selector is now hidden during `Live Detect` ownership and preset modified UI is suppressed in that mode.
+  - Enter/exit `Live Detect` now clears selected/applied preset state to prevent stale hidden preset influence after mode changes.
+  - Exiting `Live Detect` resets manual race length fields to neutral manual defaults (`20 laps` / `40 min`) for explicit post-detect user intent.
+  - Strategy calculation ownership remains effective-basis-only; no fuel model/live detect detection logic changes and no Refresh Calcs ownership mutation.
+
 - 2026-05-04 StrategyDash phase compile-fix follow-up (PR #660) landed:
   - `UpdateStrategyDashAdvice(...)` phase detection now takes explicit real-state booleans from the existing pre-race call path (`isRaceRunning`, `isGridOrFormation`) instead of referencing removed non-existent fields;
   - StrategyDash phase contract is preserved (`1=PLANNING`, `2=GRID FORMATION`, `3=RACE`) with grid+formation still combined;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -5,6 +5,10 @@
   - Exiting `Live Detect` resets manual race length fields to neutral manual defaults (`20 laps` / `40 min`) for explicit post-detect user intent.
   - Strategy calculation ownership remains effective-basis-only; no fuel model/live detect detection logic changes and no Refresh Calcs ownership mutation.
 
+- 2026-05-04 Strategy race-ownership follow-up (P1 review) landed:
+  - Live Detect background refresh now updates cached detected race basis/helper state without mutating manual `RaceLaps`/`RaceMinutes` when Live Detect is not selected.
+  - Live Detect exit now also clears detected lap/minute cache values to prevent stale detected-length reuse across mode transitions.
+
 - 2026-05-04 StrategyDash phase compile-fix follow-up (PR #660) landed:
   - `UpdateStrategyDashAdvice(...)` phase detection now takes explicit real-state booleans from the existing pre-race call path (`isRaceRunning`, `isGridOrFormation`) instead of referencing removed non-existent fields;
   - StrategyDash phase contract is preserved (`1=PLANNING`, `2=GRID FORMATION`, `3=RACE`) with grid+formation still combined;

--- a/Docs/Strategy_System.md
+++ b/Docs/Strategy_System.md
@@ -172,6 +172,10 @@ If Strategy looks repeatedly wrong, the usual causes are:
 - Fuel-per-lap source helper now sits under the input for narrow-width readability.
 - Track condition ownership is explicit: `Auto`, `Dry`, `Wet`.
 - Race type ownership now includes persistent `Live Detect`; detected race format/length are pulled from declared race metadata rather than current practice/qualifying session length.
+- Race-definition ownership is now exclusive:
+  - `Live Detect`: preset selector is hidden, preset selection/applied state are cleared, and race-length controls remain telemetry-owned.
+  - Leaving `Live Detect` for manual Lap/Time clears preset state and resets manual race length controls to neutral defaults (`20 laps` / `40 min`) to avoid stale hidden ownership.
+  - Presets remain one-shot initializers: selecting a preset sets race type + race length once, then manual edits can diverge and show `(modified)`.
 
 - PreRace fuel-needed basis now follows active contingency (`base race fuel + active contingency litres`) instead of the prior hardcoded `+2 laps` buffer.
 - StrategyDash V2 adds pre-green advice exports only; race-running fuel/pit/control contracts remain on existing runtime seams.

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -793,6 +793,8 @@ namespace LaunchPlugin
 
     // Last applied preset (for badge + modified flag)
     private RacePreset _appliedPreset;
+    private const double ManualRaceLapsDefault = 20.0;
+    private const double ManualRaceMinutesDefault = 40.0;
 
     // Badge text shown under the selector
     public string PresetBadge
@@ -804,10 +806,12 @@ namespace LaunchPlugin
                                       : "Preset: " + _appliedPreset.Name;
         }
     }
-        public bool IsPresetModifiedFlag
+    public bool IsPresetModifiedFlag
     {
         get { return IsPresetModified(); }
     }
+
+    public bool ShowRacePresetControls => !IsLiveDetectRace;
 
     // Pit-lane live detection not implemented yet; hide the button for now
     public bool IsLivePitLaneLossAvailable => false;
@@ -1107,11 +1111,16 @@ namespace LaunchPlugin
         {
             if (_raceType != value)
             {
+                var previousRaceType = _raceType;
                 _raceType = value;
+
+                HandleRaceTypeOwnershipTransition(previousRaceType, _raceType);
+
                 OnPropertyChanged("SelectedRaceType");
                 OnPropertyChanged("IsLapLimitedRace");
                 OnPropertyChanged("IsTimeLimitedRace");
                 OnPropertyChanged(nameof(IsLiveDetectRace));
+                OnPropertyChanged(nameof(ShowRacePresetControls));
                 OnPropertyChanged(nameof(IsRaceLengthEditable));
                 OnPropertyChanged(nameof(ShowEffectiveLapLimitedRace));
                 OnPropertyChanged(nameof(ShowEffectiveTimeLimitedRace));
@@ -5221,6 +5230,39 @@ namespace LaunchPlugin
     }
 
     public bool IsRaceLengthEditable => !IsLiveDetectRace;
+
+    private void HandleRaceTypeOwnershipTransition(RaceType previousRaceType, RaceType newRaceType)
+    {
+        if (previousRaceType == newRaceType)
+        {
+            return;
+        }
+
+        if (newRaceType == RaceType.LiveDetect)
+        {
+            _selectedPreset = null;
+            _appliedPreset = null;
+            OnPropertyChanged(nameof(SelectedPreset));
+            OnPropertyChanged(nameof(HasSelectedPreset));
+            return;
+        }
+
+        if (previousRaceType == RaceType.LiveDetect)
+        {
+            _liveDetectedRaceType = null;
+            _selectedPreset = null;
+            _appliedPreset = null;
+            OnPropertyChanged(nameof(SelectedPreset));
+            OnPropertyChanged(nameof(HasSelectedPreset));
+            OnPropertyChanged(nameof(ShowEffectiveLapLimitedRace));
+            OnPropertyChanged(nameof(ShowEffectiveTimeLimitedRace));
+            _liveDetectHelperText = "Live Detect: waiting for race definition";
+            OnPropertyChanged(nameof(LiveDetectHelperText));
+
+            RaceLaps = ManualRaceLapsDefault;
+            RaceMinutes = ManualRaceMinutesDefault;
+        }
+    }
 
     public void UpdateLiveDetectedRaceDefinition(string detectedSessionLabel, bool? isLapLimited, double? raceLaps, bool? isTimeLimited, double? raceMinutes)
     {

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -5250,6 +5250,8 @@ namespace LaunchPlugin
         if (previousRaceType == RaceType.LiveDetect)
         {
             _liveDetectedRaceType = null;
+            _lastLiveDetectedRaceLaps = 0.0;
+            _lastLiveDetectedRaceMinutes = 0.0;
             _selectedPreset = null;
             _appliedPreset = null;
             OnPropertyChanged(nameof(SelectedPreset));
@@ -5287,7 +5289,7 @@ namespace LaunchPlugin
                 shouldRecalculate = true;
             }
             _lastLiveDetectedRaceLaps = raceLaps.Value;
-            if (Math.Abs(RaceLaps - _lastLiveDetectedRaceLaps) > 0.001)
+            if (IsLiveDetectRace && Math.Abs(RaceLaps - _lastLiveDetectedRaceLaps) > 0.001)
             {
                 RaceLaps = _lastLiveDetectedRaceLaps;
                 shouldRecalculate = false; // RaceLaps setter already recalculates
@@ -5321,7 +5323,7 @@ namespace LaunchPlugin
                 shouldRecalculate = true;
             }
             _lastLiveDetectedRaceMinutes = raceMinutes.Value;
-            if (Math.Abs(RaceMinutes - _lastLiveDetectedRaceMinutes) > 0.001)
+            if (IsLiveDetectRace && Math.Abs(RaceMinutes - _lastLiveDetectedRaceMinutes) > 0.001)
             {
                 RaceMinutes = _lastLiveDetectedRaceMinutes;
                 shouldRecalculate = false; // RaceMinutes setter already recalculates

--- a/FuelCalculatorView.xaml
+++ b/FuelCalculatorView.xaml
@@ -490,7 +490,8 @@
                         <TextBlock Text="Race Strategy" FontWeight="Bold" Margin="0,5,0,5"/>
 
                             <!-- Race Preset selector (inline, auto-apply) -->
-                            <Grid Margin="0,10,0,10">
+                            <Grid Margin="0,10,0,10"
+                                  Visibility="{Binding ShowRacePresetControls, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
### Motivation
- Remove ownership ambiguity between Race Presets, Manual Race Type, and Live Detect so exactly one source owns the race definition at any time. 
- Prevent stale preset influence and incorrect "modified" UI cues after entering or leaving `Live Detect` without changing calculation or telemetry logic. 
- Keep changes scoped to UI/state ownership only, preserving fuel model, Live Detect detection, and strategy calculation invariants.

### Description
- Added explicit ownership transition handling in `FuelCalcs` via `HandleRaceTypeOwnershipTransition(...)` and invoked it from the `SelectedRaceType` setter to centralize enter/exit semantics. 
- Entering `LiveDetect` clears `SelectedPreset` and `_appliedPreset` so preset selection and modified badges cannot influence telemetry-owned race definition. 
- Leaving `LiveDetect` clears detected-basis cache, clears preset state, and resets manual fields to neutral defaults (`RaceLaps = 20`, `RaceMinutes = 40`) to avoid stale hidden ownership. 
- UI change: the inline Race Preset block in `FuelCalculatorView.xaml` is hidden while `Live Detect` is active by binding its `Visibility` to a new `ShowRacePresetControls` viewmodel property. 
- Documentation updates: `Docs/Strategy_System.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` updated to describe the exclusive ownership model and transition behavior. 
- Files modified: `FuelCalcs.cs`, `FuelCalculatorView.xaml`, `Docs/Strategy_System.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`.

### Testing
- Attempted to run `dotnet build` in the execution environment but it failed because the `dotnet` CLI is not available here, so no project build/test run was performed in this environment (environment limitation). 
- Ran automated repository checks (`rg`, `sed`) to verify symbol usage, XAML binding presence, and the new properties/method calls were wired correctly; those checks completed successfully. 
- No automated unit/integration tests were added or modified by this change and no runtime telemetry/detection logic was altered, so full build/CI verification should be performed in the normal build environment before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fcdaee60832faf098ecb0472b9b4)