### PR TITLE
docs: sync Phase 2B fuel export audit guidance

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,9 @@
+- 2026-05-08 Phase 2B fuel export audit documentation sync landed:
+  - marked `Fuel.Refuel.*` as canonical race-running next-stop refuel guidance surface across inventory/subsystem dash docs, while preserving `StrategyDash.NextRefuel*` as pre-green/planning (not obsolete);
+  - reinforced dashboard guidance to prefer plugin-owned `Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Contingency.*`, and `Fuel.Delta.*` for runtime fuel widgets instead of dash-side NCALC chains;
+  - added cleanup caution: do not remove/rename fuel-facing exports until both dashboard JSON usage audit and internal C# consumer audit are complete;
+  - clarified compatibility notes (`Pit.FuelControl.PushSaveMode*` alias surface, legacy one-release `SetPlan` mapping to DATA PLAN + SOURCE STBY) and reaffirmed protected runtime families/command-send behavior unchanged.
+
 
 ## 2026-05-08 — League Class canonical subsystem documentation sweep
 - Added canonical subsystem doc `Docs/Subsystems/League_Class_System.md` covering purpose, concepts, resolver precedence/fallback, boundaries, exports, effective PositionInClass semantics, UI workflow, dash guidance, non-goals, and troubleshooting.

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -17,6 +17,8 @@ Branch: work
 | Brake.PreviousPeakPct | double | Peak brake input from the most recently completed braking event (normalized 0–1). Event begins when brake exceeds 5% while throttle is below 20%; while active, peak tracks `max(peak, brake)`. Event ends when brake falls to 2% or below, or throttle rises to 20% or above; on end, the event peak is latched to this export and capture enters a short re-arm lock that requires at least three consecutive release ticks where either `brake <= 0.02` or `throttle >= 0.20` before a new event can start. Manual/session recovery resets clear active + latched state/counters and set the export to `0.0` so stale prior-session peaks cannot leak forward. | Per tick. | `LalaLaunch.cs` — runtime `DataUpdate` brake event detector + `AttachCore`. |
 
 ## Fuel
+> Export cleanup caution: do not remove/rename fuel exports until both audits are complete: (1) dashboard JSON usage audit, and (2) internal C# reference/consumer audit.
+
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
 | Fuel.LiveFuelPerLap | double | Rolling average burn per accepted lap (wet/dry windows, rejects pit/warmup/off-track/outliers). | 500 ms poll (`UpdateLiveFuelCalcs`). | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2672-L2955】 |

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -45,7 +45,8 @@ This document is the canonical dash-facing contract layer. It does **not** redef
   - `Fuel.Contingency.*` for active reserve display/debug,
   - `Fuel.Refuel.*` for race-running next-stop refuel guidance (`NextLitres`, `NextLitresCeil`, `NextText`, `Valid`, and basis context),
   - `Fuel.Delta.LitresCurrent/Plan/WillAdd` + Push/Save variants for tactical deltas.
-- `Fuel.Refuel.*` is runtime tactical guidance and should be preferred over `StrategyDash.NextRefuel*` during race-running usage; StrategyDash next-refuel helpers remain pre-green/planning oriented.
+- `Fuel.Refuel.*` is runtime tactical guidance and should be preferred over `StrategyDash.NextRefuel*` during race-running usage; StrategyDash next-refuel helpers remain pre-green/planning oriented (not obsolete).
+- Export cleanup caution: no fuel-facing export should be removed until both checks are complete: dashboard JSON usage audit and internal C# reference/consumer audit.
 - Do not rebuild burn-to-end with dash-side NCALC formula chains from raw fuel/time/pace properties; use plugin-owned `Fuel.RequiredBurnToEnd`.
 - Tactical delta exports are contingency-aware on the required-to-finish side only; `Fuel.Pit.WillAdd` remains clamp mirror and should not be treated as reserve-augmented request.
 - Runtime pit-space exports are live-cap authoritative when available: `Fuel.Pit.TankSpaceAvailable` reflects live remaining capacity and `Fuel.Pit.WillAdd`/`Fuel.Pit.FuelOnExit` consume that runtime cap seam (not Strategy/Profile max-fuel override when live cap exists).

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -196,6 +196,9 @@ Setup-fuel fallback export semantics:
 - This seam is read-only and does not overwrite `Telemetry.FuelLevel`, `Fuel.LiveFuelPerLap`, pit math, planner math, max tank, or PreRace strategy logic.
 
 Contingency-aware tactical contract:
