### PR TITLE
Prefer PROFILE fuel over SimHub fallback in no-live-lap runtime path

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -1,3 +1,8 @@
+## 2026-05-11 — Fuel burn runtime authority fix (PROFILE over SimHub fallback)
+- Classification: **both** (runtime fuel authority-chain correctness + docs/log contract alignment).
+- In `LalaLaunch`, no-accepted-lap runtime assignment now resolves `LiveFuelPerLap` to active-condition profile fuel when available, only falling back to `DataCorePlugin.Computed.Fuel_LitersPerLap` as last resort.
+- Added bounded fuel-burn authority log on no-live-lap source/value transition (`[LalaPlugin:Fuel Burn] runtime burn basis selected ...`).
+
 - 2026-05-11 property snapshot final polish pass:
   - UI cleanup: `Select All` now drives all Property Snapshot group checkboxes, and individual group toggles now back-sync `Select All`;
   - rolling hardening: snapshot value text now normalizes CR/LF to literal `\n` before CSV write to keep wide rolling reload line-safe.

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2,7 +2,7 @@
 - Classification: **both** (runtime fuel authority-chain correctness + docs/log contract alignment).
 - In `LalaLaunch`, no-accepted-lap runtime assignment now resolves `LiveFuelPerLap` to active-condition profile fuel when available, only falling back to `DataCorePlugin.Computed.Fuel_LitersPerLap` as last resort.
 - Added bounded fuel-burn authority log on no-live-lap source/value transition (`[LalaPlugin:Fuel Burn] runtime burn basis selected ...`).
-- Follow-up: narrowed transition-log signature to selected authority source + selected burn only, preventing log churn from unused fallback/profile input jitter when authority is unchanged.
+- Follow-up: narrowed transition-log signature to selected authority source only, preventing log churn from unused fallback/profile input jitter when authority is unchanged.
 
 - 2026-05-11 property snapshot final polish pass:
   - UI cleanup: `Select All` now drives all Property Snapshot group checkboxes, and individual group toggles now back-sync `Select All`;

--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2,6 +2,7 @@
 - Classification: **both** (runtime fuel authority-chain correctness + docs/log contract alignment).
 - In `LalaLaunch`, no-accepted-lap runtime assignment now resolves `LiveFuelPerLap` to active-condition profile fuel when available, only falling back to `DataCorePlugin.Computed.Fuel_LitersPerLap` as last resort.
 - Added bounded fuel-burn authority log on no-live-lap source/value transition (`[LalaPlugin:Fuel Burn] runtime burn basis selected ...`).
+- Follow-up: narrowed transition-log signature to selected authority source + selected burn only, preventing log churn from unused fallback/profile input jitter when authority is unchanged.
 
 - 2026-05-11 property snapshot final polish pass:
   - UI cleanup: `Select All` now drives all Property Snapshot group checkboxes, and individual group toggles now back-sync `Select All`;

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -73,6 +73,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Fuel Burn] Car/track change detected – clearing seeds and confidence`** — Fuel model reset because car or track identity changed.【F:LalaLaunch.cs†L968-L983】
 - **`[LalaPlugin:Session] token change old=... new=... type=...`** — Session identity changed (SessionID/SubSessionID); triggers subsystem resets and pit-save finalization.【F:LalaLaunch.cs†L3308-L3365】
 - **`[LalaPlugin:Fuel Burn] live-max health source=... raw=... live=... lastValid=... effective=...`** — Debounced live-cap diagnostic snapshot for runtime-authoritative max tank seam and fallback state.
+- **`[LalaPlugin:Fuel Burn] runtime burn basis selected source=... burn=... liveAccepted=... fallback=... profileFuel=... reason=...`** — Logged on no-live-lap runtime authority selection changes to prove PROFILE-before-SIMHUB ordering.
 - **`[LalaPlugin:Surface] Mode flip Dry->Wet/Wet->Dry (tyres=..., PlayerTireCompound=..., ExtraProp=..., trackWetness=...)`** — Wet mode toggled based on tyre compound telemetry; includes track wetness context for the change.【F:LalaLaunch.cs†L1402-L1426】
 
 ## Lap detection and per-lap summaries

--- a/Docs/Internal/SimHubLogMessages.md
+++ b/Docs/Internal/SimHubLogMessages.md
@@ -73,7 +73,7 @@ Scope: Info/Warn logs emitted via `SimHub.Logging.Current.Info(...)` and `SimHub
 - **`[LalaPlugin:Fuel Burn] Car/track change detected – clearing seeds and confidence`** — Fuel model reset because car or track identity changed.【F:LalaLaunch.cs†L968-L983】
 - **`[LalaPlugin:Session] token change old=... new=... type=...`** — Session identity changed (SessionID/SubSessionID); triggers subsystem resets and pit-save finalization.【F:LalaLaunch.cs†L3308-L3365】
 - **`[LalaPlugin:Fuel Burn] live-max health source=... raw=... live=... lastValid=... effective=...`** — Debounced live-cap diagnostic snapshot for runtime-authoritative max tank seam and fallback state.
