### PR TITLE
Fix League class cohort matching for ClassLeader/ClassBest identity path

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,9 @@
+
+## 2026-05-05 — League Race final cohort integration replay follow-up (ClassLeader/ClassBest identity fix)
+- Classification: **internal-only** (race-context cohort identity seam correction; no math/export contract additions).
+- Fixed `ClassLeader`/`ClassBest` race-context class matching path to construct `OpponentsEngine.NativeCarRow` candidates from session identity sources (`UserID`, `UserName` fallback, `CarNumber`, class-color identity key) rather than synthetic `car:{idx}` rows with blank names.
+- Root cause: when `UserID` is unavailable/zero, League Class resolver matching requires driver name fallback; blank candidate names caused false cohort mismatch, so class leader/best stayed on native class.
+- Preserved fallbacks/invariants: disabled or unresolved League Class still uses native class matching; no `PitExit`/Opponents gap-timing formula changes, no CarSA/H2HTrack ownership changes.
 ## 2026-05-05 — StrategyDash start-fuel advice decoupled from PreRace status (PR #660 follow-up)
 
 - Updated `StrategyDash.StartFuelAdviceText/StartFuelStatus` to use a dedicated start-fuel comparison instead of mapping from `LalaLaunch.PreRace.StatusText/StatusColour`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,4 +1,9 @@
 ## Documentation sync status
+- 2026-05-05 League Race final cohort integration follow-up landed (PR #669 replay fix):
+  - fixed ClassLeader/ClassBest race-context candidate matching to build native race-context rows from the same session identity sources used by Opponents (`UserID` + `UserName`/`CarNumber`/`CarClassColor` identity key), instead of synthetic `car:{idx}` rows with blank names;
+  - this restores League Class cohort matching when resolver paths depend on name fallback (e.g., suffix/manual flows where `UserID` may be absent) while preserving native class fallback when League Class is disabled/unresolved;
+  - PitExit cohort path remains delegated via `BuildRaceContextLeagueClassMatchDelegate()` into `Opponents.Update(...)` unchanged; no pit-exit timing/gap math changes.
+
 - 2026-05-05 StrategyDash start-fuel advice decoupling follow-up landed (PR #660):
   - `StrategyDash.StartFuelAdviceText/StartFuelStatus` now come from a dedicated start-fuel comparison (live fuel first, setup fallback second, unknown otherwise) against `StrategyDash.StartFuelRequiredLitres` with `1.0 L` tolerance;
   - start-fuel text/status no longer map from `LalaLaunch.PreRace.StatusText/StatusColour`;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5252,19 +5252,49 @@ namespace LaunchPlugin
                 return IsCarInPlayerClass(pluginManager, candidateCarIdx, isMultiClassSession, playerClassShort);
             }
 
-            if (!TryGetCarDriverInfo(pluginManager, playerCarIdx, out _, out _, out int playerUserId, out _, out _, out _, out _, out _, out _, out _))
+            if (!TryBuildRaceContextNativeCarRow(pluginManager, playerCarIdx, out var playerRow))
             {
                 return IsCarInPlayerClass(pluginManager, candidateCarIdx, isMultiClassSession, playerClassShort);
             }
 
-            if (!TryGetCarDriverInfo(pluginManager, candidateCarIdx, out _, out _, out int candidateUserId, out _, out _, out _, out _, out _, out _, out _))
+            if (!TryBuildRaceContextNativeCarRow(pluginManager, candidateCarIdx, out var candidateRow))
             {
                 return false;
             }
 
-            var playerRow = new OpponentsEngine.NativeCarRow { CarIdx = playerCarIdx, IdentityKey = "car:" + playerCarIdx.ToString(CultureInfo.InvariantCulture), UserID = playerUserId, Name = string.Empty };
-            var candidateRow = new OpponentsEngine.NativeCarRow { CarIdx = candidateCarIdx, IdentityKey = "car:" + candidateCarIdx.ToString(CultureInfo.InvariantCulture), UserID = candidateUserId, Name = string.Empty };
             return raceContextMatch(playerRow, candidateRow);
+        }
+
+        private bool TryBuildRaceContextNativeCarRow(PluginManager pluginManager, int carIdx, out OpponentsEngine.NativeCarRow row)
+        {
+            row = null;
+            if (pluginManager == null || carIdx < 0 || carIdx >= CarSAEngine.MaxCars)
+            {
+                return false;
+            }
+
+            if (!TryGetCarDriverInfo(pluginManager, carIdx, out _, out string classColorHex, out _, out _, out _, out _, out string abbrevName, out _, out int userId, out _))
+            {
+                return false;
+            }
+
+            TryGetCarIdentityFromSessionInfo(pluginManager, carIdx, out string name, out string carNumber, out string identityClassColor);
+            string resolvedName = !string.IsNullOrWhiteSpace(name) ? name : (abbrevName ?? string.Empty);
+            string resolvedClassColor = !string.IsNullOrWhiteSpace(identityClassColor) ? identityClassColor : classColorHex;
+            string identityKey = BuildIdentityKey(resolvedClassColor, carNumber);
+            if (string.IsNullOrWhiteSpace(identityKey))
+            {
+                identityKey = "car:" + carIdx.ToString(CultureInfo.InvariantCulture);
+            }
+
+            row = new OpponentsEngine.NativeCarRow
+            {
+                CarIdx = carIdx,
+                IdentityKey = identityKey,
+                UserID = userId,
+                Name = resolvedName ?? string.Empty
+            };
+            return true;
         }
 
         private EffectiveRaceClassInfo ResolveLivePlayerLeagueClassInfo()

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5281,7 +5281,7 @@ namespace LaunchPlugin
             TryGetCarIdentityFromSessionInfo(pluginManager, carIdx, out string name, out string carNumber, out string identityClassColor);
             string resolvedName = !string.IsNullOrWhiteSpace(name) ? name : (abbrevName ?? string.Empty);
             string resolvedClassColor = !string.IsNullOrWhiteSpace(identityClassColor) ? identityClassColor : classColorHex;
