### PR TITLE
Reclassify PreRace '2 STINT PLAN REQUIRES MORE FUEL' from red to orange

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,9 @@
+## 2026-05-07 — PreRace one-stop under-fuel severity reclassification (ref #7)
+- Classification: **both** (dash-facing status colour/priority intent change + catalog/docs alignment).
+- Reclassified `2 STINT PLAN REQUIRES MORE FUEL` from red to orange in `LalaLaunch.PreRace.StatusText/StatusColour` for the one-stop under-fuel path when one-stop remains feasible.
+- Rationale: this state is advisory (next-stop refuel-settable) rather than a hard invalid strategy fault; hard-stop red remains `2 STINT PLAN NOT POSSIBLE`.
+- Updated `Docs/Internal/FuelSystemMessages_Catalog.csv` ref #7 to orange high-priority advisory semantics aligned near `CHECK NEXT STINT FUEL` behavior intent.
+
 ## 2026-05-06 — PR #687 follow-up build fix: CarSA PositionInClass null-coalescing removal
 - Classification: **internal-only** (compile blocker fix only; no runtime contract change).
 - Removed invalid null-coalescing on non-nullable `CarSASlot.PositionInClass` in `Car.Ahead01..05.PositionInClass` and `Car.Behind01..05.PositionInClass` publish-time attach lambdas.

--- a/Docs/Internal/FuelSystemMessages_Catalog.csv
+++ b/Docs/Internal/FuelSystemMessages_Catalog.csv
@@ -5,7 +5,7 @@ Ref,PreRace message,Colour,Priority,Meaning (short),Phase 1 (Pre Grid),Phase 2 (
 4,SINGLE STINT POSSIBLE,orange,O4,Required no-stop but another strategy selected,✅,✅,X,X,Planning choice guidance; lower value once gridding.
 5,SINGLE STINT NOT POSSIBLE,red,R2,Required one-stop but no-stop selected,✅,✅,X,X,Important hard constraint warning in both phases.
 6,2 STINT PLAN NOT POSSIBLE,red,R3,One-stop selected but not feasible,✅,✅,X,X,Critical strategy invalidity; still important on grid.
-7,2 STINT PLAN REQUIRES MORE FUEL,red,R6,One-stop feasible but under-fuelled plan,✅,✅,X,X,Actionable and urgent until race start.
+7,2 STINT PLAN REQUIRES MORE FUEL,orange,O3A,One-stop feasible but under-fuelled plan (refuel-settable),✅,✅,✅,✅,Advisory to verify next-stint refuel; high-priority orange, not hard-stop red when next-stop target fits tank space.
 8,OVERFUELLED,orange,O6,One-stop selected with significant extra fuel,X,✅,✅,X,Mostly optimization; less critical once on grid.
 9,CHECK NEXT STINT FUEL,orange,O3,Refuel target likely too low / needs review,X,✅,✅,✅,Still useful on grid because refuel plan is phase-relevant.
 10,SINGLE STOP OKAY,green,G2,One-stop selected and checks pass,✅,X,X,X,Good planning confidence cue; can be de-prioritized on grid.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,7 @@
+- 2026-05-07 PreRace one-stop under-fuel severity review landed:
+  - `2 STINT PLAN REQUIRES MORE FUEL` now publishes `orange` (was `red`) when one-stop is still feasible but under target;
+  - intent is high-priority advisory parity with next-stint review, while hard invalidity remains `2 STINT PLAN NOT POSSIBLE` (red).
+
 - 2026-05-06: PR #687 follow-up fixed a compile blocker in `LalaLaunch` by removing invalid nullable coalescing from CarSA Ahead/Behind `PositionInClass` publish lambdas; effective-position seam behavior unchanged.
 - 2026-05-06 CarSA PositionInClass publish-seam alignment landed:
   - `Car.Ahead01..05.PositionInClass` / `Car.Behind01..05.PositionInClass` now publish through the shared effective-position seam (`GetEffectivePositionInClassForPublishedContext`), using Opponents effective race-context rank when available and native slot fallback otherwise;

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -36,7 +36,7 @@ This document is the canonical dash-facing contract layer. It does **not** redef
   - manual PreRace selections may still emit `live` when planner fuel value is active from live snapshot/runtime source labeling.
 - PreRace status is scenario-first (`required strategy` vs `selected strategy`) and fully partitioned:
   - required `No Stop` => `SINGLE STINT OKAY` or `ADD START FUEL FOR SINGLE STINT`; selecting stop strategies shows `SINGLE STINT POSSIBLE`,
-  - required `One Stop` => no-stop `SINGLE STINT NOT POSSIBLE`, one-stop feasibility (pit-stop refill-capacity gate, then `2 STINT PLAN REQUIRES MORE FUEL` / `OVERFUELLED` / `SINGLE STOP OKAY`), multi-stop `SINGLE STOP POSSIBLE`,
+  - required `One Stop` => no-stop `SINGLE STINT NOT POSSIBLE`, one-stop feasibility (pit-stop refill-capacity gate, then orange advisory `2 STINT PLAN REQUIRES MORE FUEL` when under-fuelled-but-refuel-settable, `OVERFUELLED`, `CHECK NEXT STINT FUEL`, or `SINGLE STOP OKAY`), multi-stop `SINGLE STOP POSSIBLE`,
   - required `Multi Stop` => non-multi selections publish `MULTI STINTS REQUIRED`; multi-stop publishes `MAX FUEL SET FOR MULTI STOP` or max-fuel-required guidance.
 - If a widget is meant to represent runtime truth, prefer stable `Fuel.*` / pace outputs over UI-only text from elsewhere.
 - Race-end dash gating should consume plugin-owned finish-phase exports directly: `Race.EndPhase` / `Race.EndPhaseText` / `Race.EndPhaseConfidence` plus `Race.LastLapLikely`; dashboards must not infer leader finish from player white/checkered flags or track-disappearance heuristics.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -1340,7 +1340,7 @@ namespace LaunchPlugin
 
                     if (oneStopUnderFuel)
                     {
-                        return new PreRaceStatusDecision { Text = "2 STINT PLAN REQUIRES MORE FUEL", Colour = "red" };
+                        return new PreRaceStatusDecision { Text = "2 STINT PLAN REQUIRES MORE FUEL", Colour = "orange" };
                     }
 
                     if (oneStopOverFuel)


### PR DESCRIPTION
### Motivation
- The `2 STINT PLAN REQUIRES MORE FUEL` pre-race message (ref #7) was too strong for scenarios where one-stop remains feasible by setting the next-stint refuel, so it should be an advisory high-priority orange rather than a hard red urgent fault.
- Align the runtime behaviour with the canonical message catalog and dash guidance so dashboards and operators see the intended advisory semantics near the `CHECK NEXT STINT FUEL` priority.

### Description
- Changed the PreRace decision colour in `LalaLaunch.cs` so `2 STINT PLAN REQUIRES MORE FUEL` now returns `Colour = "orange"` instead of `"red"` in the one-stop under-fuel path.
- Updated `Docs/Internal/FuelSystemMessages_Catalog.csv` entry for ref #7 to `orange` with adjusted priority and explanatory text clarifying the refuel-settable advisory intent.
- Synchronized documentation text in `Docs/Subsystems/Dash_Integration.md`, added an entry to `Docs/Internal/Development_Changelog.md`, and updated `Docs/RepoStatus.md` to record the severity reclassification and rationale.

### Testing
- Attempted `dotnet build -v minimal` as an automated build check, but the environment lacks the .NET SDK (`dotnet: command not found`), so a full automated build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf7927a84832f83ceeaee750f9ce0)