-- **`[LalaPlugin:Fuel Burn] runtime burn basis selected source=... burn=... liveAccepted=... fallback=... profileFuel=... reason=...`** — Logged on no-live-lap runtime authority selection changes to prove PROFILE-before-SIMHUB ordering.
+- **`[LalaPlugin:Fuel Burn] runtime burn basis selected source=... burn=... liveAccepted=... fallback=... profileFuel=... reason=...`** — Logged on no-live-lap runtime authority source transitions to prove PROFILE-before-SIMHUB ordering without per-tick jitter spam.
 - **`[LalaPlugin:Surface] Mode flip Dry->Wet/Wet->Dry (tyres=..., PlayerTireCompound=..., ExtraProp=..., trackWetness=...)`** — Wet mode toggled based on tyre compound telemetry; includes track wetness context for the change.【F:LalaLaunch.cs†L1402-L1426】
 
 ## Lap detection and per-lap summaries

--- a/Docs/Internal/SimHubParameterInventory.md
+++ b/Docs/Internal/SimHubParameterInventory.md
@@ -21,7 +21,7 @@ Branch: work
 
 | Exported name | Type | Units / meaning | Update cadence | Defined in |
 | --- | --- | --- | --- | --- |
-| Fuel.LiveFuelPerLap | double | Rolling average burn per accepted lap (wet/dry windows, rejects pit/warmup/off-track/outliers). | 500 ms poll (`UpdateLiveFuelCalcs`). | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2672-L2955】 |
+| Fuel.LiveFuelPerLap | double | Rolling average burn per accepted lap (wet/dry windows, rejects pit/warmup/off-track/outliers). When accepted laps are unavailable, runtime uses profile condition burn before SimHub/DataCore fallback. | 500 ms poll (`UpdateLiveFuelCalcs`). | `LalaLaunch.cs` — `UpdateLiveFuelCalcs` + `AttachCore`【F:LalaLaunch.cs†L1895-L2143】【F:LalaLaunch.cs†L2672-L2955】 |
 | Fuel.LiveFuelPerLap_Stable / StableSource / StableConfidence | double/string/double | Smoothed burn chosen from live/profile (deadband hold; confidence aligned to source). | 500 ms poll. | `LalaLaunch.cs` — `UpdateStableFuelPerLap` + `AttachCore`【F:LalaLaunch.cs†L4180-L4254】【F:LalaLaunch.cs†L2672-L2955】 |
 | Surface.TrackWetness | int | Raw iRacing track wetness (0–3/4 depending on telemetry); informational only. | 500 ms poll. | `LalaLaunch.cs` — `ReadTrackWetness` + `AttachCore`【F:LalaLaunch.cs†L1402-L1426】【F:LalaLaunch.cs†L6095-L6134】【F:LalaLaunch.cs†L2996-L3003】 |
 | Surface.TrackWetnessLabel | string | Human label for track wetness (“Dry/Damp/Light Wet/Mod Wet/Very Wet/Unknown”). | 500 ms poll. | `LalaLaunch.cs` — `MapWetnessLabel` + `AttachCore`【F:LalaLaunch.cs†L1402-L1426】【F:LalaLaunch.cs†L6115-L6134】【F:LalaLaunch.cs†L2996-L3003】 |

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,7 +1,7 @@
 - 2026-05-11 fuel burn authority-chain fix landed:
   - in no-accepted-lap runtime path, `LiveFuelPerLap` now uses active-condition profile fuel when valid and only uses SimHub/DataCore fallback as last resort;
   - added bounded `[LalaPlugin:Fuel Burn] runtime burn basis selected ...` transition log for source/value auditability.
