### PR TITLE
Fix nullable pit-loss read and align race-context driver-info call signature (build fixes)

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,9 @@
+## 2026-05-05 — Build-fix follow-up: nullable pit-loss read + race-context driver-info signature alignment
+- Classification: **internal-only** (compile correctness fix; no runtime feature/contract redesign).
+- `FuelCalcs.SavePlannerDataToProfile()` now reads existing `PitLaneLossSeconds` with nullable-safe fallback (`?? 0.0`) before diffing planner value.
+- `LalaLaunch.IsRaceContextClassMatchForCarIdx(...)` now calls `TryGetCarDriverInfo(...)` with correct out-parameter types/signature (arg 11 remains `out int teamId`), removing CS1503 argument-type failures.
+- Race-context matcher row names are now left empty in this seam; class-match behavior remains identity/class-driven and unchanged.
+
 ## 2026-05-05 — PR #666 follow-up: planner-save pit-loss learning-mode preservation
 - Classification: **internal-only** (metadata persistence correctness; no UI/export contract changes).
 - Fixed `FuelCalcs.SavePlannerDataToProfile()` so `PitLaneLossSource`/`PitLaneLossLearningMode` are only forced to `manual` when planner save actually changes pit-loss seconds.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,4 +1,9 @@
 ## Documentation sync status
+- 2026-05-05 Build-fix follow-up landed:
+  - fixed nullable pit-loss read in `FuelCalcs.SavePlannerDataToProfile()` (`PitLaneLossSeconds ?? 0.0`) to resolve CS0266;
+  - fixed race-context `TryGetCarDriverInfo(...)` call-site argument types in `LalaLaunch.IsRaceContextClassMatchForCarIdx(...)` (arg 11 stays `out int teamId`) to resolve CS1503;
+  - no intended runtime behavior change (compile restoration only).
+
 - 2026-05-04 StrategyDash IsOnTrackCar phase-gate follow-up landed:
   - `StrategyDash.Phase` now hard-gates `2 = GRID FORMATION` on `DataCorePlugin.GameRawData.Telemetry.IsOnTrackCar==true` in addition to existing grid/formation session-state authority;
   - `3 = RACE` authority remains unchanged;

--- a/FuelCalcs.cs
+++ b/FuelCalcs.cs
@@ -2737,7 +2737,7 @@ namespace LaunchPlugin
             }
         }
 
-        double existingPitLossSec = trackRecord.PitLaneLossSeconds;
+        double existingPitLossSec = trackRecord.PitLaneLossSeconds ?? 0.0;
         bool pitLossChanged = Math.Abs(existingPitLossSec - this.PitLaneTimeLoss) > 0.0005;
         if (pitLossChanged)
         {

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5231,18 +5231,18 @@ namespace LaunchPlugin
                 return IsCarInPlayerClass(pluginManager, candidateCarIdx, isMultiClassSession, playerClassShort);
             }
 
-            if (!TryGetCarDriverInfo(pluginManager, playerCarIdx, out _, out _, out int playerUserId, out _, out _, out _, out _, out _, out string playerName, out _))
+            if (!TryGetCarDriverInfo(pluginManager, playerCarIdx, out _, out _, out int playerUserId, out _, out _, out _, out _, out _, out _, out _))
             {
                 return IsCarInPlayerClass(pluginManager, candidateCarIdx, isMultiClassSession, playerClassShort);
             }
 
-            if (!TryGetCarDriverInfo(pluginManager, candidateCarIdx, out _, out _, out int candidateUserId, out _, out _, out _, out _, out _, out string candidateName, out _))
+            if (!TryGetCarDriverInfo(pluginManager, candidateCarIdx, out _, out _, out int candidateUserId, out _, out _, out _, out _, out _, out _, out _))
             {
                 return false;
             }
 
-            var playerRow = new OpponentsEngine.NativeCarRow { CarIdx = playerCarIdx, IdentityKey = "car:" + playerCarIdx.ToString(CultureInfo.InvariantCulture), UserID = playerUserId, Name = playerName ?? string.Empty };
-            var candidateRow = new OpponentsEngine.NativeCarRow { CarIdx = candidateCarIdx, IdentityKey = "car:" + candidateCarIdx.ToString(CultureInfo.InvariantCulture), UserID = candidateUserId, Name = candidateName ?? string.Empty };
+            var playerRow = new OpponentsEngine.NativeCarRow { CarIdx = playerCarIdx, IdentityKey = "car:" + playerCarIdx.ToString(CultureInfo.InvariantCulture), UserID = playerUserId, Name = string.Empty };
+            var candidateRow = new OpponentsEngine.NativeCarRow { CarIdx = candidateCarIdx, IdentityKey = "car:" + candidateCarIdx.ToString(CultureInfo.InvariantCulture), UserID = candidateUserId, Name = string.Empty };
             return raceContextMatch(playerRow, candidateRow);
         }
 


### PR DESCRIPTION
### Motivation
- Restore build correctness for two compile errors by making nullable-safe reads and aligning a `TryGetCarDriverInfo` call-site to the actual out-parameter signature. 
- Keep runtime behavior and race-context class-matching semantics unchanged while preventing accidental metadata overwrites on planner saves.

### Description
- Use a nullable-safe read for stored pit-lane loss in `FuelCalcs.SavePlannerDataToProfile()` by changing `trackRecord.PitLaneLossSeconds` to `trackRecord.PitLaneLossSeconds ?? 0.0`. 
- Ensure pit-loss metadata (`PitLaneLossSeconds`/`PitLaneLossSource`/`PitLaneLossLearningMode`) is only written when the planner value actually changes (existing logic preserved). 
- Align `LalaLaunch.IsRaceContextClassMatchForCarIdx(...)` call sites to the correct `TryGetCarDriverInfo(...)` signature and stop propagating driver name into the race-context seam by passing empty `Name` fields, resolving argument-type mismatches. 
- Update `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` with the follow-up notes describing these build-fix and preservation changes.

### Testing
- Built the solution (`msbuild`/IDE build) to verify compile errors were resolved and the project now compiles successfully. 
- Ran the existing automated unit test suite (`dotnet test`) and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f947e14c44832fb2794a27d54567b4)