### PR TITLE
Fix League class race-context gating for ClassLeader/ClassBest

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,10 @@
+## 2026-05-05 — League Class ClassLeader/PitExit replay identity gate fix
+- Classification: **internal-only** (race-context cohort seam correctness; no new exports/UI).
+- Root cause: `LalaLaunch.TryBuildRaceContextNativeCarRow(...)` required `TryGetCarDriverInfo(...)` success and synthesized `car:{idx}` identity fallback, so ClassLeader/ClassBest race-context matching could drop to native fallback in replay states where Opponents still had valid session identity.
+- Fix: race-context row build now prefers session identity (`UserName`/`CarNumber`/`CarClassColor`) and returns `false` when canonical identity key is unavailable (no synthetic `car:{idx}` fallback).
+- Fix: `TryResolveClassSessionBestLap(...)` now only hard-fails on missing native player class-short when League race-context matcher is inactive; with active League matcher it proceeds through the shared race-context delegate path.
+- Preserved invariants: Opp race-slot ordering/gap math unchanged, PitExit timing/gap/countdown formulas unchanged, CarSA unchanged, H2HTrack and H2H sector/delta logic unchanged.
+
 
 ## 2026-05-05 — League Race final cohort integration replay follow-up (ClassLeader/ClassBest identity fix)
 - Classification: **internal-only** (race-context cohort identity seam correction; no math/export contract additions).

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,8 @@
+- 2026-05-05 League Class replay-identity follow-up landed:
+  - fixed ClassLeader/ClassBest race-context cohort gating to avoid native fallback when League matcher is active but native class-short is unresolved in multiclass replay states;
+  - removed synthetic `car:{idx}` race-context identity fallback in `LalaLaunch` class leader/class best candidate rows so matching now relies on canonical Opponents-style identity (`ClassColor:CarNumber`) only;
+  - PitExit remains on shared Opponents race-context matcher seam; no pit-exit math/countdown changes.
+
 ## Documentation sync status
 - 2026-05-05 League Race final cohort integration follow-up landed (PR #669 replay fix):
   - fixed ClassLeader/ClassBest race-context candidate matching to build native race-context rows from the same session identity sources used by Opponents (`UserID` + `UserName`/`CarNumber`/`CarClassColor` identity key), instead of synthetic `car:{idx}` rows with blank names;

--- a/Docs/Subsystems/Opponents.md
+++ b/Docs/Subsystems/Opponents.md
@@ -107,3 +107,8 @@ Opponents now reads from:
 - 2026-05-04 League Race Final Behaviour phase:
   - `PitExit.*` class-relative cohort selection now uses the same race-context class seam as Opp targets (`IsRaceContextClassMatch`) so enabled+valid League Class uses effective-class matching; disabled/enabled+unresolved-player paths fall back to native class-color matching unchanged.
   - Pit-exit countdown/loss/progress/gap math and active pit-cycle model are unchanged; only same-class cohort inclusion changed.
+
+
+- 2026-05-05 replay identity/gating follow-up:
+  - ClassLeader/ClassBest race-context candidate rows built in `LalaLaunch` now require canonical identity (`ClassColor:CarNumber`) and no longer synthesize `car:{idx}` fallback identities;
+  - multiclass class-best resolution no longer hard-gates on native class-short when League race-context matcher is active, so ClassLeader/ClassBest stay on the same effective-class delegate seam used by Opponents/PitExit.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -5273,18 +5273,15 @@ namespace LaunchPlugin
                 return false;
             }
 
-            if (!TryGetCarDriverInfo(pluginManager, carIdx, out _, out string classColorHex, out _, out _, out _, out _, out string abbrevName, out _, out int userId, out _))
-            {
-                return false;
-            }
-
+            TryGetCarDriverInfo(pluginManager, carIdx, out _, out string classColorHex, out _, out _, out _, out _, out string abbrevName, out _, out int userId, out _);
             TryGetCarIdentityFromSessionInfo(pluginManager, carIdx, out string name, out string carNumber, out string identityClassColor);
+
             string resolvedName = !string.IsNullOrWhiteSpace(name) ? name : (abbrevName ?? string.Empty);
             string resolvedClassColor = !string.IsNullOrWhiteSpace(identityClassColor) ? identityClassColor : classColorHex;
             string identityKey = OpponentsEngine.MakeIdentityKey(resolvedClassColor, carNumber);
             if (string.IsNullOrWhiteSpace(identityKey))
             {
-                identityKey = "car:" + carIdx.ToString(CultureInfo.InvariantCulture);
+                return false;
             }
 
             row = new OpponentsEngine.NativeCarRow
@@ -15289,7 +15286,8 @@ namespace LaunchPlugin
             bool isMultiClassSession = IsMultiClassSession(pluginManager);
             var raceContextMatch = BuildRaceContextLeagueClassMatchDelegate();
             string playerClassShort = string.Empty;
-            if (isMultiClassSession && !TryResolvePlayerClassShortName(pluginManager, playerCarIdx, out playerClassShort))
+            bool hasPlayerClassShort = TryResolvePlayerClassShortName(pluginManager, playerCarIdx, out playerClassShort);
+            if (isMultiClassSession && raceContextMatch == null && !hasPlayerClassShort)
             {
                 failureReason = "blank_class_identity_multiclass";
                 return false;


### PR DESCRIPTION
### Motivation
- Ensure `ClassLeader`/`ClassBest` (and by extension `PitExit` cohort selection) use the same League effective-class matcher seam as `Opponents` so replay/CSV/suffix flows that change Opp slots also affect leader/best outputs.
- Prevent local identity/gating in `LalaLaunch` from short-circuiting the shared matcher and forcing native-class fallback in replay states.

### Description
- Change `TryBuildRaceContextNativeCarRow(...)` in `LalaLaunch.cs` to require a canonical session identity (`ClassColor:CarNumber`) and to return `false` when that identity cannot be constructed instead of synthesizing `"car:{idx}"` fallback identities.
- Relax the multiclass pre-gate in `TryResolveClassSessionBestLap(...)` so missing native player class short-name only aborts when the League race-context delegate is inactive, allowing the shared `BuildRaceContextLeagueClassMatchDelegate()` path to resolve candidates when present.
- Keep all race math and ordering invariants untouched by reusing the existing Opponents/Narrow race-context matcher; update documentation to record root cause, fix, and invariant confirmations.
- Files changed: `LalaLaunch.cs`, `Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, and `Docs/Subsystems/Opponents.md`.

### Testing
- Attempted to run `dotnet build` in the environment but the command failed (`dotnet: command not found`), so a full compile/test run could not be executed.
- Performed static/code-path verification by tracing usages of `BuildRaceContextLeagueClassMatchDelegate()`, `IsRaceContextClassMatch`, and the amended methods to ensure the shared matcher is used and no undefined calls were introduced.
- Committed the changes after verification (`git commit` completed) and updated internal docs to reflect the fix and preserved invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0304e52c832f9a4e363e91e487a9)