-  - follow-up narrowed that log throttle signature to true authority state (`source + selected burn`) so fallback-input jitter cannot spam repeated transition logs.
+  - follow-up narrowed that log throttle signature to true authority state (`source`) so fallback-input jitter cannot spam repeated transition logs.
 
 - 2026-05-11 rolling snapshot legacy schema guard fix:
   - rolling `PropertySnapshot_Rolling.csv` reuse now validates header column 0 as exact `SimHubProperty` before parsing existing rows;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,6 +1,7 @@
 - 2026-05-11 fuel burn authority-chain fix landed:
   - in no-accepted-lap runtime path, `LiveFuelPerLap` now uses active-condition profile fuel when valid and only uses SimHub/DataCore fallback as last resort;
   - added bounded `[LalaPlugin:Fuel Burn] runtime burn basis selected ...` transition log for source/value auditability.
+  - follow-up narrowed that log throttle signature to true authority state (`source + selected burn`) so fallback-input jitter cannot spam repeated transition logs.
 
 - 2026-05-11 rolling snapshot legacy schema guard fix:
   - rolling `PropertySnapshot_Rolling.csv` reuse now validates header column 0 as exact `SimHubProperty` before parsing existing rows;

--- a/Docs/RepoStatus.md
+++ b/Docs/RepoStatus.md
@@ -1,3 +1,7 @@
+- 2026-05-11 fuel burn authority-chain fix landed:
+  - in no-accepted-lap runtime path, `LiveFuelPerLap` now uses active-condition profile fuel when valid and only uses SimHub/DataCore fallback as last resort;
+  - added bounded `[LalaPlugin:Fuel Burn] runtime burn basis selected ...` transition log for source/value auditability.
+
 - 2026-05-11 rolling snapshot legacy schema guard fix:
   - rolling `PropertySnapshot_Rolling.csv` reuse now validates header column 0 as exact `SimHubProperty` before parsing existing rows;
   - legacy header `SnapshotUtc` and malformed/unknown headers are treated as incompatible and safely reset/re-written in current wide schema;

--- a/Docs/Subsystems/Dash_Integration.md
+++ b/Docs/Subsystems/Dash_Integration.md
@@ -239,3 +239,7 @@ The v1 GitHub docs now present dashboards as the presentation layer across all s
   - `StrategyDash.BurnPlanText` is a concise no-stop/grid helper (`BURN PLAN: NORM/SAVE/PUSH`, optional `/ LIVE` or `/ MEMORY`) so dashes can show useful burn intent when next-refuel is not applicable; `NORM` is runtime/live, while `PUSH`/`SAVE` suffixes follow DATA when the basis is clear,
   - `StrategyDash.NextRefuelDeltaLitres` is `requested refuel - StrategyDash.NextRefuelTargetLitres`, using the exact same burn/source/DATA basis as the target,
   - `StrategyDash.NextRefuelStatus` aligns to absolute delta (`<=0.5 OK`, `<=2.0 CHECK`, else ACTION).