+- Runtime race-running next-stop guidance is canonical on `Fuel.Refuel.*` (`NextLitres`, `NextLitresCeil`, `NextText`, `Valid`, `BurnSource`, `LapSource`, `DataMode`, `BurnMode`).
+- `StrategyDash.NextRefuel*` remains supported for pre-green/planning pages and is not obsolete, but new race-running dash work should prefer `Fuel.Refuel.*`.
+- Export cleanup caution: do not remove/rename exports until both checks are complete: dashboard JSON usage audit and internal C# reference/consumer audit.
 - `Fuel.RequiredBurnToEnd*` provides driver-facing burn-to-end guidance while protecting active contingency reserve.
 - Active contingency authority is planner-first, then profile track fallback, then default fallback.
 - `Fuel.Delta.LitresCurrent/Plan/WillAdd` and Push/Save variants protect active contingency on the **required-to-finish side only**; when contingency is configured in laps, contingency litres are resolved per burn basis (stable for Normal, push burn for Push, save burn for Save).
@@ -207,7 +210,7 @@ Contingency-aware tactical contract:
   - if `FinalStopNeed <= decision capacity`, publish `max(0, FinalStopNeed)` (final-stop guidance; contingency included once),
   - if `FinalStopNeed > decision capacity`, publish conservative multi-stop add guidance from runtime add-cap seam (`Fuel.Pit.TankSpaceAvailable`) rather than reporting full tank size as an add amount; contingency is not repeatedly stacked on non-final max-fill stops,
   - `Fuel.Refuel.NextLitresCeil` is `ceil(max(0, NextLitres))` and `Fuel.Refuel.NextText` is short dash-safe (`CHECK FUEL`, `NO REFUEL`, `REFUEL {N}L`),
-  - Pit Fuel Control DATA/SOURCE (`LIVE/PLAN`, `NORM/PUSH/SAVE/STBY`) informs basis selection read-only; command send ownership remains unchanged in Pit Fuel Control.
+  - Pit Fuel Control DATA/SOURCE (`DATA=LIVE/PLAN`, `SOURCE=STBY/NORM/PUSH/SAVE`) informs basis selection read-only; PLAN is DATA (not SOURCE), and command-send ownership remains unchanged in Pit Fuel Control.
 
 ### Logging expectations
 The subsystem logs:

--- a/Docs/Subsystems/Fuel_Planner_Tab.md
+++ b/Docs/Subsystems/Fuel_Planner_Tab.md
@@ -171,6 +171,8 @@ Using planner-selected lap time + fuel per lap:
 - Number of stops required by plan from the planner-feasible strategy result.
 - Planner stop count and planner outputs are fully independent from the PreRace mode selector. PreRace Auto mirrors planner totals/stints when planner values are available, with runtime fallback only if planner values are unavailable. Auto delta only applies live pit-menu refuel intent when planner-required next add is greater than zero; otherwise it reuses the planner fuel-basis fallback so arbitrary pit-menu add does not mask Auto deficit.
 - Dash-facing pre-race visibility uses `LalaLaunch.PreRace.Stints` instead of separate stop-count exports.
