### PR TITLE
Fix stable fuel authority to prevent fallback poisoning

### DIFF
--- a/Docs/Internal/Development_Changelog.md
+++ b/Docs/Internal/Development_Changelog.md
@@ -2252,3 +2252,10 @@ The public user-facing release history is maintained in the root `CHANGELOG.md`.
 - Classification: **internal-only** (documentation wording clarification only; no runtime/code changes).
 - Clarified finish-latch wording to describe checkered as the practical finish-like source in this telemetry path, while noting crossed is not relied on as required line-crossing proof.
 - Kept existing RaceFinish/leader-finished latch behavior unchanged.
+
+## 2026-05-11 — PR #708 fuel stable-authority follow-up (fallback poisoning fix)
+- Classification: **internal-only** (runtime fuel stable-source correctness; no lap-acceptance/profile-persistence/pit-command/dashboard ownership changes).
+- Tightened `UpdateStableFuelPerLap(...)` authority ordering to strict `Live (trusted) -> Profile -> Fallback`.
+- Removed prior profile-confidence ceiling gate from stable-source selection so valid profile burn cannot be bypassed by fallback when live confidence is still below threshold.
+- Added fallback replacement guard: when stable source is currently `Fallback`, any newly valid `Profile` or trusted `Live` candidate now replaces stable source+value immediately (deadband does not block authority recovery).
+- Session/combo reset semantics remain intact: stable fuel source/value/confidence are still reset together by existing reset paths.

--- a/Docs/Subsystems/Fuel_Model.md
+++ b/Docs/Subsystems/Fuel_Model.md
@@ -117,6 +117,10 @@ The runtime chooses a stable burn candidate from:
 2. profile condition averages,
 3. safe fallback behavior.
 
+Fallback promotion guardrail:
+- Fallback must never become or remain stable authority when a valid profile candidate exists, or when trusted live confidence is reached.
+- If current stable source is fallback and a valid Profile/Live candidate appears, stable value and source are replaced together immediately (no deadband hold against authority replacement).
+
 A deadband holds the previous stable value when the new candidate is only trivially different, while source and confidence labels can still update.
 
 ### 4) Confidence growth

--- a/LalaLaunch.cs
+++ b/LalaLaunch.cs
@@ -18250,19 +18250,30 @@ namespace LaunchPlugin
             var (profileDry, profileWet) = GetProfileFuelBaselines();
             double profileFuel = isWetMode ? profileWet : profileDry;
             double fuelReadyConfidence = GetFuelReadyConfidenceThreshold();
+            bool hasLiveAuthority = Confidence >= fuelReadyConfidence && LiveFuelPerLap > 0.0;
+            bool hasProfileAuthority = profileFuel > 0.0;
 
-            double candidate = fallbackFuelPerLap;
+            double candidate = 0.0;
             string source = "Fallback";
 
-            if (Confidence >= fuelReadyConfidence && LiveFuelPerLap > 0.0)
+            // Authority order (strict):
+            // 1) trusted live
+            // 2) profile burn
+            // 3) fallback only when neither live nor profile are valid
+            if (hasLiveAuthority)
             {
                 candidate = LiveFuelPerLap;
                 source = "Live";
             }
-            else if (profileFuel > 0.0 && fuelReadyConfidence <= ProfileAllowedConfidenceCeiling)
+            else if (hasProfileAuthority)
             {
                 candidate = profileFuel;
                 source = "Profile";
+            }
+            else if (fallbackFuelPerLap > 0.0)
+            {
+                candidate = fallbackFuelPerLap;
+                source = "Fallback";
             }
 
             // --- Stable confidence reflects the chosen stable source, not always live Confidence ---
@@ -18280,6 +18291,10 @@ namespace LaunchPlugin
             double stable = _stableFuelPerLap;
             string selectedSource = source;
             double selectedConfidence = GetConfidenceForStableSource(selectedSource);
+
+            bool stableIsFallback = string.Equals(_stableFuelPerLapSource, "Fallback", StringComparison.OrdinalIgnoreCase);
+            bool candidateIsAuthority = string.Equals(source, "Live", StringComparison.OrdinalIgnoreCase) ||
+                                       string.Equals(source, "Profile", StringComparison.OrdinalIgnoreCase);
 
             if (candidate <= 0.0)
             {
@@ -18299,7 +18314,8 @@ namespace LaunchPlugin
             }
             else
             {
-                if (stable <= 0.0 || Math.Abs(candidate - stable) >= StableFuelPerLapDeadband)
+                bool forceReplaceFallbackWithAuthority = stableIsFallback && candidateIsAuthority;
+                if (stable <= 0.0 || forceReplaceFallbackWithAuthority || Math.Abs(candidate - stable) >= StableFuelPerLapDeadband)
                 {
                     // Accept new stable candidate: update source + confidence together.
                     stable = candidate;


### PR DESCRIPTION
### Motivation
- The stable fuel selector could be poisoned by SimHub/DataCore fallback and remain authoritative despite a valid profile or later sane live sample, causing corrupted dashboard and projection outputs. 
- The change enforces the intended authority ordering so stable burn is never held by fallback when a profile or trusted live candidate is available. 

### Description
- Updated `UpdateStableFuelPerLap(...)` in `LalaLaunch.cs` to enforce strict authority order: trusted Live → Profile → Fallback, and to only use fallback when neither live nor profile are valid. 
- When the current stable source is `Fallback`, a newly-appearing `Profile` or trusted `Live` candidate now immediately replaces the stable value and source (bypassing the deadband hold). 
- Preserved existing reset semantics so session/combo resets still clear stable value/source/confidence together and did not change lap-acceptance, profile persistence, pit-command, DATA/SOURCE state-machine, or dashboard ownership. 
- Updated `Docs/Subsystems/Fuel_Model.md` and `Docs/Internal/Development_Changelog.md` to record the guardrail and the follow-up fix. 

### Testing
- Performed a code review and targeted inspections of affected paths (`UpdateStableFuelPerLap` and callers) to verify authority ordering and immediate-replace logic were implemented as intended. 
- Attempted a build with `dotnet build -nologo` but the environment lacks `dotnet` so an automated compile could not be run (build failed: `dotnet: command not found`). 
- No unit/integration test run was possible in this environment; recommend CI compilation and scenario replay validation (cases A–E from the issue report) before publishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020cf5f9f4832fbc7ec176511e8d4f)