### PR TITLE
Fix RaceFinish solo-class class-field-size freeze edge case

### DIFF
--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -8633,8 +8633,8 @@ namespace LaunchPlugin
 
         private int ResolveRaceFinishLiveClassFieldSize(PluginManager pluginManager, int playerCarIdx)
         {
-            int classOpponentsCount = SafeReadInt(pluginManager, "DataCorePlugin.GameRawData.Telemetry.OpponentsInClassCount", 0);
-            if (classOpponentsCount > 0)
+            int classOpponentsCount = SafeReadInt(pluginManager, "DataCorePlugin.GameRawData.Telemetry.OpponentsInClassCount", int.MinValue);
+            if (classOpponentsCount >= 0)
             {
                 return classOpponentsCount + 1;
             }


### PR DESCRIPTION
### Motivation
- Fix an edge case where a solo-class telemetry value (`OpponentsInClassCount == 0`) was treated as invalid, allowing `RaceFinish.PlayerClassFieldSize` to freeze to `0` and produce invalid dash rendering like `P1 / 0`.

### Description
- Change telemetry read default for `OpponentsInClassCount` to `int.MinValue` and update the resolution check from `> 0` to `>= 0` so `0` is treated as a valid solo-class value and resolves to `OpponentsInClassCount + 1`.
- Implemented the change in `LalaLaunch.cs` in `ResolveRaceFinishLiveClassFieldSize(...)` so the resolver now returns `1` for solo-class telemetry and preserves existing fallback behavior when telemetry is unavailable.
- No changes were made to snapshot lifecycle, freeze timing, finish detection, ClassLeader/ClassBest logic, or other subsystem semantics.

### Testing
- Attempted to run `dotnet build LaunchPlugin.sln -c Release` in this environment but the build could not run because `dotnet` is not installed (`dotnet: command not found`).
- No automated tests were executed here; please run CI/build in the normal environment to validate compilation and verify that solo-class sessions produce `RaceFinish.PlayerClassFieldSize = 1` and multi-car classes continue to produce correct denominators.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4c5ee68c832fa2eaea4812f7f173)