### PR TITLE
Guard rolling PropertySnapshot_Rolling.csv against legacy SnapshotUtc schema

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2235,6 +2235,13 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - `BuildH2HTrackSelector(...)` now carries selected CarSA slot `UserID` into `H2HEngine.TargetSelector` so `H2HTrack.Ahead/Behind.ClassColor` and `ClassColorHex` can resolve League Class via the same CSV-first identity seam as CarSA/H2HRace when enabled.
 - Kept H2HTrack physical target selection and all sector/delta/timing logic unchanged; unresolved/disabled paths still fall back to native class colour behavior.
 
+## 2026-05-11 — Rolling snapshot CSV legacy-schema guard fix (PR #705 follow-up)
+- Classification: **internal-only** (debug rolling CSV compatibility hardening; no runtime telemetry/export contract changes).
+- Added a strict rolling wide-schema header guard in `LalaLaunch.WriteSnapshotRollingWide(...)`:
+  - valid reusable rolling files must have header column 0 exactly `SimHubProperty`;
+  - legacy schema (`SnapshotUtc` column 0) is detected and treated as incompatible.
+- Incompatible rolling files (legacy/missing/blank/unknown header) are no longer parsed as wide-property rows; they are safely rewritten in current wide schema on the next capture with a bounded info diagnostic line.
+
 ## 2026-05-09 — PR follow-up: finish-like flag wording clarification
 - Classification: **internal-only** (documentation wording clarification only; no runtime/code changes).
 - Clarified finish-latch wording to describe checkered as the practical finish-like source in this telemetry path, while noting crossed is not relied on as required line-crossing proof.

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -163,6 +163,9 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Finish] leader_finish trigger=derived source=...`** — Derived leader finish (class/overall) once timer zero seen and heuristics trip.【F:LalaLaunch.cs†L4716-L4740】
 - **`[LalaPlugin:Finish] finish_latch trigger=driver_checkered ...`** — Driver checkered lap detected; logs timer0, leader/driver checkered times, after-zero measurements.【F:LalaLaunch.cs†L4729-L4780】
 
+## Property snapshot debug exports
+- **`[LalaPlugin:Debug] Property snapshot rolling CSV schema reset: <reason>. Existing file will be rewritten using current wide schema.`** — One-shot rolling snapshot compatibility guard log emitted when an existing rolling CSV is legacy (`SnapshotUtc`), missing/blank, or unknown schema; old contents are not parsed as wide rows and the file is safely rewritten in current wide format (`SimHubProperty` column-0 authority).
+
 ## Leader lap selection
 - **`[LalaPlugin:Leader Lap] reject source=... reason=...`** — Candidate leader lap rejected (too small, below floor); may fall back to previous avg.【F:LalaLaunch.cs†L4845-L4862】
 - **`[LalaPlugin:Leader Lap] using leader lap from <source> = Xs`** — Accepted leader lap source (telemetry fallback ordering).【F:LalaLaunch.cs†L4852-L4867】

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,8 @@
+- 2026-05-11 rolling snapshot legacy schema guard fix:
+  - rolling `PropertySnapshot_Rolling.csv` reuse now validates header column 0 as exact `SimHubProperty` before parsing existing rows;
+  - legacy header `SnapshotUtc` and malformed/unknown headers are treated as incompatible and safely reset/re-written in current wide schema;
+  - added bounded debug info log when a rolling schema reset occurs.
+
 - 2026-05-11 property snapshot final polish pass:
   - UI cleanup: `Select All` now drives all Property Snapshot group checkboxes, and individual group toggles now back-sync `Select All`;
   - rolling hardening: snapshot value text now normalizes CR/LF to literal `\n` before CSV write to keep wide rolling reload line-safe.

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -12951,15 +12951,23 @@ namespace LaunchPlugin
                 if (lines.Length > 0)
                 {
                     var header = ParseCsvLineQuoted(lines[0]);
-                    for (int i = 1; i < header.Count; i++) stamps.Add(header[i]);
-                    for (int i = 1; i < lines.Length; i++)
+                    string schemaGuardReason = GetRollingSnapshotWideSchemaGuardReason(header);
+                    if (schemaGuardReason == null)
                     {
-                        var cols = ParseCsvLineQuoted(lines[i]);
-                        if (cols.Count == 0) continue;
-                        var values = new List<string>();
-                        for (int c = 1; c < cols.Count; c++) values.Add(cols[c]);
-                        while (values.Count < stamps.Count) values.Add(string.Empty);
-                        existing[cols[0]] = values;
+                        for (int i = 1; i < header.Count; i++) stamps.Add(header[i]);
+                        for (int i = 1; i < lines.Length; i++)
+                        {
+                            var cols = ParseCsvLineQuoted(lines[i]);
+                            if (cols.Count == 0) continue;
+                            var values = new List<string>();
+                            for (int c = 1; c < cols.Count; c++) values.Add(cols[c]);
+                            while (values.Count < stamps.Count) values.Add(string.Empty);
+                            existing[cols[0]] = values;
+                        }
+                    }
+                    else
+                    {
+                        SimHub.Logging.Current.Info("[LalaPlugin:Debug] Property snapshot rolling CSV schema reset: " + schemaGuardReason + ". Existing file will be rewritten using current wide schema.");
                     }
                 }
             }
@@ -12992,6 +13000,32 @@ namespace LaunchPlugin
                 sb.AppendLine();
             }
             File.WriteAllText(filePath, sb.ToString());
+        }
+
+        private static string GetRollingSnapshotWideSchemaGuardReason(List<string> header)
+        {
+            if (header == null || header.Count == 0)
+            {
+                return "missing/blank header";
+            }
+
+            string first = header[0] ?? string.Empty;
+            if (string.Equals(first, "SimHubProperty", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (string.Equals(first, "SnapshotUtc", StringComparison.Ordinal))
+            {
+                return "legacy schema detected (SnapshotUtc)";
+            }
+
+            if (string.IsNullOrWhiteSpace(first))
+            {
+                return "blank header column 0";
+            }
+
+            return "unknown schema header column 0='" + first + "'";
         }
         private bool IsPropertySnapshotGroupEnabled(string group)
         {


### PR DESCRIPTION
### Motivation
- Legacy rolling CSV files using the old `SnapshotUtc,...` header could be misinterpreted as the new wide-format where column 0 is a property key, causing timestamps to become property keys and corrupt rolling history.
- Add a minimal, localized guard so the wide rolling writer only parses and reuses existing files that strictly match the current `SimHubProperty` header, avoiding broad refactors or behaviour changes outside the snapshot writer.

### Description
- Added `GetRollingSnapshotWideSchemaGuardReason(...)` helper to classify header validity and detect legacy (`SnapshotUtc`), missing/blank, or unknown headers.
- Updated `WriteSnapshotRollingWide(...)` to only parse and reuse existing file rows when the header guard returns `null` (valid `SimHubProperty` header); otherwise the existing file is not parsed and will be rewritten in the current wide schema on next capture.
- Emitted a bounded info log when an incompatible header is detected: `Property snapshot rolling CSV schema reset: <reason>. Existing file will be rewritten using current wide schema.`
- Updated internal docs and status entries: `Docs/Internal/SimHubLogMessages.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` to record the new log line and compatibility behaviour.

### Testing
- Attempted to build with `dotnet build LaunchPlugin.sln` as an automated verification step but the environment lacks the `dotnet` tool so the build could not be executed (`dotnet: command not found`).
- Performed static/code-path inspection and grep-based checks over `LalaLaunch.cs` and updated docs to verify the guard is present and the new log message and changelog entries were added; no runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e1a92da0832fbe1a42e53b475b11)