+
+- Dashboard guidance boundary: pre-grid/planning pages may keep using `StrategyDash.*` and `LalaLaunch.PreRace.*`; runtime race pages should use `Fuel.Refuel.*` for next-stop refuel guidance, `Fuel.RequiredBurnToEnd*` for burn-to-end widgets, `Fuel.Contingency.*` for reserve visibility, and `Fuel.Delta.*` for tactical finish deltas.
 - Pit add requirement.
 
 These values are **planner-only** and intentionally decoupled from live volatility.

--- a/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
+++ b/Docs/Subsystems/Pit_Commands_And_Fuel_Control.md
@@ -78,6 +78,7 @@ This is the canonical technical document for the pit/custom command stack and re
 - Target litres and override-active semantics for command generation.
 - DATA defaults to `LIVE` on session/control reset. Changing DATA always forces `SOURCE=STBY`, disarms AUTO, and sends no fuel command.
 - `SOURCE=PLAN` has been retired. The one-release compatibility action `Pit.FuelControl.SetPlan` now maps to `DATA=PLAN` + `SOURCE=STBY` and publishes `FUEL DATA PLAN`.
+- `Pit.FuelControl.PushSaveMode*` is a compatibility/alias surface after the DATA model cutover and should not be treated as a new source family.
 - `NORM` always uses the runtime/live burn target. `PUSH`/`SAVE` use DATA: `LIVE` selects live push/save targets; `PLAN` selects planner/profile memory push/save targets with the existing guarded fallback behavior.
 - Fault export state (`Pit.FuelControl.Fault`) for post-settle selector disagreement diagnostics only (`0/1/2/3` contract).
 


### PR DESCRIPTION
### Motivation
- Sync documentation after the Phase 2B fuel export audit to make the canonical runtime/dashboard contract explicit and avoid accidental export churn. 
- Emphasize that `Fuel.Refuel.*` is the canonical race-running next-stop guidance and that `StrategyDash.NextRefuel*` remains a pre-green/planning seam. 
- Add an explicit cleanup caution and compatibility notes so exports and pit-command mappings are not removed or misinterpreted without full audits. 

### Description
- Updated `Docs/Internal/SimHubParameterInventory.md` to add an export-cleanup caution near the Fuel section that blocks removal/rename until both a dashboard JSON usage audit and an internal C# consumer audit are completed. 
- Updated `Docs/Subsystems/Fuel_Model.md` to mark `Fuel.Refuel.*` as the canonical runtime next-stop guidance family, clarified DATA vs SOURCE phrasing (`DATA=LIVE/PLAN`, `SOURCE=STBY/NORM/PUSH/SAVE`), and added the cleanup caution. 
- Updated `Docs/Subsystems/Dash_Integration.md` and `Docs/Subsystems/Fuel_Planner_Tab.md` to reinforce dashboard guidance to prefer plugin-owned runtime exports (`Fuel.Refuel.*`, `Fuel.RequiredBurnToEnd*`, `Fuel.Contingency.*`, `Fuel.Delta.*`) for race-running widgets while preserving `StrategyDash.*` for pre-grid/planning. 
- Updated `Docs/Subsystems/Pit_Commands_And_Fuel_Control.md` to add compatibility clarification that `Pit.FuelControl.PushSaveMode*` is an alias/compat surface and to restate the one-release `Pit.FuelControl.SetPlan` mapping to `DATA=PLAN` + `SOURCE=STBY`. 
- Prepended an entry in `Docs/Internal/Development_Changelog.md` summarizing this Phase 2B documentation sync. 

### Testing
- Ran repository discovery and file inspections (`find`, `rg`, `cat`) to verify target docs and updated content presence, and these checks completed successfully. 
- Performed diff and status checks (`git status --short`, `git diff`) to validate changeset and then committed the docs updates successfully. 
- Searched the doc tree for relevant fuel/export terms to confirm wording alignment and presence of the new cautions and notes, and these text searches succeeded. 
- No runtime or unit tests were required because this is a documentation-only change and no code or exports were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe43d1475c832f909cd0bb72999f29)