+
+
+## Fuel PROFILE provenance contract
+When `Fuel.LiveFuelPerLap_StableSource` resolves to `Profile`, runtime numeric fuel burn consumed by fuel outputs is profile-backed for that condition; SimHub/DataCore fallback must not be used in parallel as numeric authority.

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -111,6 +111,7 @@ The subsystem then:
 - pace/avg-lap persistence is driven by **pace-accepted laps** (not gated behind fuel-sample acceptance), so valid wet pace can continue feeding Strategy/Profile lap-time data even when a lap's fuel delta is rejected.
 
 ### 3) Stable burn selection
+The runtime stable/active burn authority must keep source and numeric value aligned: when valid profile fuel exists and accepted live laps are unavailable, profile fuel is the active burn basis; SimHub/DataCore fallback is last-resort only.
 The runtime chooses a stable burn candidate from:
 1. trustworthy live window data,
 2. profile condition averages,

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4276,11 +4276,7 @@ namespace LaunchPlugin
                     FuelCalculator?.OnLiveFuelPerLapUpdated();
 
                 string reason = useProfileFallback ? "profile-before-simhub" : "simhub-last-resort";
-                string signature = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0}|{1:0.###}",
-                    useProfileFallback ? "PROFILE" : "SIMHUB",
-                    LiveFuelPerLap);
+                string signature = useProfileFallback ? "PROFILE" : "SIMHUB";
                 if (!string.Equals(signature, _lastFuelBurnAuthoritySignature, StringComparison.Ordinal))
                 {
                     _lastFuelBurnAuthoritySignature = signature;

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4261,16 +4261,43 @@ namespace LaunchPlugin
                 _lapStartFuel = currentFuel;
             }
 
-            // If we haven’t accumulated any accepted laps yet, fall back to SimHub’s estimator
+            // If we haven’t accumulated any accepted laps yet, keep profile fuel authoritative over SimHub fallback.
             if ((_validDryLaps + _validWetLaps) == 0)
             {
-                LiveFuelPerLap = fallbackFuelPerLap;
-                _usingFallbackFuelProfile = true;
+                var (profileDry, profileWet) = GetProfileFuelBaselines();
+                double profileFuelPerLap = _isWetMode ? profileWet : profileDry;
+                bool useProfileFallback = profileFuelPerLap > 0.0;
+                LiveFuelPerLap = useProfileFallback ? profileFuelPerLap : fallbackFuelPerLap;
+                _usingFallbackFuelProfile = !useProfileFallback;
                 Confidence = 0;
                 FuelCalculator?.SetLiveConfidenceLevels(Confidence, PaceConfidence, OverallConfidence);
 
                 if (LiveFuelPerLap > 0)
                     FuelCalculator?.OnLiveFuelPerLapUpdated();
+
+                string reason = useProfileFallback ? "profile-before-simhub" : "simhub-last-resort";
+                string signature = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}|{1:0.###}|{2:0.###}|{3:0.###}|{4}",
+                    useProfileFallback ? "PROFILE" : "SIMHUB",
+                    LiveFuelPerLap,
+                    fallbackFuelPerLap,
+                    profileFuelPerLap,
+                    reason);
+                if (!string.Equals(signature, _lastFuelBurnAuthoritySignature, StringComparison.Ordinal))
+                {
+                    _lastFuelBurnAuthoritySignature = signature;
+                    SimHub.Logging.Current.Info(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "[LalaPlugin:Fuel Burn] runtime burn basis selected source={0} burn={1:F3} liveAccepted={2} fallback={3:F3} profileFuel={4:F3} reason={5}",
+                            useProfileFallback ? "PROFILE" : "SIMHUB",
+                            LiveFuelPerLap,
+                            (_validDryLaps + _validWetLaps),
+                            fallbackFuelPerLap,
+                            profileFuelPerLap,
+                            reason));
+                }
             }
 
             UpdateStableFuelPerLap(_isWetMode, fallbackFuelPerLap);
