### PR TITLE
Fix RaceFinish lifecycle hold, player snapshot latching, and class-field-size freeze

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,9 @@
+- 2026-05-11 RaceFinish lifecycle hold + player/class snapshot follow-up fixes:
+  - RaceFinish snapshot reset no longer clears split-stage snapshots merely because `SessionState<5`; active finish snapshots now hold through valid post-timer-zero `SessionState 4` class-finish lifecycle and only clear when leaving race lifecycle (`SessionState<4`) or existing full reset paths.
+  - `RaceFinish.PlayerSnapshotActive` capture trigger now explicitly aligns with player-checkered evidence while class snapshot is active (`driver_checkered` seams via `GameData.Flag_Checkered` / `SessionFlagsDetails.IsCheckered*`) instead of deferring to `SessionState==6` fallback.
+  - `RaceFinish.PlayerClassFieldSize` freeze now retries class cohort resolution through existing League/native seams (including native class-driver-count fallback) so valid class cohorts no longer freeze at `0` when `OpponentsInClassCount` is missing.
+  - `Race.OverallLeaderHasFinished` now latches from `SessionState>=5` as overall lifecycle authority in multiclass as well (class-finish ownership unchanged and still independently resolved).
+
 - 2026-05-11 property snapshot final polish pass:
   - UI cleanup: `Select All` now drives all Property Snapshot group checkboxes, and individual group toggles now back-sync `Select All`;
   - rolling hardening: snapshot value text now normalizes CR/LF to literal `\n` before CSV write to keep wide rolling reload line-safe.

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,9 @@
+- 2026-05-11 RaceFinish lifecycle/player snapshot/class-field-size follow-up landed:
+  - active RaceFinish split-stage snapshots now remain held through valid class-finish lifecycle in `SessionState 4` after timer-zero; reset no longer fires purely on `<5` and now clears when leaving race lifecycle (`SessionState<4`) plus existing timing/session resets;
+  - player snapshot capture now aligns with player-checkered seams while class snapshot is active (no forced wait for `SessionState 6` fallback);
+  - class denominator freeze (`RaceFinish.PlayerClassFieldSize`) now falls back through League/native class cohort seams when `OpponentsInClassCount` is unavailable, preventing valid cohorts from freezing as `0`;
+  - multiclass now also latches `Race.OverallLeaderHasFinished` from `SessionState>=5` lifecycle authority while class-leader finish logic remains independently resolved.
+
 - 2026-05-11 property snapshot final polish pass:
   - UI cleanup: `Select All` now drives all Property Snapshot group checkboxes, and individual group toggles now back-sync `Select All`;
   - rolling hardening: snapshot value text now normalizes CR/LF to literal `\n` before CSV write to keep wide rolling reload line-safe.

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -49,6 +49,7 @@ This document is the canonical dash-facing contract layer. It does **not** redef
 - `RaceFinish.PlayerOverallFieldSize` / `RaceFinish.PlayerClassFieldSize` freeze at class snapshot (not player snapshot) so `Pxx / yy` denominators do not drift when drivers quit before player finish.
 - `RaceFinish.PlayerFinishGapSec` (and compatibility mirror `ClassWinnerGapSec`) is a live timer after class snapshot and freezes at player snapshot.
 - Player snapshot trigger hierarchy is plugin-owned: per-car finish-like flags and robust player-checkered seams (`GameData.Flag_Checkered` / `SessionFlagsDetails.IsCheckered*`) are used before `SessionState==6` safety fallback. Dashboards must consume exported snapshot flags and must not reimplement finish crossing heuristics.
+- RaceFinish reset semantics are lifecycle-scoped: active class/player snapshots may remain valid in post-timer-zero `SessionState 4` during multiclass class-finish flow, and are only expected to clear when race lifecycle is left (`SessionState<4`) or on explicit finish/session reset paths.
 - Strategy fuel guidance should consume plugin-owned tactical exports directly:
   - `Fuel.RequiredBurnToEnd*` for burn-to-end guidance/state/source,
   - `Fuel.Contingency.*` for active reserve display/debug,

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -8577,14 +8577,17 @@ namespace LaunchPlugin
             SimHub.Logging.Current.Info($"[LalaPlugin:RaceFinish] class snapshot captured state={sessionStateNumeric} source={source} winner='{_raceFinishClassWinnerName}'");
         }
 
