### PR TITLE
Fix H2HTrack selected-target League Class color identity handoff

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1977,3 +1977,8 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Classification: **internal-only** (state-ownership correction; no fuel/detection formula changes).
 - `UpdateLiveDetectedRaceDefinition(...)` now updates manual `RaceLaps` / `RaceMinutes` only while `SelectedRaceType == LiveDetect`; outside Live Detect it still caches helper/basis state but does not mutate manual race-length ownership.
 - Exiting Live Detect now clears detected-length caches (`_lastLiveDetectedRaceLaps`, `_lastLiveDetectedRaceMinutes`) in addition to detected basis type, preventing stale basis reuse on later re-entry when fresh detection is unavailable.
+
+## 2026-05-06 — H2HTrack selected-target League identity handoff fix
+- Classification: **both** (H2HTrack class presentation correctness + internal contract/docs alignment).
+- `BuildH2HTrackSelector(...)` now carries selected CarSA slot `UserID` into `H2HEngine.TargetSelector` so `H2HTrack.Ahead/Behind.ClassColor` and `ClassColorHex` can resolve League Class via the same CSV-first identity seam as CarSA/H2HRace when enabled.
+- Kept H2HTrack physical target selection and all sector/delta/timing logic unchanged; unresolved/disabled paths still fall back to native class colour behavior.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1186,3 +1186,7 @@ Branch: work
   - `TrackLearning.Condition.Locked` is active-condition mapped (`DryConditionsLocked` vs `WetConditionsLocked`) and therefore shared by condition avg-lap + fuel persistence ownership,
   - pit-loss and condition toggles use existing immediate profile-save behavior,
   - marker toggle uses the existing marker-store lock seam.
+
+- 2026-05-06 H2HTrack selected-target League identity handoff fix landed:
+  - `BuildH2HTrackSelector(...)` now forwards selected-slot `UserID` into H2H target selector identity so `H2HTrack.Ahead/Behind.ClassColor` and `ClassColorHex` resolve through CSV-first League Class semantics when available;
+  - fallback behavior unchanged when League Class is disabled/unresolved, and no H2HTrack physical target-selection or sector/delta/timing ownership was changed.

--- a/Docs/Subsystems/H2H.md
+++ b/Docs/Subsystems/H2H.md
@@ -1,7 +1,7 @@
 # Head-to-Head (H2H)
 
 Validated against commit: HEAD
-Last updated: 2026-04-21
+Last updated: 2026-05-06
 Branch: work
 
 ## Purpose
@@ -84,6 +84,7 @@ Both `H2HRace.*` and `H2HTrack.*` expose the same flat shape:
 - H2H no longer owns target-bound sector completion timing, bind-aware row rebuild mechanics, or sector-6 lap-wrap carryover. Those published sector outputs are now entirely driven by the CarSA cache.
 - `ClassColor` / `ClassColorHex` are published as dash-ready `#RRGGBB` on H2H exports.
 - `H2HTrack.*` keeps CarSA-owned physical target selection, but class-facing presentation now follows the same League Class presentation gate as `H2HRace.*` when enabled+resolved; disabled/unresolved paths remain native fallback.
+- `H2HTrack.*` selected-target class presentation now passes through selected-slot `UserID` identity when available, enabling CSV-first League Class color resolution parity with CarSA/H2HRace; suffix fallback remains secondary when CSV is unavailable and mode permits it.
 
 - 2026-04-30 Phase 1 League Race Class infrastructure: no H2HRace/H2HTrack selector behavior changes yet; H2HTrack remains CarSA-native selection.
 - 2026-05-03 League Race Phase 3:

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -13533,6 +13533,7 @@ namespace LaunchPlugin
                     Name = slot.Name ?? string.Empty,
                     CarNumber = slot.CarNumber ?? string.Empty,
                     ClassColor = NormalizeH2HClassColor(slotClassColor),
+                    UserID = slot.UserID > 0 ? slot.UserID : 0,
                     PositionInClass = GetEffectivePositionInClassForPublishedContext(slot.CarIdx, slot.PositionInClass)
                 };
             }


### PR DESCRIPTION
### Motivation
- H2HTrack target class colours could resolve via fallback suffix/name logic instead of the selected target's CSV/effective League Class because the selected CarSA slot `UserID` was not being forwarded to the H2H selector identity seam. 
- The change aims to make `H2HTrack.Ahead/Behind.ClassColor` and `ClassColorHex` resolve via the same CSV-first League Class resolver path used by CarSA/H2HRace while preserving existing selection and timing ownership.

### Description
- In `LalaLaunch.cs` updated `BuildH2HTrackSelector(...)` to populate `UserID = slot.UserID > 0 ? slot.UserID : 0` on the returned `H2HEngine.TargetSelector` so the League-aware resolver receives the strong identity when available. 
- No changes to H2HTrack physical target selection, sector/delta/timing logic, CarSA slot ordering/filtering, or Opponents/H2HRace selector ownership were made. 
- Documentation updates: `Docs/Subsystems/H2H.md` `Last updated` timestamp and a note describing the `UserID` handoff; `Docs/Internal/Development_Changelog.md` and `Docs/RepoStatus.md` entries added documenting the fix and scope.

### Testing
- Attempted automated build with `dotnet build -v minimal`, but `dotnet` is not available in this environment so compile validation could not be executed (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb11dcefc832fb1e0386671793519)