### PR TITLE
Restore ResolveDataGovernedBurnAndPaceBasis helper in LalaLaunch (PR #679 build-fix)

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,11 @@
+## 2026-05-06 — PR #679 build fix: restore PreRace data-governed burn/pace helper
+- Classification: **internal-only** (compile restoration + intended source-hierarchy reattachment; no protected runtime-domain changes).
+- Restored `ResolveDataGovernedBurnAndPaceBasis(...)` inside `LalaLaunch` near PreRace helpers so `UpdatePreRaceOutputs(...)` compiles and resolves source authority in one place again.
+- Preserved approved hierarchy and source tokens:
+  - DATA LIVE: BURN `LIVE -> PLAN -> PROFILE -> DEFAULT`; LAP `LIVE -> PLAN -> PROFILE -> SIM -> DEFAULT`.
+  - DATA PLAN: BURN `PLAN -> PROFILE -> DEFAULT`; LAP `PLAN -> PROFILE -> DEFAULT`.
+- Explicitly kept untouched protected domains: `Fuel.Delta.*`, `Fuel.Pit.*`, `Fuel.RequiredBurnToEnd*`, boxed refuel latches, and `PitFuelControlEngine` target/send behavior.
+
 ## 2026-05-06 — PreRace live-facing lap/burn basis helper export
 - Classification: **both** (new dash-facing helper export + internal contract docs alignment).
 - Added `LalaLaunch.PreRace.LiveFacingBasisText` as a concise combined readout of active pre-race source authority: `LAP <source> / BURN <source>`.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,10 @@
+- 2026-05-06 PR #679 build-fix landed:
+  - restored missing `ResolveDataGovernedBurnAndPaceBasis(...)` helper in `LalaLaunch` (PreRace helper region) so `UpdatePreRaceOutputs(...)` compile path is valid again;
+  - hierarchy/source contracts preserved exactly:
+    - DATA LIVE burn: `LIVE -> PLAN -> PROFILE -> DEFAULT`; lap: `LIVE -> PLAN -> PROFILE -> SIM -> DEFAULT`;
+    - DATA PLAN burn: `PLAN -> PROFILE -> DEFAULT`; lap: `PLAN -> PROFILE -> DEFAULT`;
+  - protected runtime domains untouched (`Fuel.Delta.*`, `Fuel.Pit.*`, `Fuel.RequiredBurnToEnd*`, boxed refuel latches, `PitFuelControlEngine` target/send behavior).
+
 - 2026-05-05 Pit Fuel Control DATA/SOURCE simplification landed:
   - retired `SOURCE=PLAN`; source cycle is now `STBY -> NORM -> PUSH -> SAVE -> STBY`;
   - added `Pit.FuelControl.Data` / `DataText` and actions `SetDataLive`, `SetDataPlan`, `CycleData`;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1096,6 +1096,63 @@ namespace LaunchPlugin
             return RequiredPreRaceStrategy.MultiStop;
         }
 