-            string identityKey = BuildIdentityKey(resolvedClassColor, carNumber);
+            string identityKey = OpponentsEngine.MakeIdentityKey(resolvedClassColor, carNumber);
             if (string.IsNullOrWhiteSpace(identityKey))
             {
                 identityKey = "car:" + carIdx.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
### Motivation
- ClassLeader/ClassBest selection sometimes failed to honor enabled League Class CSV/suffix/manual cohort rules because candidate/player rows were constructed with synthetic identity keys and blank names, preventing resolver name-fallback matches. 
- PitExit cohort logic was already wired through the Opponents delegate seam, so the root cause was limited to the identity shape used by ClassLeader/ClassBest call paths. 
- The change must preserve native fallbacks and not alter any gap/timing/math, CarSA, or H2HTrack behavior. 

### Description
- Reworked `IsRaceContextClassMatchForCarIdx(...)` to build real race-context rows using a new helper `TryBuildRaceContextNativeCarRow(...)` instead of synthetic `car:{idx}` rows. 
- `TryBuildRaceContextNativeCarRow(...)` populates `OpponentsEngine.NativeCarRow` with `UserID`, resolved driver `Name` (session identity with `AbbrevName` fallback), and a canonical identity key (`ClassColor:CarNumber`) with `car:{idx}` fallback. 
- This makes ClassLeader/ClassBest use the same proven identity sources Opponents relies on so League Class resolver paths that need name fallback will match correctly, while leaving disabled/unresolved League Class behavior unchanged. 
- Updated docs: `Docs/RepoStatus.md` and `Docs/Internal/Development_Changelog.md` with the root cause, fix summary, and invariants. 

### Testing
- Attempted `dotnet build` in the environment but `dotnet` is not installed so a compile run could not be executed. 
- Performed static inspection and grep-based verification to confirm the delegate is still passed into `_opponentsEngine.Update(...)` and that `ClassLeader`/`ClassBest` call sites now produce populated `NativeCarRow` objects (verified changed lines in `LalaLaunch.cs`). 
- Committed changes and prepared the PR payload; no automated unit/integration tests were run due to the container environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97562e658832fbaf397e851678e0b)