-        private void TryCaptureRaceFinishPlayerSnapshot(PluginManager pluginManager, int sessionStateNumeric, int playerCarIdx, bool playerFinishedByFlags, double sessionTimeSec)
+        private void TryCaptureRaceFinishPlayerSnapshot(PluginManager pluginManager, int sessionStateNumeric, int playerCarIdx, bool playerFinishedByFlags, bool playerFinishedByCheckered, double sessionTimeSec)
         {
             if (_raceFinishPlayerSnapshotActive)
             {
                 return;
             }
 
-            bool shouldCapture = playerFinishedByFlags || sessionStateNumeric == 6;
+            bool shouldCapture =
+                sessionStateNumeric == 6
+                || playerFinishedByFlags
+                || (_raceFinishClassSnapshotActive && playerFinishedByCheckered);
             if (!shouldCapture)
             {
                 return;
@@ -8663,13 +8666,16 @@ namespace LaunchPlugin
                 return classOpponentsCount + 1;
             }
 
-            if (playerCarIdx >= 0)
+            int driverCount = GetLeagueClassPlayerDriverCount();
+            if (driverCount > 0)
             {
-                int driverCount = GetLeagueClassPlayerDriverCount();
-                if (driverCount > 0)
-                {
-                    return driverCount;
-                }
+                return driverCount;
+            }
+
+            int nativeDriverCount = GetNativePlayerClassDriverCount();
+            if (nativeDriverCount > 0)
+            {
+                return nativeDriverCount;
             }
 
             return 0;
@@ -9958,7 +9964,7 @@ namespace LaunchPlugin
                     myPaceSec,
                     playerBestLapTimeSec,
                     playerLastLapTimeSec);
-                if ((_raceFinishClassSnapshotActive || _raceFinishPlayerSnapshotActive) && sessionState < 5)
+                if ((_raceFinishClassSnapshotActive || _raceFinishPlayerSnapshotActive) && sessionState < 4)
                 {
                     ResetRaceFinishSnapshot("session_state_left_post_finish");
                 }
@@ -9995,6 +10001,7 @@ namespace LaunchPlugin
                     sessionState,
                     playerCarIdx,
                     playerFinishedByFlags || playerFinishedByCheckered,
+                    playerFinishedByCheckered,
                     sessionTimeSec);
                 if (_h2hEngine != null)
                 {
@@ -18933,7 +18940,7 @@ namespace LaunchPlugin
                     $"[LalaPlugin:Finish] overall_finish trigger=caridx_flags carIdx={overallLeaderIdx} flags={carIdxSessionFlags[overallLeaderIdx]}");
             }
 
-            if (!OverallLeaderHasFinished && !isMultiClassSession && hasSessionState && sessionStateNumeric >= 5)
+            if (!OverallLeaderHasFinished && hasSessionState && sessionStateNumeric >= 5)
             {
                 OverallLeaderHasFinished = true;
                 SimHub.Logging.Current.Info(


### PR DESCRIPTION
### Motivation
- Prevent repeated RaceFinish snapshot reset/capture loops when a valid class-finish lifecycle can occur in `SessionState 4` after timer-zero.
- Ensure player snapshot captures immediately on player checkered evidence when a class snapshot is active instead of waiting for the `SessionState==6` fallback.
- Avoid `RaceFinish.PlayerClassFieldSize` freezing to `0` when a usable class cohort can be derived from other seams, and ensure multiclass overall-leader finish latches on lifecycle authority.

### Description
- Hold RaceFinish split-stage snapshots through valid post-timer-zero class-finish lifecycle by changing the reset gate to only clear snapshots when leaving the race lifecycle (`SessionState < 4`) instead of any `sessionState < 5` (updated `Reset` condition in `LalaLaunch.cs`).
- Align player snapshot trigger with player-checkered evidence when class snapshot is active by extending `TryCaptureRaceFinishPlayerSnapshot` to accept explicit `playerFinishedByCheckered` and capture if class snapshot is active (keeps per-car-flag and `SessionState==6` fallback semantics intact).
- Harden `RaceFinish.PlayerClassFieldSize` resolution by chaining existing fallback seams: prefer `OpponentsInClassCount`, then `LeagueClass.Player.DriverCount`, then native class driver-count (`GetNativePlayerClassDriverCount`) to avoid a zero denominator when class cohort is known (changes in `ResolveRaceFinishLiveClassFieldSize`).
- Allow `Race.OverallLeaderHasFinished` to latch from `SessionState >= 5` as lifecycle authority for multiclass too by removing the `!isMultiClassSession` guard while leaving class-leader finish ownership and dynamic class-finish logic unchanged.
- Updated canonical docs to reflect behavior changes (`Docs/Internal/Development_Changelog.md`, `Docs/RepoStatus.md`, `Docs/Subsystems/Dash_Integration.md`).

### Testing
- Attempted build with `dotnet build -v minimal`, but the environment lacks the .NET SDK and the build failed (`dotnet: command not found`).
- Verified code paths and diffs via repository inspection and grep to confirm updated gating, snapshot trigger wiring, class-field-size fallback, and overall-latch logic; no automated unit/integration tests executed due to missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e344cb04832f94cd05e081e3ce91)