@@ -6072,6 +6099,7 @@ namespace LaunchPlugin
 
         // --- Already added earlier for MaxFuel throttling ---
         private double _lastAnnouncedMaxFuel = -1;
+        private string _lastFuelBurnAuthoritySignature = string.Empty;
         private const double LiveMaxFuelJitterThreshold = 0.1;
 
         // --- Track marker trigger pulses (for messaging module) ---

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -4278,12 +4278,9 @@ namespace LaunchPlugin
                 string reason = useProfileFallback ? "profile-before-simhub" : "simhub-last-resort";
                 string signature = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0}|{1:0.###}|{2:0.###}|{3:0.###}|{4}",
+                    "{0}|{1:0.###}",
                     useProfileFallback ? "PROFILE" : "SIMHUB",
-                    LiveFuelPerLap,
-                    fallbackFuelPerLap,
-                    profileFuelPerLap,
-                    reason);
+                    LiveFuelPerLap);
                 if (!string.Equals(signature, _lastFuelBurnAuthoritySignature, StringComparison.Ordinal))
                 {
                     _lastFuelBurnAuthoritySignature = signature;


### PR DESCRIPTION
### Motivation
- The no-accepted-laps branch was copying `DataCorePlugin.Computed.Fuel_LitersPerLap` into `LiveFuelPerLap`, which allowed SimHub/DataCore fallback numbers to be treated as the runtime numeric authority even when a valid profile value existed, causing source/value split-brain between `LiveFuelPerLap_StableSource` and the numeric burn. 
- The change aims to ensure numeric authority and provenance agree: when no live accepted laps exist but a profile baseline is available for the active condition, the runtime burn must be profile-backed and SimHub fallback must remain last-resort. 

### Description
- In `LalaLaunch.cs` updated the no-accepted-laps assignment so it prefers the active-condition profile baseline (`GetProfileFuelBaselines()`) and only uses `DataCorePlugin.Computed.Fuel_LitersPerLap` when no profile exists, preserving existing live-accepted-lap behavior. 
- Added a bounded transition log (signature latch `_lastFuelBurnAuthoritySignature`) that emits a single `SimHub.Logging.Current.Info(...)` line when the runtime no-live-lap authority selection changes to aid auditability (tagged `[LalaPlugin:Fuel Burn] runtime burn basis selected ...`). 
- Added a small private field (`_lastFuelBurnAuthoritySignature`) to prevent per-tick spam and ensure logging only on meaningful transitions. 
- Updated docs to match behavior: `Docs/Subsystems/Fuel_Model.md`, `Docs/Subsystems/Dash_Integration.md`, `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/SimHubLogMessages.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md` to state profile-over-fallback ordering and document the new bounded log. 
- Files changed: `LalaLaunch.cs`, `Docs/Subsystems/Fuel_Model.md`, `Docs/Subsystems/Dash_Integration.md`, `Docs/Internal/SimHubParameterInventory.md`, `Docs/Internal/SimHubLogMessages.md`, `Docs/Internal/Development_Changelog.md`, and `Docs/RepoStatus.md`. 

### Testing
- Searched and inspected runtime paths and references to confirm the exact no-live-lap assignment and stable-resolver code paths using `rg`/source scans and verified the guard was placed at the canonical site (`UpdateLiveFuelCalcs` / no-accepted-laps branch). 
- Committed the code changes and updated docs; automated build verification (`dotnet build`) could not be executed in this environment because the .NET SDK is not installed, so compilation was not validated here. 
- No other automated unit/integration tests were run in this environment; runtime validation (in-plugin live telemetry) is recommended to confirm downstream consumers (`Fuel.*` exports and `FuelCalculator` consumers) receive profile-backed numeric burns when no accepted live laps exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e9f53f28832faea14d9f927ffc85)