+
+        private void ResolveDataGovernedBurnAndPaceBasis(
+            GameData data,
+            double fallbackFuelPerLap,
+            out double fuelPerLap,
+            out double lapSeconds,
+            out string fuelSource,
+            out string lapSource)
+        {
+            double liveFuel = LiveFuelPerLap_Stable > 0.0 ? LiveFuelPerLap_Stable : LiveFuelPerLap;
+            double liveLap = GetProjectionLapSeconds(data);
+
+            double planFuel = FuelCalculator?.FuelPerLap ?? 0.0;
+            double planLap = 0.0;
+            string planLapText = FuelCalculator?.EstimatedLapTime ?? string.Empty;
+            if (TimeSpan.TryParse(planLapText, out var planLapSpan) && planLapSpan.TotalSeconds > 0.0)
+            {
+                planLap = planLapSpan.TotalSeconds;
+            }
+
+            var (profileFuelDry, profileFuelWet) = GetProfileFuelBaselines();
+            double profileFuel = _isWetMode ? profileFuelWet : profileFuelDry;
+            double profileLap = GetProfileAvgLapSeconds();
+
+            double simLap = (data.NewData?.LastLapTime ?? TimeSpan.Zero).TotalSeconds;
+            bool usePlanData = (_pitFuelControlEngine?.Data ?? PitFuelControlData.Live) == PitFuelControlData.Plan;
+
+            fuelPerLap = 0.0;
+            lapSeconds = 0.0;
+            fuelSource = "DEFAULT";
+            lapSource = "DEFAULT";
+
+            if (!usePlanData)
+            {
+                if (liveFuel > 0.0) { fuelPerLap = liveFuel; fuelSource = "LIVE"; }
+                else if (planFuel > 0.0) { fuelPerLap = planFuel; fuelSource = "PLAN"; }
+                else if (profileFuel > 0.0) { fuelPerLap = profileFuel; fuelSource = "PROFILE"; }
+                else if (fallbackFuelPerLap > 0.0) { fuelPerLap = fallbackFuelPerLap; fuelSource = "DEFAULT"; }
+
+                if (liveLap > 0.0) { lapSeconds = liveLap; lapSource = "LIVE"; }
+                else if (planLap > 0.0) { lapSeconds = planLap; lapSource = "PLAN"; }
+                else if (profileLap > 0.0) { lapSeconds = profileLap; lapSource = "PROFILE"; }
+                else if (simLap > 0.0) { lapSeconds = simLap; lapSource = "SIM"; }
+                else { lapSource = "DEFAULT"; }
+            }
+            else
+            {
+                if (planFuel > 0.0) { fuelPerLap = planFuel; fuelSource = "PLAN"; }
+                else if (profileFuel > 0.0) { fuelPerLap = profileFuel; fuelSource = "PROFILE"; }
+                else if (fallbackFuelPerLap > 0.0) { fuelPerLap = fallbackFuelPerLap; fuelSource = "DEFAULT"; }
+
+                if (planLap > 0.0) { lapSeconds = planLap; lapSource = "PLAN"; }
+                else if (profileLap > 0.0) { lapSeconds = profileLap; lapSource = "PROFILE"; }
+                else { lapSource = "DEFAULT"; }
+            }
+        }
+
         private PlannerLiveSessionMatchSnapshot BuildLiveSessionMatchSnapshot(double raceSessionDurationSeconds, long raceSessionLaps)
         {
             string liveCarIdentity = !string.IsNullOrWhiteSpace(CurrentCarModel) && !CurrentCarModel.Equals("Unknown", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
### Motivation
- Fix a post-merge compile failure where `UpdatePreRaceOutputs(...)` referenced a missing helper `ResolveDataGovernedBurnAndPaceBasis(...)`. 
- Re-establish the intended pre-race burn/pace source-resolution hierarchy and restrict changes to non-protected domains. 

### Description
- Added a private helper `ResolveDataGovernedBurnAndPaceBasis(GameData data, double fallbackFuelPerLap, out double fuelPerLap, out double lapSeconds, out string fuelSource, out string lapSource)` inside `LalaLaunch` in the PreRace helper area immediately before `BuildLiveSessionMatchSnapshot(...)`. 
- The implementation enforces the required source hierarchies and tokens exactly: for DATA LIVE burn = `LIVE -> PLAN -> PROFILE -> DEFAULT` and lap = `LIVE -> PLAN -> PROFILE -> SIM -> DEFAULT`; for DATA PLAN burn = `PLAN -> PROFILE -> DEFAULT` and lap = `PLAN -> PROFILE -> DEFAULT`. 
- The method uses only the approved source tokens (`LIVE`, `PLAN`, `PROFILE`, `SIM`, `DEFAULT`), honors `Live` stable fallbacks, consults `FuelCalculator` and profile baselines, and selects plan-mode behavior when `PitFuelControlEngine.Data == PitFuelControlData.Plan`. 
- Updated internal docs to record the restoration and preserved invariants in `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md`.

### Testing
- Attempted to run a full build with `dotnet build` but the environment lacks the SDK (`dotnet: command not found`), so a binary build could not be executed. 
- Performed source-level checks with `rg` to confirm the helper exists and the call site resolves (`rg -n "ResolveDataGovernedBurnAndPaceBasis" LalaLaunch.cs`). 
- Verified placement and signature via file excerpt inspection (`nl -ba LalaLaunch.cs | sed -n '1096,1160p'`), confirming the exact signature and that the call in `UpdatePreRaceOutputs(...)` matches the restored helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faab8c940c832f863f677506286e5b)