### PR TITLE
Refresh Profiles/Tracks marker lock checkbox after dash toggle

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -404,6 +404,7 @@ namespace LaunchPlugin
         {
             var key = GetCanonicalTrackKeyForMarkers();
             _pit?.SetTrackMarkersLock(key, locked);
+            ProfilesViewModel?.RefreshTrackMarkersSnapshotForSelectedTrack();
         }
 
         public void ToggleTrackLearningPitLossLock()
@@ -428,6 +429,7 @@ namespace LaunchPlugin
                 // Keep the store-provided default lock baseline for missing keyed rows.
             }
             _pit.SetTrackMarkersLock(key, !current);
+            ProfilesViewModel?.RefreshTrackMarkersSnapshotForSelectedTrack();
         }
 
         public void ToggleTrackLearningConditionLock()
@@ -479,6 +481,7 @@ namespace LaunchPlugin
         {
             if (string.IsNullOrWhiteSpace(trackKey)) return;
             _pit?.SetTrackMarkersLock(trackKey, locked);
+            ProfilesViewModel?.RefreshTrackMarkersSnapshotForSelectedTrack();
         }
 
         public void ReloadTrackMarkersFromDisk()


### PR DESCRIPTION
### Motivation
- Dash/TrackLearning marker lock actions were correctly updating the marker store but the Profiles → Tracks locked checkbox did not refresh immediately because the Profiles UI refresh path was not invoked after external lock changes.

### Description
- Call the existing UI refresh seam `ProfilesViewModel?.RefreshTrackMarkersSnapshotForSelectedTrack()` after `SetTrackMarkersLocked(...)`, `ToggleTrackLearningMarkersLock()`, and `SetTrackMarkersLockedForKey(...)` so the checkbox and related snapshot fields update immediately using the ViewModel's dispatcher-safe refresh logic.

### Testing
- Ran an automated `dotnet build` attempt which failed in this environment due to the SDK not being installed (`/bin/bash: dotnet: command not found`), so no successful automated build/test run could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f945c1a1b8832f8f8e8e1f182d4c8a)